### PR TITLE
chore: improve `AccountId32` types

### DIFF
--- a/packages/metadata-builders/src/checksum-builder.ts
+++ b/packages/metadata-builders/src/checksum-builder.ts
@@ -115,6 +115,10 @@ const _buildChecksum = (
       "Result()",
     )
 
+  if (input.type === "AccountId32") {
+    return getChecksum([primitiveChecksums.u8, 32n], "AccountId32")
+  }
+
   // it has to be an enum by now
   const dependencies = Object.values(input.value).map((v) => {
     if (v.type === "primitive") return 0n

--- a/packages/metadata-builders/src/dynamic-builder.ts
+++ b/packages/metadata-builders/src/dynamic-builder.ts
@@ -7,9 +7,6 @@ import { mapObject } from "@polkadot-api/utils"
 
 const _bytes = scale.Bin()
 
-const isBytes = (input: LookupEntry) =>
-  input.type === "primitive" && input.value === "u8"
-
 const _buildCodec = (
   input: LookupEntry,
   cache: Map<number, Codec<any>>,
@@ -17,6 +14,7 @@ const _buildCodec = (
   _accountId: Codec<scale.SS58String>,
 ): Codec<any> => {
   if (input.type === "primitive") return scale[input.value]
+  if (input.type === "AccountId32") return _accountId
   if (input.type === "compact") return scale.compact
   if (input.type === "bitSequence") return scale.bitSequence
 
@@ -48,11 +46,8 @@ const _buildCodec = (
 
   if (input.type === "array") {
     // Bytes case
-    if (isBytes(input.value)) {
-      return input.len === 32 && (input.id === 0 || input.id === 1)
-        ? _accountId
-        : scale.Bin(input.len)
-    }
+    if (input.value.type === "primitive" && input.value.value === "u8")
+      return scale.Bin(input.len)
 
     return buildVector(input.value, input.len)
   }

--- a/packages/metadata-builders/src/lookups.ts
+++ b/packages/metadata-builders/src/lookups.ts
@@ -29,7 +29,12 @@ export type PrimitiveVar =
 
 export type CompactVar = { type: "compact"; isBig: boolean }
 export type BitSequenceVar = { type: "bitSequence" }
-export type TerminalVar = PrimitiveVar | CompactVar | BitSequenceVar
+export type AccountId32 = { type: "AccountId32" }
+export type TerminalVar =
+  | PrimitiveVar
+  | CompactVar
+  | BitSequenceVar
+  | AccountId32
 
 export type TupleVar = {
   type: "tuple"
@@ -118,6 +123,7 @@ export const getLookupFn = (lookupData: V14Lookup) => {
     }
   }
 
+  let isAccountId32SearchOn = true
   const getLookupEntryDef = withCache((id): Var => {
     const { def, path, params } = lookupData[id]
 
@@ -125,8 +131,16 @@ export const getLookupFn = (lookupData: V14Lookup) => {
       if (def.value.length === 0) return voidVar
 
       // used to be a "pointer"
-      if (def.value.length === 1)
+      if (def.value.length === 1) {
+        if (
+          isAccountId32SearchOn &&
+          path.join(",") === "sp_core,crypto,AccountId32"
+        ) {
+          isAccountId32SearchOn = false
+          return { type: "AccountId32" }
+        }
         return getLookupEntryDef(def.value[0].type as number)
+      }
 
       let allKey = true
 

--- a/packages/metadata-builders/src/view-builder/view-builder.ts
+++ b/packages/metadata-builders/src/view-builder/view-builder.ts
@@ -99,6 +99,7 @@ const _buildShapedDecoder = (
   _accountId: WithShapeWithoutExtra<AccountIdDecoded>,
 ): ShapedDecoder => {
   if (input.type === "primitive") return primitives[input.value]
+  if (input.type === "AccountId32") return _accountId
   if (input.type === "compact")
     return input.isBig ? primitives.compactBn : primitives.compactNumber
   if (input.type === "bitSequence") return primitives.bitSequence
@@ -135,9 +136,7 @@ const _buildShapedDecoder = (
   if (input.type === "array") {
     // Bytes case
     if (input.value.type === "primitive" && input.value.value === "u8") {
-      return input.len === 32 && (input.id === 0 || input.id === 1)
-        ? _accountId
-        : primitives.BytesArray(input.len)
+      return primitives.BytesArray(input.len)
     }
 
     return buildVector(input.value, input.len)

--- a/packages/metadata-builders/tests/__snapshots__/checksum-builder.spec.ts.snap
+++ b/packages/metadata-builders/tests/__snapshots__/checksum-builder.spec.ts.snap
@@ -1,5 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`getChecksumBuilder > batched call 1`] = `"ec9rkh05ed60m"`;
+exports[`getChecksumBuilder > batched call 1`] = `"dqbhlegmacpj6"`;
 
-exports[`getChecksumBuilder > felloship referenda submit 1`] = `"f3mrpiovirlv8"`;
+exports[`getChecksumBuilder > felloship referenda submit 1`] = `"82ldgipvnhim8"`;

--- a/packages/metadata-builders/tests/__snapshots__/view-builder.spec.ts.snap
+++ b/packages/metadata-builders/tests/__snapshots__/view-builder.spec.ts.snap
@@ -65,6 +65,11 @@ exports[`getViewBuilder > batched call 1`] = `
                             "value": {
                               "codec": "AccountId",
                               "input": "0xdc97b0271418c41f80d049826cfb1d6bd2e44e11ea39759addf6b01632ca973d",
+                              "path": [
+                                "sp_core",
+                                "crypto",
+                                "AccountId32",
+                              ],
                               "value": {
                                 "address": "HZZ7X3nzKuYpdrT7wSDBb8HqB7cc8z77C8oVi2MACzfAhh4",
                                 "ss58Prefix": 2,
@@ -138,6 +143,11 @@ exports[`getViewBuilder > batched call 1`] = `
                                 "value": {
                                   "codec": "AccountId",
                                   "input": "0xdc97b0271418c41f80d049826cfb1d6bd2e44e11ea39759addf6b01632ca973d",
+                                  "path": [
+                                    "sp_core",
+                                    "crypto",
+                                    "AccountId32",
+                                  ],
                                   "value": {
                                     "address": "HZZ7X3nzKuYpdrT7wSDBb8HqB7cc8z77C8oVi2MACzfAhh4",
                                     "ss58Prefix": 2,


### PR DESCRIPTION
Prior to these changes any `[u8; 32]` was being typed and encoded/decoded as a `SS58String` 🙈 That worked well most of the times, however there were many other cases for which this was completely wrong and undesirable, for instance the `parent_hash` field of a header was being encoded/decoded and typed as a `SS58String` 😬.

This PR fixes that issue.