### PR TITLE
feat(cli): chainspec support

### DIFF
--- a/experiments/package.json
+++ b/experiments/package.json
@@ -48,6 +48,10 @@
     "ksm": {
       "metadata": "../packages/metadata-fixtures/ksm-metadata.scale",
       "outputFolder": "./src/descriptors/"
+    },
+    "derp": {
+      "metadata": "derp-metadata.scale",
+      "outputFolder": "derp"
     }
   }
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -13,9 +13,10 @@ Polkadot API CLI
 
 Options:
   -j, --pkgJSONKey <key>  key in package json for descriptor metadata (default: "polkadot-api")
-  k --key <key>           first key in descriptor metadata
-  f --file <file>         path to descriptor metadata file; alternative to package json
-  w --wsURL <wsURL>       websocket url to fetch metadata
+  -k --key <key>           first key in descriptor metadata
+  -f --file <file>         path to descriptor metadata file; alternative to package json
+  -w --wsURL <wsURL>       websocket url to fetch metadata
+  -c --chainSpec <chainSpec> chainspec to fetch metadata
   -i, --interactive       whether to run in interactive mode (default: false)
   -h, --help              display help for command
 ```
@@ -67,6 +68,12 @@ If you want to fetch the metadata using a websocket url you can use the `--wsURL
 
 ```sh
 polkadot-api --interactive --wsURL "<YOUR WS URL>"
+```
+
+Alternatively, If you want to connect to a parachain with a chainspec, you can use the `--chainSpec` flag
+
+```sh
+polkadot-api --interactive --chainSpec "<YOUR CHAINSPEC FILE>"
 ```
 
 ## Non-Interactive Usage

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -23,6 +23,7 @@ const ProgramArgs = z.object({
   key: z.string().optional(),
   file: z.string().optional(),
   wsURL: z.string().optional(),
+  chainSpec: z.string().optional(),
   interactive: z.boolean(),
 })
 
@@ -42,6 +43,7 @@ program
     "path to descriptor metadata file; alternative to package json",
   )
   .option("w --wsURL <wsURL>", "websocket url to fetch metadata")
+  .option("c --chainSpec <chainSpec>", "chainspec to fetch metadata")
   .option("-i, --interactive", "whether to run in interactive mode", false)
 
 program.parse()
@@ -82,18 +84,20 @@ if (!metadata) {
       }
     : options.wsURL
       ? { source: "ws" as const, url: options.wsURL }
-      : {
-          source: "chain" as const,
-          chain: await select({
-            message: "Select a chain to pull metadata from",
-            choices: [
-              { name: "polkadot", value: WellKnownChain.polkadot },
-              { name: "westend", value: WellKnownChain.westend2 },
-              { name: "ksm", value: WellKnownChain.ksmcc3 },
-              { name: "rococo", value: WellKnownChain.rococo_v2_2 },
-            ],
-          }),
-        }
+      : options.chainSpec
+        ? { source: "chainSpec" as const, chainSpec: options.chainSpec }
+        : {
+            source: "chain" as const,
+            chain: await select({
+              message: "Select a chain to pull metadata from",
+              choices: [
+                { name: "polkadot", value: WellKnownChain.polkadot },
+                { name: "westend", value: WellKnownChain.westend2 },
+                { name: "ksm", value: WellKnownChain.ksmcc3 },
+                { name: "rococo", value: WellKnownChain.rococo_v2_2 },
+              ],
+            }),
+          }
 
   const spinner = ora(`Loading Metadata`).start()
   metadata = await getMetadata(metadataArgs)

--- a/packages/cli/src/smolldot-worker.ts
+++ b/packages/cli/src/smolldot-worker.ts
@@ -1,18 +1,58 @@
 export const PROVIDER_WORKER_CODE = `
 const { parentPort, workerData } = require("node:worker_threads")
-const { getScProvider } = require("@polkadot-api/sc-provider")
+const { createScClient, WellKnownChain } = require("@substrate/connect")
+const { getSyncProvider } = require("@polkadot-api/json-rpc-provider-proxy")
 
-const chain = workerData
-const scProvider = getScProvider()
-const getProvider = scProvider(chain).relayChain
+const wellKnownChains = new Set(Object.values(WellKnownChain))
+
+const isWellKnownChain = (input) => wellKnownChains.has(input)
+
+let client
+const noop = () => {}
+const ScProvider = (input, relayChainSpec) => {
+  client ??= createScClient()
+  const addChain = (input, jsonRpcCallback) =>
+    isWellKnownChain(input)
+      ? client.addWellKnownChain(input, jsonRpcCallback)
+      : client.addChain(input, jsonRpcCallback)
+
+  return getSyncProvider(async () => {
+    let listener = noop
+    const onMessage = (msg) => {
+      listener(msg)
+    }
+
+    let chain
+    const relayChain = relayChainSpec
+      ? await addChain(relayChainSpec)
+      : undefined
+    chain = relayChain
+      ? await relayChain.addChain(input, onMessage)
+      : await addChain(input, onMessage)
+
+    return (onMessage) => {
+      listener = onMessage
+      return {
+        send(msg) {
+          chain.sendJsonRpc(msg)
+        },
+        disconnect() {
+          listener = noop
+          chain.remove()
+        },
+      }
+    }
+  })
+}
+
+const { input, relayChainSpec } = workerData
+const getProvider = ScProvider(input, relayChainSpec)
 
 if (!parentPort) {
   throw new Error("no parent port")
 }
 
-const provider = getProvider(
-  (msg) => parentPort.postMessage(msg)
-)
+const provider = getProvider((msg) => parentPort.postMessage(msg))
 
 parentPort.on("message", (msg) => {
   switch (msg.type) {


### PR DESCRIPTION
Adds support for passing in a chainspec to the CLI. i.e.

```
polkadot-api --interactive --chainSpec "collectives.json"
```

[collectives.json](https://gist.github.com/ryanleecode/8ed7f6b280c9c8d65bc502e0b2348495)