### PR TITLE
test(substrate-client): improve tests on substrate-client

### DIFF
--- a/packages/substrate-client/tests/chainHead-functions.spec.ts
+++ b/packages/substrate-client/tests/chainHead-functions.spec.ts
@@ -4,92 +4,90 @@ import {
   setupChainHead,
   setupChainHeadWithSubscription,
 } from "./fixtures"
-import { DisjointError } from "@/chainhead"
+import { DisjointError, FollowResponse } from "@/chainhead"
 import { RpcError } from "@/client"
 
 describe.each([
-  [
-    "unpin" as "unpin",
-    [["someHash", "someOtherHash"]] as [string[]],
-    null,
-    undefined,
-  ],
-  ["header" as "header", ["someHash"] as [string], "someHeader", "someHeader"],
-])("chainhead: %s", (name, args, result, expectedResult) => {
-  it("sends the correct message", () => {
-    const { provider, SUBSCRIPTION_ID, chainHead } =
-      setupChainHeadWithSubscription()
+  ["unpin", [["someHash", "someOtherHash"]], null, undefined],
+  ["header", ["someHash"], "someHeader", "someHeader"],
+] satisfies Array<[keyof FollowResponse, any[], any, any]>)(
+  "chainhead: %s",
+  (name, args, result, expectedResult) => {
+    it("sends the correct message", () => {
+      const { provider, SUBSCRIPTION_ID, chainHead } =
+        setupChainHeadWithSubscription()
 
-    provider.getNewMessages()
-    chainHead[name](...(args as [any]))
+      provider.getNewMessages()
+      chainHead[name](...(args as [any]))
 
-    expect(provider.getNewMessages()).toMatchObject([
-      {
-        method: `chainHead_unstable_${name}`,
-        params: [SUBSCRIPTION_ID, ...args],
-      },
-    ])
-  })
-
-  it("resolves the correct response", () => {
-    const { provider, chainHead } = setupChainHeadWithSubscription()
-
-    const promise = chainHead[name](...(args as [any]))
-
-    provider.sendMessage({
-      id: 3,
-      result,
+      expect(provider.getNewMessages()).toMatchObject([
+        {
+          method: `chainHead_unstable_${name}`,
+          params: [SUBSCRIPTION_ID, ...args],
+        },
+      ])
     })
 
-    return expect(promise).resolves.toEqual(expectedResult)
-  })
+    it("resolves the correct response", () => {
+      const { provider, chainHead } = setupChainHeadWithSubscription()
 
-  it("rejects the JSON-RPC Error when the request fails", () => {
-    const { provider, chainHead } = setupChainHeadWithSubscription()
+      const promise = chainHead[name](...(args as [any]))
 
-    const promise = chainHead[name](...(args as [any]))
+      provider.sendMessage({
+        id: 3,
+        result,
+      })
 
-    provider.sendMessage({
-      id: 3,
-      error: parseError,
+      return expect(promise).resolves.toEqual(expectedResult)
     })
 
-    return expect(promise).rejects.toEqual(new RpcError(parseError))
-  })
+    it("rejects the JSON-RPC Error when the request fails", () => {
+      const { provider, chainHead } = setupChainHeadWithSubscription()
 
-  it("rejects with an `DisjointError` when the function is created after `unfollow`", () => {
-    const { chainHead } = setupChainHead()
+      const promise = chainHead[name](...(args as [any]))
 
-    chainHead.unfollow()
+      provider.sendMessage({
+        id: 3,
+        error: parseError,
+      })
 
-    return expect(chainHead[name](...(args as [any]))).rejects.toEqual(
-      new DisjointError(),
-    )
-  })
-
-  it("rejects an `DisjointError` when the follow subscription fails and the operation is pending", async () => {
-    const { provider, chainHead } = setupChainHead()
-
-    const promise = chainHead[name](...(args as [any]))
-    // The errored JSON-RPC response comes **after** the user has called `header`/`unpin`
-    provider.sendMessage({
-      id: 2,
-      error: parseError,
+      return expect(promise).rejects.toEqual(new RpcError(parseError))
     })
 
-    await expect(promise).rejects.toEqual(new DisjointError())
-  })
+    it("rejects with an `DisjointError` when the function is created after `unfollow`", () => {
+      const { chainHead } = setupChainHead()
 
-  it("rejects an `DisjointError` when the follow subscription fails for any subsequent operation", async () => {
-    const { provider, chainHead } = setupChainHead()
+      chainHead.unfollow()
 
-    // The errored JSON-RPC response comes **before** the user has called `header`/`unpin`
-    provider.sendMessage({
-      id: 2,
-      error: parseError,
+      return expect(chainHead[name](...(args as [any]))).rejects.toEqual(
+        new DisjointError(),
+      )
     })
-    const promise = chainHead[name](...(args as [any]))
 
-    await expect(promise).rejects.toEqual(new DisjointError())
-  })
-})
+    it("rejects an `DisjointError` when the follow subscription fails and the operation is pending", async () => {
+      const { provider, chainHead } = setupChainHead()
+
+      const promise = chainHead[name](...(args as [any]))
+      // The errored JSON-RPC response comes **after** the user has called `header`/`unpin`
+      provider.sendMessage({
+        id: 2,
+        error: parseError,
+      })
+
+      await expect(promise).rejects.toEqual(new DisjointError())
+    })
+
+    it("rejects an `DisjointError` when the follow subscription fails for any subsequent operation", async () => {
+      const { provider, chainHead } = setupChainHead()
+
+      // The errored JSON-RPC response comes **before** the user has called `header`/`unpin`
+      provider.sendMessage({
+        id: 2,
+        error: parseError,
+      })
+      const promise = chainHead[name](...(args as [any]))
+
+      await expect(promise).rejects.toEqual(new DisjointError())
+    })
+  },
+)

--- a/packages/substrate-client/tests/chainHead-operations.spec.ts
+++ b/packages/substrate-client/tests/chainHead-operations.spec.ts
@@ -1,5 +1,6 @@
 import { expect, describe, test, it } from "vitest"
 import {
+  ChainHeadOperation,
   parseError,
   setupChainHead,
   setupChainHeadOperation,
@@ -7,17 +8,20 @@ import {
 } from "./fixtures"
 import {
   DisjointError,
+  FollowResponse,
   OperationError,
   OperationInaccessibleError,
   OperationLimitError,
 } from "@/chainhead"
 
+type Args<T extends keyof FollowResponse> = Parameters<FollowResponse[T]>
+
 describe.each([
   [
-    "body" as "body",
-    { name: "body" } as const,
-    ["someHash"] as [string],
-    ["someHash"] as [string],
+    "body",
+    { name: "body" },
+    ["someHash"] satisfies Args<"body">,
+    ["someHash"],
     [
       {
         event: "operationBodyDone",
@@ -27,10 +31,10 @@ describe.each([
     ["tx1", "tx2"],
   ],
   [
-    "call" as "call",
-    { name: "call" } as const,
-    ["someHash", "someFnName", "someCallParams"] as [string, string, string],
-    ["someHash", "someFnName", "someCallParams"] as [string, string, string],
+    "call",
+    { name: "call" },
+    ["someHash", "someFnName", "someCallParams"] satisfies Args<"call">,
+    ["someHash", "someFnName", "someCallParams"],
     [
       {
         event: "operationCallDone",
@@ -41,13 +45,8 @@ describe.each([
   ],
   [
     "storage - value",
-    { name: "storage", discardedItems: 0 } as const,
-    ["someHash", "value", "someStorageKey", null] as [
-      hash: string,
-      type: "value",
-      key: string,
-      childTrie: string | null,
-    ],
+    { name: "storage", discardedItems: 0 },
+    ["someHash", "value", "someStorageKey", null] satisfies Args<"storage">,
     ["someHash", [{ key: "someStorageKey", type: "value" }], null],
     [
       {
@@ -67,13 +66,8 @@ describe.each([
   ],
   [
     "storage - hash",
-    { name: "storage", discardedItems: 0 } as const,
-    ["someHash", "hash", "someStorageKey", null] as [
-      hash: string,
-      type: "hash",
-      key: string,
-      childTrie: string | null,
-    ],
+    { name: "storage", discardedItems: 0 },
+    ["someHash", "hash", "someStorageKey", null] satisfies Args<"storage">,
     ["someHash", [{ key: "someStorageKey", type: "hash" }], null],
     [
       {
@@ -93,13 +87,13 @@ describe.each([
   ],
   [
     "storage - closestDescendantMerkleValue",
-    { name: "storage", discardedItems: 0 } as const,
-    ["someHash", "closestDescendantMerkleValue", "someStorageKey", null] as [
-      hash: string,
-      type: "closestDescendantMerkleValue",
-      key: string,
-      childTrie: string | null,
-    ],
+    { name: "storage", discardedItems: 0 },
+    [
+      "someHash",
+      "closestDescendantMerkleValue",
+      "someStorageKey",
+      null,
+    ] satisfies Args<"storage">,
     [
       "someHash",
       [{ key: "someStorageKey", type: "closestDescendantMerkleValue" }],
@@ -123,13 +117,13 @@ describe.each([
   ],
   [
     "storage - descendantsValues",
-    { name: "storage", discardedItems: 0 } as const,
-    ["someHash", "descendantsValues", "someStorageKey", null] as [
-      hash: string,
-      type: "descendantsValues",
-      key: string,
-      childTrie: string | null,
-    ],
+    { name: "storage", discardedItems: 0 },
+    [
+      "someHash",
+      "descendantsValues",
+      "someStorageKey",
+      null,
+    ] satisfies Args<"storage">,
     ["someHash", [{ key: "someStorageKey", type: "descendantsValues" }], null],
     [
       {
@@ -162,13 +156,13 @@ describe.each([
   ],
   [
     "storage - descendantsHashes",
-    { name: "storage", discardedItems: 0 } as const,
-    ["someHash", "descendantsHashes", "someStorageKey", null] as [
-      hash: string,
-      type: "descendantsHashes",
-      key: string,
-      childTrie: string | null,
-    ],
+    { name: "storage", discardedItems: 0 },
+    [
+      "someHash",
+      "descendantsHashes",
+      "someStorageKey",
+      null,
+    ] satisfies Args<"storage">,
     ["someHash", [{ key: "someStorageKey", type: "descendantsHashes" }], null],
     [
       {
@@ -199,7 +193,7 @@ describe.each([
       },
     ],
   ],
-])(
+] satisfies Array<[string, ChainHeadOperation, any[], any[], any, any]>)(
   "chainhead: %s",
   (_, op, args, expectedMsgArgs, operationNotifications, expectedResult) => {
     it("sends the correct operation message", () => {

--- a/packages/substrate-client/tests/createClient.spec.ts
+++ b/packages/substrate-client/tests/createClient.spec.ts
@@ -1,0 +1,16 @@
+import { createClient } from "@/index"
+import { describe, expect, it } from "vitest"
+import { createMockProvider } from "./fixtures"
+
+describe("createClient", () => {
+  it("connects immediately to the client when created, and disconnects when destroying it", () => {
+    const provider = createMockProvider()
+    expect(provider.isConnected()).toBe(false)
+
+    const client = createClient(provider)
+    expect(provider.isConnected()).toBe(true)
+
+    client.destroy()
+    expect(provider.isConnected()).toBe(false)
+  })
+})


### PR DESCRIPTION
I have added a couple of tests: One that checks that an error on an operation doesn't kill the subscription, and another that just covers when the connection is created and destroyed. 

And the test "stops receiving messages upon cancelation"  wasn't covering the case correctly, as it was sending a message that couldn't be mapped to an operationId (and the assertion passed because it was checking that no messages were received).

The other changes are mainly types, style, etc. 