### PR TITLE
feat: better tx API

### DIFF
--- a/examples/vite/src/main.ts
+++ b/examples/vite/src/main.ts
@@ -7,6 +7,7 @@ import {
 } from "@polkadot-api/legacy-polkadot-provider"
 import { createScClient } from "@substrate/connect"
 import test, { TestMultiAddress } from "./codegen/test"
+
 const { relayChains, connectAccounts } = getLegacyProvider(createScClient())
 connectAccounts("polkadot-js")
 
@@ -42,10 +43,10 @@ function populateUserDropdown(select: Element) {
 }
 
 function transfer(alexa: Account, billy: Account, amount: bigint) {
-  client.test.tx.Balances.transfer_keep_alive(
-    TestMultiAddress.Id(billy.address),
-    amount,
-  )
+  client.test.tx.Balances.transfer_keep_alive({
+    dest: TestMultiAddress.Id(billy.address),
+    value: amount,
+  })
     .submit$(alexa.address)
     .subscribe({
       next: (event) => {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -5,7 +5,7 @@ import {
 import { createStorageEntry, type StorageEntry } from "./storage"
 import { getObservableClient } from "./observableClient"
 import { CreateClient, CreateTx, EvApi, StorageApi, TxApi } from "./types"
-import { TxClient, createTxEntry } from "./tx"
+import { Transaction, createTxEntry } from "./tx"
 import { firstValueFrom } from "rxjs"
 import { EvClient, createEventEntry } from "./event"
 import {
@@ -44,7 +44,10 @@ const createNamespace = (
     }
   }
 
-  const tx = {} as Record<string, Record<string, TxClient<any>>>
+  const tx = {} as Record<
+    string,
+    Record<string, (a: any) => Transaction<any, any, any>>
+  >
   for (const pallet in descriptors) {
     tx[pallet] ||= {}
     const [, txEntries] = descriptors[pallet]

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -7,7 +7,7 @@ import {
   TxFromDescriptors,
 } from "@polkadot-api/substrate-bindings"
 import { StorageEntry } from "./storage"
-import { TxClient } from "./tx"
+import { Transaction } from "./tx"
 import { EvClient } from "./event"
 import { Observable } from "rxjs"
 import { BlockInfo } from "./observableClient"
@@ -55,12 +55,12 @@ export type StorageApi<
   }
 }
 
-export type TxApi<
-  A extends Record<string, Record<string, Array<any> | unknown>>,
-> = {
-  [K in keyof A]: {
-    [KK in keyof A[K]]: A[K][KK] extends Array<any>
-      ? TxClient<A[K][KK]>
+export type TxApi<A extends Record<string, Record<string, any>>> = {
+  [K in keyof A & string]: {
+    [KK in keyof A[K] & string]: A[K][KK] extends {} | undefined
+      ? (
+          ...args: A[K][KK] extends undefined ? [] : [data: A[K][KK]]
+        ) => Transaction<A[K][KK], K, KK>
       : unknown
   }
 }

--- a/packages/metadata-builders/src/dynamic-builder.ts
+++ b/packages/metadata-builders/src/dynamic-builder.ts
@@ -85,8 +85,6 @@ const _buildCodec = (
 }
 const buildCodec = withCache(_buildCodec, scale.Self, (res) => res)
 
-const emptyTuple = scale.Tuple()
-
 export const getDynamicBuilder = (metadata: V14) => {
   const lookupData = metadata.lookup
   const getLookupEntryDef = getLookupFn(lookupData)
@@ -162,11 +160,10 @@ export const getDynamicBuilder = (metadata: V14) => {
 
   const buildEnumEntry = (
     entry: EnumVar["value"][keyof EnumVar["value"]],
-    forceTuple = false,
   ): Codec<any> => {
-    if (entry.type === "primitive") return forceTuple ? emptyTuple : scale._void
+    if (entry.type === "primitive") return scale._void
 
-    return entry.type === "tuple" || forceTuple
+    return entry.type === "tuple"
       ? scale.Tuple(
           ...Object.values(entry.value).map((l) => buildDefinition(l.id)),
         )
@@ -219,7 +216,7 @@ export const getDynamicBuilder = (metadata: V14) => {
 
     return {
       location: [palletEntry.index, entry.idx],
-      args: buildEnumEntry(lookup.value[name], true),
+      args: buildEnumEntry(lookup.value[name]),
     }
   }
 

--- a/packages/metadata-builders/tests/__snapshots__/dynamic-builder.spec.ts.snap
+++ b/packages/metadata-builders/tests/__snapshots__/dynamic-builder.spec.ts.snap
@@ -1,8 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`getDynamicBuilder > batched call 1`] = `
-[
-  [
+{
+  "calls": [
     {
       "as": [Function],
       "is": [Function],
@@ -43,12 +43,28 @@ exports[`getDynamicBuilder > batched call 1`] = `
       },
     },
   ],
-]
+}
 `;
 
 exports[`getDynamicBuilder > felloship referenda submit 1`] = `
-[
-  {
+{
+  "enactment_moment": {
+    "as": [Function],
+    "is": [Function],
+    "type": "After",
+    "value": 1,
+  },
+  "proposal": {
+    "as": [Function],
+    "is": [Function],
+    "type": "Inline",
+    "value": {
+      "asBytes": [Function],
+      "asHex": [Function],
+      "asText": [Function],
+    },
+  },
+  "proposal_origin": {
     "as": [Function],
     "is": [Function],
     "type": "Origins",
@@ -59,21 +75,5 @@ exports[`getDynamicBuilder > felloship referenda submit 1`] = `
       "value": undefined,
     },
   },
-  {
-    "as": [Function],
-    "is": [Function],
-    "type": "Inline",
-    "value": {
-      "asBytes": [Function],
-      "asHex": [Function],
-      "asText": [Function],
-    },
-  },
-  {
-    "as": [Function],
-    "is": [Function],
-    "type": "After",
-    "value": 1,
-  },
-]
+}
 `;

--- a/packages/substrate-bindings/src/descriptors.ts
+++ b/packages/substrate-bindings/src/descriptors.ts
@@ -7,8 +7,8 @@ export type StorageDescriptor<
   Optional extends true | false,
 > = string & { _type: T; _args: Args; _optional: Optional }
 
-export type TxDescriptor<Args extends Array<any>> = string & {
-  _args: Args
+export type TxDescriptor<Args extends {} | undefined> = string & {
+  ___: Args
 }
 
 export type Descriptors = Record<


### PR DESCRIPTION
Today I demoed to @peetzweg the latest improvements introduced by #256. During that call we noticed this improvement in the tx API, which makes it trivial to re-use the tx created with the client as inputs into the list of batched calls of the `Utility.batch` et al.