### PR TITLE
chore(substrate-client): flatten out fixtures on tests

### DIFF
--- a/packages/substrate-client/src/chainhead/public-types.ts
+++ b/packages/substrate-client/src/chainhead/public-types.ts
@@ -138,4 +138,9 @@ export interface ChainHead {
     cb: (event: FollowEventWithRuntime) => void,
     onError: (error: Error) => void,
   ): FollowResponse
+  (
+    withRuntime: boolean,
+    cb: (event: FollowEventWithoutRuntime | FollowEventWithRuntime) => void,
+    onError: (error: Error) => void,
+  ): FollowResponse
 }


### PR DESCRIPTION
This is a small refactor for substrate-client integration test mocks. Essentially it has the same as before but reorganised in a way that I think that it's easier to think about.

My idea is to have a `MockProvider extends ConnectProvider` that has the functions to send messages and assert the received ones.

Then you can build on top of that to create other mock functions that provide more utilities: one for chainHead, another for transaction, etc.

I also liked the `getNewMessages()` function to exclude past calls, so I brought those to spies (onMsg, onError)
