### PR TITLE
test(client): add tests to observableClient

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -36,7 +36,8 @@
   ],
   "scripts": {
     "build": "tsc --noEmit && tsup-node src/index.ts --clean --sourcemap --platform neutral --target=es2020 --format esm,cjs --dts && tsup-node src/index.ts --clean --sourcemap --platform neutral --target=es2020 --format cjs --dts --minify --out-dir dist/min",
-    "test": "echo 'no tests'",
+    "test": "vitest",
+    "coverage": "vitest run --coverage",
     "lint": "prettier --check README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
     "format": "prettier --write README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
     "prepack": "pnpm run build"

--- a/packages/client/tests/fixtures.ts
+++ b/packages/client/tests/fixtures.ts
@@ -1,0 +1,79 @@
+import { blockHeader } from "@polkadot-api/substrate-bindings"
+import {
+  BestBlockChanged,
+  Finalized,
+  InitializedWithRuntime,
+  NewBlockWithRuntime,
+  Runtime,
+} from "@polkadot-api/substrate-client"
+import { toHex } from "@polkadot-api/utils"
+
+export const nilHash =
+  "0x0000000000000000000000000000000000000000000000000000000000000000"
+let lastHash = 0
+export const newHash = () => {
+  const value = ++lastHash
+  return "0x" + value.toString(16).padStart(64, "0")
+}
+
+function fixtureWithDefault<T>(defaultValue: () => T) {
+  return (overrides: Partial<T> = {}): T => ({
+    ...defaultValue(),
+    ...overrides,
+  })
+}
+
+export const newRuntime = fixtureWithDefault<Runtime>(() => ({
+  apis: {},
+  implName: "mock",
+  implVersion: 1,
+  specName: "spec",
+  specVersion: 1,
+  transactionVersion: 1,
+}))
+
+export const newInitialized = fixtureWithDefault<InitializedWithRuntime>(
+  () => ({
+    type: "initialized",
+    finalizedBlockHash: nilHash,
+    finalizedBlockRuntime: newRuntime(),
+  }),
+)
+
+export const createNewBlock = fixtureWithDefault<NewBlockWithRuntime>(() => ({
+  type: "newBlock",
+  blockHash: nilHash,
+  newRuntime: null,
+  parentBlockHash: nilHash,
+}))
+
+export const newBestBlockChanged = fixtureWithDefault<BestBlockChanged>(() => ({
+  type: "bestBlockChanged",
+  bestBlockHash: nilHash,
+}))
+
+export const newFinalized = fixtureWithDefault<Finalized>(() => ({
+  type: "finalized",
+  finalizedBlockHashes: [nilHash],
+  prunedBlockHashes: [],
+}))
+
+type Header = ReturnType<typeof blockHeader.dec>
+export const createHeader = (overrides: Partial<Header> = {}) => ({
+  digests: [],
+  extrinsicRoot: nilHash,
+  number: 0,
+  parentHash: nilHash,
+  stateRoot: nilHash,
+  ...overrides,
+})
+
+export const encodeHeader = (header: Header) => toHex(blockHeader.enc(header))
+
+export const wait = (timeout = 0) =>
+  new Promise((resolve) => setTimeout(resolve, timeout))
+export const waitMicro = async (amount = 1) => {
+  for (let i = 0; i < amount; i++) {
+    await Promise.resolve()
+  }
+}

--- a/packages/client/tests/fixtures.ts
+++ b/packages/client/tests/fixtures.ts
@@ -2,11 +2,13 @@ import { blockHeader } from "@polkadot-api/substrate-bindings"
 import {
   BestBlockChanged,
   Finalized,
+  FollowEventWithRuntime,
   InitializedWithRuntime,
   NewBlockWithRuntime,
   Runtime,
 } from "@polkadot-api/substrate-client"
 import { toHex } from "@polkadot-api/utils"
+import { MockSubstrateClient } from "./mockSubstrateClient"
 
 export const nilHash =
   "0x0000000000000000000000000000000000000000000000000000000000000000"
@@ -21,6 +23,16 @@ function fixtureWithDefault<T>(defaultValue: () => T) {
     ...defaultValue(),
     ...overrides,
   })
