### PR TITLE
fix(substrate-client): reject ongoing chainHead promises with DisjointError after calling disconnect

### DIFF
--- a/packages/substrate-client/src/chainhead/chainhead.ts
+++ b/packages/substrate-client/src/chainhead/chainhead.ts
@@ -25,6 +25,7 @@ import { createStorageFn } from "./storage"
 import { createUnpinFn } from "./unpin"
 import { DisjointError, StopError } from "./errors"
 import { createStorageCb } from "./storage-subscription"
+import { DestroyedError } from "@/client/DestroyedError"
 
 type FollowEventRpc =
   | FollowEventWithRuntimeRpc
@@ -77,7 +78,7 @@ export function getChainHead(
 
     const onAllFollowEventsError = (error: Error) => {
       onFollowError(error)
-      unfollow()
+      unfollow(!(error instanceof DestroyedError))
     }
 
     const onFollowRequestSuccess = (
@@ -106,7 +107,11 @@ export function getChainHead(
     }
 
     const onFollowRequestError = (e: Error) => {
-      onFollowError(e)
+      if (e instanceof DestroyedError) {
+        unfollow(false)
+      } else {
+        onFollowError(e)
+      }
       followSubscription = null
       deferredFollow.res(e)
     }

--- a/packages/substrate-client/src/client/DestroyedError.ts
+++ b/packages/substrate-client/src/client/DestroyedError.ts
@@ -1,0 +1,6 @@
+export class DestroyedError extends Error {
+  constructor() {
+    super("Client destroyed")
+    this.name = "DestroyedError"
+  }
+}

--- a/packages/substrate-client/src/client/createClient.ts
+++ b/packages/substrate-client/src/client/createClient.ts
@@ -5,6 +5,7 @@ import {
 import { UnsubscribeFn } from "../common-types"
 import { RpcError, IRpcError } from "./RpcError"
 import { getSubscriptionsManager, Subscriber } from "@/internal-utils"
+import { DestroyedError } from "./DestroyedError"
 
 export type FollowSubscriptionCb<T> = (
   methodName: string,
@@ -103,6 +104,9 @@ export const createClient = (gProvider: ConnectProvider): Client => {
   const disconnect = () => {
     provider?.disconnect()
     provider = null
+    subscriptions.errorAll(new DestroyedError())
+    responses.forEach((r) => r.onError(new DestroyedError()))
+    responses.clear()
   }
 
   let nextId = 1

--- a/packages/substrate-client/src/client/index.ts
+++ b/packages/substrate-client/src/client/index.ts
@@ -1,2 +1,3 @@
 export * from "./RpcError"
 export * from "./createClient"
+export * from "./DestroyedError"

--- a/packages/substrate-client/src/index.ts
+++ b/packages/substrate-client/src/index.ts
@@ -22,7 +22,7 @@ export type * from "./client"
 export type * from "./transaction"
 export type * from "./chainhead"
 
-export { RpcError } from "./client"
+export { RpcError, DestroyedError } from "./client"
 export { TransactionError } from "./transaction"
 export {
   StopError,
@@ -65,6 +65,7 @@ export const createClient = (provider: ConnectProvider): SubstrateClient => {
   >("rpc_methods", []).then(
     (x) => (rpcMethods = new Set(Array.isArray(x) ? x : x.methods)),
   )
+  rpcMethods.catch(noop)
 
   const getSubmitAndWatchNamespace = (input: Set<string>) =>
     input.has("transaction_unstable_submitAndWatch")

--- a/packages/substrate-client/src/transaction/transaction.ts
+++ b/packages/substrate-client/src/transaction/transaction.ts
@@ -1,5 +1,5 @@
 import { noop } from "@/internal-utils"
-import type { ClientRequest } from "../client"
+import { DestroyedError, type ClientRequest } from "../client"
 import type {
   TxEventRpc,
   TxFinalizedRpc,
@@ -71,7 +71,7 @@ export const getTransaction =
               next(eventToType(event))
             },
             error(e) {
-              cancel()
+              if (!(e instanceof DestroyedError)) cancel()
               cancel = noop
               error(e)
             },

--- a/packages/substrate-client/tests/chainHead-functions.spec.ts
+++ b/packages/substrate-client/tests/chainHead-functions.spec.ts
@@ -32,11 +32,7 @@ describe.each([
       const { provider, chainHead } = setupChainHeadWithSubscription()
 
       const promise = chainHead[name](...(args as [any]))
-
-      provider.sendMessage({
-        id: 3,
-        result,
-      })
+      provider.replyLast({ result })
 
       return expect(promise).resolves.toEqual(expectedResult)
     })
@@ -45,11 +41,7 @@ describe.each([
       const { provider, chainHead } = setupChainHeadWithSubscription()
 
       const promise = chainHead[name](...(args as [any]))
-
-      provider.sendMessage({
-        id: 3,
-        error: parseError,
-      })
+      provider.replyLast({ error: parseError })
 
       return expect(promise).rejects.toEqual(new RpcError(parseError))
     })
@@ -69,8 +61,7 @@ describe.each([
 
       const promise = chainHead[name](...(args as [any]))
       // The errored JSON-RPC response comes **after** the user has called `header`/`unpin`
-      provider.sendMessage({
-        id: 2,
+      provider.replyLast({
         error: parseError,
       })
 
@@ -81,8 +72,7 @@ describe.each([
       const { provider, chainHead } = setupChainHead()
 
       // The errored JSON-RPC response comes **before** the user has called `header`/`unpin`
-      provider.sendMessage({
-        id: 2,
+      provider.replyLast({
         error: parseError,
       })
       const promise = chainHead[name](...(args as [any]))

--- a/packages/substrate-client/tests/chainHead-operations.spec.ts
+++ b/packages/substrate-client/tests/chainHead-operations.spec.ts
@@ -250,8 +250,7 @@ describe.each([
 
       controller.abort()
 
-      provider.sendMessage({
-        id: 2,
+      provider.replyLast({
         result: "someSubscription",
       })
 
@@ -268,8 +267,7 @@ describe.each([
         ...args,
       )
 
-      provider.sendMessage({
-        id: 3,
+      provider.replyLast({
         result: { result: "limitReached" },
       })
 
@@ -317,8 +315,7 @@ describe.each([
 
       const promise = (chainHead[op.name] as any)(...(args as any[]))
 
-      provider.sendMessage({
-        id: 2,
+      provider.replyLast({
         error: parseError,
       })
 
@@ -328,8 +325,7 @@ describe.each([
     it("rejects an `DisjointError` error when the follow subscription fails for any subsequent operation", async () => {
       const { provider, chainHead } = setupChainHead()
 
-      provider.sendMessage({
-        id: 2,
+      provider.replyLast({
         error: parseError,
       })
 

--- a/packages/substrate-client/tests/chainHead.spec.ts
+++ b/packages/substrate-client/tests/chainHead.spec.ts
@@ -182,8 +182,7 @@ describe("chainHead", () => {
       setupChainHeadWithSubscription()
 
     const bodyPromise = chainHead.body("")
-    provider.sendMessage({
-      id: 3,
+    provider.replyLast({
       result: {
         result: "started",
         operationId: "operationBody",
@@ -191,8 +190,7 @@ describe("chainHead", () => {
     })
 
     const storagePromise = chainHead.storage("", "value", "df", null)
-    provider.sendMessage({
-      id: 4,
+    provider.replyLast({
       result: {
         result: "started",
         operationId: "operationStorage",
@@ -200,8 +198,7 @@ describe("chainHead", () => {
     })
 
     const callPromise = chainHead.call("", "", "")
-    provider.sendMessage({
-      id: 5,
+    provider.replyLast({
       result: {
         result: "started",
         operationId: "operationCall",
@@ -241,8 +238,7 @@ describe("chainHead", () => {
   it("propagates the JSON-RPC Error when the initial request fails", () => {
     const { provider, onMsg, onError } = setupChainHead()
 
-    provider.sendMessage({
-      id: 2,
+    provider.replyLast({
       error: parseError,
     })
 
@@ -298,8 +294,7 @@ describe("chainHead", () => {
   test("destroying the client triggers a `DisjointError` on all pending requests", () => {
     const { client, chainHead, provider } = setupChainHead()
     const SUBSCRIPTION_ID = "SUBSCRIPTION_ID"
-    provider.sendMessage({
-      id: 2,
+    provider.replyLast({
       result: SUBSCRIPTION_ID,
     })
 

--- a/packages/substrate-client/tests/transaction.spec.ts
+++ b/packages/substrate-client/tests/transaction.spec.ts
@@ -11,7 +11,7 @@ async function setupTx(tx: string = "") {
   const onMsg = vi.fn()
   const onError = vi.fn()
   const { client, provider } = createTestClient()
-  provider.sendMessage({ id: 1, result: [] })
+  provider.replyLast({ result: [] })
   provider.getNewMessages()
 
   const cancel = client.transaction(tx, onMsg, onError)
@@ -25,8 +25,7 @@ async function setupTxWithSubscription() {
   provider.getNewMessages()
 
   const SUBSCRIPTION_ID = "SUBSCRIPTION_ID"
-  provider.sendMessage({
-    id: 2,
+  provider.replyLast({
     result: SUBSCRIPTION_ID,
   })
 
@@ -119,8 +118,7 @@ describe("transaction", () => {
     cancel()
 
     const SUBSCRIPTION_ID = "SUBSCRIPTION_ID"
-    provider.sendMessage({
-      id: 2,
+    provider.replyLast({
       result: SUBSCRIPTION_ID,
     })
 
@@ -222,8 +220,7 @@ describe("transaction", () => {
   it("propagates the JSON-RPC Error when the initial request fails", async () => {
     const { provider, onMsg, onError } = await setupTx()
 
-    provider.sendMessage({
-      id: 2,
+    provider.replyLast({
       error: parseError,
     })
 


### PR DESCRIPTION
While working on improving tests I found this gap: It's theoretically possible to call `client.destroy()`, which disconnects from the provider, and the ongoing promises are left unresolved.

I propose that they should be rejected with a DisjointError (as if the subscription was stopped), and I have added a possible fix.

We'll have to check for the same case on transaction.