+}
+function sendFnChainheadFollow<
+  Args extends any[],
+  R extends FollowEventWithRuntime,
+>(fn: (...args: Args) => R) {
+  return (client: MockSubstrateClient, ...args: Args) => {
+    const value = fn(...args)
+    client.chainHead.mock.send(value)
+    return value
+  }
 }
 
 export const newRuntime = fixtureWithDefault<Runtime>(() => ({
@@ -39,6 +51,7 @@ export const newInitialized = fixtureWithDefault<InitializedWithRuntime>(
     finalizedBlockRuntime: newRuntime(),
   }),
 )
+export const sendInitialized = sendFnChainheadFollow(newInitialized)
 
 export const createNewBlock = fixtureWithDefault<NewBlockWithRuntime>(() => ({
   type: "newBlock",
@@ -46,17 +59,20 @@ export const createNewBlock = fixtureWithDefault<NewBlockWithRuntime>(() => ({
   newRuntime: null,
   parentBlockHash: nilHash,
 }))
+export const sendNewBlock = sendFnChainheadFollow(createNewBlock)
 
 export const newBestBlockChanged = fixtureWithDefault<BestBlockChanged>(() => ({
   type: "bestBlockChanged",
   bestBlockHash: nilHash,
 }))
+export const sendBestBlockChanged = sendFnChainheadFollow(newBestBlockChanged)
 
 export const newFinalized = fixtureWithDefault<Finalized>(() => ({
   type: "finalized",
   finalizedBlockHashes: [nilHash],
   prunedBlockHashes: [],
 }))
+export const sendFinalized = sendFnChainheadFollow(newFinalized)
 
 type Header = ReturnType<typeof blockHeader.dec>
 export const createHeader = (overrides: Partial<Header> = {}) => ({
@@ -76,4 +92,41 @@ export const waitMicro = async (amount = 1) => {
   for (let i = 0; i < amount; i++) {
     await Promise.resolve()
   }
+}
+
+export const initialize = async (mockClient: MockSubstrateClient) => {
+  const initialized = sendInitialized(mockClient, newInitialized())
+
+  const header = createHeader({
+    parentHash: newHash(),
+  })
+  await mockClient.chainHead.mock.header.reply(
+    initialized.finalizedBlockHash,
+    encodeHeader(header),
+  )
+  // Wait a microtask, internally the code is mapping values through .then(), but it's guaranteed the result will come in the same macro task
+  await waitMicro()
+
+  return {
+    initialHash: initialized.finalizedBlockHash,
+    initialNumber: header.number,
+    initialized,
+    header,
+  }
+}
+
+export const sendNewBlockBranch = (
+  mockClient: MockSubstrateClient,
+  parentHash: string,
+  length: number,
+) => {
+  let previousHash = parentHash
+  return new Array(length).fill(0).map(() => {
+    const result = sendNewBlock(mockClient, {
+      blockHash: newHash(),
+      parentBlockHash: previousHash,
+    })
+    previousHash = result.blockHash
+    return result
+  })
 }

--- a/packages/client/tests/mockSubstrateClient.ts
+++ b/packages/client/tests/mockSubstrateClient.ts
@@ -1,0 +1,166 @@
+import {
+  ChainHead,
+  FollowEventWithRuntime,
+  StorageItemInput,
+  StorageResult,
+  SubstrateClient,
+} from "@polkadot-api/substrate-client"
+import { noop } from "@polkadot-api/utils"
+import { Mock, vi } from "vitest"
+
+export interface MockSubstrateClient extends SubstrateClient {
+  chainHead: MockChainHead
+}
+
+export const createMockSubstrateClient = (): MockSubstrateClient => {
+  const chainHead = createMockChainHead()
+
+  // transaction: Transaction;
+  // destroy: UnsubscribeFn;
+  // request: <T>(method: string, params: any[], abortSignal?: AbortSignal) => Promise<T>;
+  // _request: <Reply, Notification>(method: string, params: any[], cb?: ClientRequestCb<Reply, Notification>) => UnsubscribeFn;
+
+  return {
+    _request: notImplemented,
+    chainHead,
+    transaction: notImplemented,
+    destroy: noop,
+    request: notImplemented,
+  }
+}
+
+interface MockChainHeadMocks {
+  hasUnpinned: (hash: string) => boolean
+  body: MockOperationFn<[string, AbortSignal | undefined], string[]>
+  call: MockOperationFn<
+    [string, string, string, AbortSignal | undefined],
+    string
+  >
+  header: MockOperationFn<[string], string>
+  storage: MockOperationFn<
+    [
+      string,
+      StorageItemInput["type"],
+      string,
+      string | null,
+      AbortSignal | undefined,
+    ],
+    StorageResult<StorageItemInput["type"]>
+  >
+  unfollow: Mock<[], void>
+  unpin: Mock<[string[]], Promise<void>>
+  send: (evt: FollowEventWithRuntime) => void
+  sendError: (error: Error) => void
+}
+interface MockChainHead extends ChainHead {
+  mock: MockChainHeadMocks
+}
+
+const createMockChainHead = (): MockChainHead => {
+  const unpinnedHashes = new Set<string>()
+  let active: {
+    cb: (evt: FollowEventWithRuntime) => void
+    onError: (error: Error) => void
+  } | null = null
+
+  const mock: MockChainHeadMocks = {
+    hasUnpinned: (hash) => unpinnedHashes.has(hash),
+    body: createMockPromiseFn(),
+    call: createMockPromiseFn(),
+    header: createMockPromiseFn(),
+    storage: createMockPromiseFn(),
+    unfollow: vi.fn(),
+    unpin: vi.fn(async (hashes) => {
+      hashes.forEach((hash) => unpinnedHashes.add(hash))
+    }),
+    send: (evt: FollowEventWithRuntime) => {
+      if (!active) {
+        throw new Error("No one subscribed to chainHead")
+      }
+      active.cb(evt)
+    },
+    sendError: (error: Error) => {
+      if (!active) {
+        throw new Error("No one subscribed to chainHead")
+      }
+      active.onError(error)
+    },
+  }
+
+  const chainHead: ChainHead = (_, cb, onError) => {
+    if (active) {
+      throw new Error("Mock doesn't support multiple chainHead subscriptions")
+    }
+    active = { cb, onError }
+
+    return {
+      _request: notImplemented,
+      body: mock.body,
+      call: mock.call,
+      header: mock.header,
+      storage: mock.storage as any,
+      storageSubscription: notImplemented,
+      unfollow: mock.unfollow,
+      unpin: mock.unpin,
+    }
+  }
+
+  return Object.assign(chainHead, { mock })
+}
+
+type MockOperationFn<T extends any[], R> = Mock<T, DeferredPromise<R>> & {
+  getAllCalls: (hash: string) => T[]
+  getLastCall: (hash: string) => T
+  reply: (hash: string, response: R | Promise<R>) => Promise<void>
+}
+const createMockPromiseFn = <
+  T extends [string, ...any[]],
+  R,
+>(): MockOperationFn<T, R> => {
+  const spy = vi.fn((..._: T) => deferred<R>())
+
+  function getLastCallIdx(hash: string) {
+    const idx = spy.mock.calls.findLastIndex((v) => v[0] === hash)
+    if (idx < 0) {
+      throw new Error("No call received for " + hash)
+    }
+    return idx
+  }
+
+  return Object.assign(spy, {
+    getAllCalls: (hash: string) => spy.mock.calls.filter((v) => v[0] === hash),
+    getLastCall: (hash: string) => spy.mock.calls[getLastCallIdx(hash)],
+    reply: async (hash: string, response: R | Promise<R>) => {
+      const result = spy.mock.results[getLastCallIdx(hash)]
+      if (result.type !== "return") {
+        throw new Error("Unreachable")
+      }
+      const deferred = result.value
+
+      await Promise.resolve(response).then(deferred.res, deferred.rej)
+      // Wait for the consumer of the promise to receive the message
+      await Promise.resolve()
+    },
+  })
+}
+
+interface DeferredPromise<T> extends Promise<T> {
+  res: (value: T) => void
+  rej: (err: Error) => void
+}
+
+function deferred<T>(): DeferredPromise<T> {
+  let res: (value: T) => void = () => {}
+  let rej: (err: Error) => void = () => {}
+
+  const promise = new Promise<T>((_res, _rej) => {
+    res = _res
+    rej = _rej
+  })
+
+  return Object.assign(promise, { res, rej })
+}
+
+const notImplemented = () => {
+  throw new Error("Mock not implemented")
+}

--- a/packages/client/tests/observableClient.spec.ts
+++ b/packages/client/tests/observableClient.spec.ts
@@ -3,22 +3,27 @@ import { describe, expect, it } from "vitest"
 import {
   createHeader,
   encodeHeader,
+  initialize,
   newHash,
-  newInitialized,
+  sendBestBlockChanged,
+  sendFinalized,
+  sendInitialized,
+  sendNewBlock,
+  sendNewBlockBranch,
+  wait,
   waitMicro,
 } from "./fixtures"
 import { createMockSubstrateClient } from "./mockSubstrateClient"
 import { observe } from "./observe"
 
-describe("observableClient", () => {
+describe("observableClient chainHead", () => {
   describe("finalized$", () => {
     it("emits the latest finalized block after initialized", async () => {
       const mockClient = createMockSubstrateClient()
       const client = getObservableClient(mockClient)
       const { next, error, complete } = observe(client.chainHead$().finalized$)
 
-      const initialized = newInitialized()
-      mockClient.chainHead.mock.send(initialized)
+      const initialized = sendInitialized(mockClient)
 
       // initialized event is missing some parameters before `finalized$` can emit
       expect(next).not.toHaveBeenCalled()
@@ -46,5 +51,156 @@ describe("observableClient", () => {
       expect(error).not.toHaveBeenCalled()
       expect(complete).not.toHaveBeenCalled()
     })
+
+    it("emits the new finalized block after finalized", async () => {
+      const mockClient = createMockSubstrateClient()
+      const client = getObservableClient(mockClient)
+      const { next, error, complete } = observe(client.chainHead$().finalized$)
+
+      const { initialHash, initialNumber } = await initialize(mockClient)
+
+      const newBlock = sendNewBlock(mockClient, {
+        blockHash: newHash(),
+        parentBlockHash: initialHash,
+      })
+
+      sendBestBlockChanged(mockClient, {
+        bestBlockHash: newBlock.blockHash,
+      })
+      sendFinalized(mockClient, {
+        finalizedBlockHashes: [newBlock.blockHash],
+      })
+
+      expect(next).toHaveBeenCalledTimes(2)
+      expect(next).toHaveBeenLastCalledWith({
+        hash: newBlock.blockHash,
+        number: initialNumber + 1,
+        parent: newBlock.parentBlockHash,
+      } satisfies BlockInfo)
+      expect(error).not.toHaveBeenCalled()
+      expect(complete).not.toHaveBeenCalled()
+    })
+
+    it("emits the latest finalized block even when there were no subscribers previously", async () => {
+      const mockClient = createMockSubstrateClient()
+      const client = getObservableClient(mockClient)
+      const chainHead = client.chainHead$()
+
+      const { initialHash, initialNumber } = await initialize(mockClient)
+
+      const newBlock = sendNewBlock(mockClient, {
+        blockHash: newHash(),
+        parentBlockHash: initialHash,
+      })
+
+      sendBestBlockChanged(mockClient, {
+        bestBlockHash: newBlock.blockHash,
+      })
+      sendFinalized(mockClient, {
+        finalizedBlockHashes: [newBlock.blockHash],
+      })
+
+      const { next, error, complete } = observe(chainHead.finalized$)
+
+      expect(next).toHaveBeenCalledOnce()
+      expect(next).toHaveBeenLastCalledWith({
+        hash: newBlock.blockHash,
+        number: initialNumber + 1,
+        parent: newBlock.parentBlockHash,
+      } satisfies BlockInfo)
+      expect(error).not.toHaveBeenCalled()
+      expect(complete).not.toHaveBeenCalled()
+
+      cleanup(chainHead.unfollow)
+    })
+  })
+
+  describe("unpinning logic", () => {
+    it("automatically unpins unused blocks after the last finalized block", async () => {
+      const mockClient = createMockSubstrateClient()
+      const client = getObservableClient(mockClient)
+      const chainHead = client.chainHead$()
+
+      const { initialHash } = await initialize(mockClient)
+
+      const firstChain = sendNewBlockBranch(mockClient, initialHash, 3)
+      const followingChain = sendNewBlockBranch(
+        mockClient,
+        firstChain.at(-1)!.blockHash,
+        2,
+      )
+
+      // Mark all as best block
+      sendBestBlockChanged(mockClient, {
+        bestBlockHash: followingChain.at(-1)!.blockHash,
+      })
+
+      expect(mockClient.chainHead.mock.unpin).not.toHaveBeenCalled()
+
+      sendFinalized(mockClient, {
+        finalizedBlockHashes: firstChain.map((v) => v.blockHash),
+      })
+
+      let [unpinned] = await mockClient.chainHead.mock.unpin.waitNextCall()
+
+      let expected = [
+        initialHash,
+        ...firstChain.slice(0, -1).map((v) => v.blockHash),
+      ]
+      expect(new Set(unpinned)).toEqual(new Set(expected))
+
+      sendFinalized(mockClient, {
+        finalizedBlockHashes: followingChain.map((v) => v.blockHash),
+      })
+
+      unpinned = (await mockClient.chainHead.mock.unpin.waitNextCall())[0]
+      expected = [
+        firstChain.slice(-1)[0].blockHash,
+        ...followingChain.slice(0, -1).map((v) => v.blockHash),
+      ]
+      expect(new Set(unpinned)).toEqual(new Set(expected))
+
+      cleanup(chainHead.unfollow)
+    })
+
+    it("unpins pruned branches", async () => {
+      const mockClient = createMockSubstrateClient()
+      const client = getObservableClient(mockClient)
+      const chainHead = client.chainHead$()
+
+      const { initialHash } = await initialize(mockClient)
+
+      const bestChain = sendNewBlockBranch(mockClient, initialHash, 5)
+      const deadChain = sendNewBlockBranch(
+        mockClient,
+        bestChain[2].blockHash,
+        10,
+      )
+      sendBestBlockChanged(mockClient, {
+        bestBlockHash: bestChain.at(-1)!.blockHash,
+      })
+
+      sendFinalized(mockClient, {
+        finalizedBlockHashes: bestChain.map((v) => v.blockHash),
+        prunedBlockHashes: deadChain.map((v) => v.blockHash),
+      })
+
+      let [unpinned] = await mockClient.chainHead.mock.unpin.waitNextCall()
+
+      let expected = [
+        initialHash,
+        ...bestChain.slice(0, -1).map((v) => v.blockHash),
+        ...deadChain.map((v) => v.blockHash),
+      ]
+      expect(new Set(unpinned)).toEqual(new Set(expected))
+
+      cleanup(chainHead.unfollow)
+    })
   })
 })
+
+// cleans up the subscription after a macro task. Doing it too quickly might actually create a subscription, as there are delays internally.
+const cleanup = async (unfollow: () => void) => {
+  await wait()
+  unfollow()
+}

--- a/packages/client/tests/observableClient.spec.ts
+++ b/packages/client/tests/observableClient.spec.ts
@@ -1,0 +1,50 @@
+import { BlockInfo, getObservableClient } from "@/observableClient"
+import { describe, expect, it } from "vitest"
+import {
+  createHeader,
+  encodeHeader,
+  newHash,
+  newInitialized,
+  waitMicro,
+} from "./fixtures"
+import { createMockSubstrateClient } from "./mockSubstrateClient"
+import { observe } from "./observe"
+
+describe("observableClient", () => {
+  describe("finalized$", () => {
+    it("emits the latest finalized block after initialized", async () => {
+      const mockClient = createMockSubstrateClient()
+      const client = getObservableClient(mockClient)
+      const { next, error, complete } = observe(client.chainHead$().finalized$)
+
+      const initialized = newInitialized()
+      mockClient.chainHead.mock.send(initialized)
+
+      // initialized event is missing some parameters before `finalized$` can emit
+      expect(next).not.toHaveBeenCalled()
+      expect(mockClient.chainHead.mock.header).toHaveBeenCalledWith(
+        initialized.finalizedBlockHash,
+      )
+
+      const header = createHeader({
+        parentHash: newHash(),
+      })
+      await mockClient.chainHead.mock.header.reply(
+        initialized.finalizedBlockHash,
+        encodeHeader(header),
+      )
+
+      // finalized does some `.then()` to map values, so you won't get it immediately, but within the same macro task.
+      await waitMicro()
+
+      expect(next).toHaveBeenCalledOnce()
+      expect(next).toHaveBeenLastCalledWith({
+        hash: initialized.finalizedBlockHash,
+        number: header.number,
+        parent: header.parentHash,
+      } satisfies BlockInfo)
+      expect(error).not.toHaveBeenCalled()
+      expect(complete).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/client/tests/observe.ts
+++ b/packages/client/tests/observe.ts
@@ -1,0 +1,18 @@
+import { Observable } from "rxjs"
+import { vi, Mock as _ } from "vitest"
+
+export function observe<T>(obs$: Observable<T>) {
+  const next = vi.fn<[T], void>()
+  const error = vi.fn<[any], void>()
+  const complete = vi.fn<[], void>()
+
+  const subscription = obs$.subscribe({
+    next,
+    error,
+    complete,
+  })
+  const unsubscribe = () => subscription.unsubscribe()
+  const getLastEmission = () => next.mock.calls.at(-1)?.[0]
+
+  return { next, error, complete, getLastEmission, unsubscribe }
+}


### PR DESCRIPTION
I found that blocks were not getting unpinned after they were pruned on a finalize event, from the [JSON-RPC Spec on pinning](https://paritytech.github.io/json-rpc-interface-spec/api/chainHead_unstable_follow.html#pinning):

> Blocks stay pinned even if they have been pruned from the chain of blocks, and must always be unpinned by the JSON-RPC client.