### PR TITLE
feat(client): track tx

### DIFF
--- a/packages/client/src/observableClient/chainHead/chainHead.ts
+++ b/packages/client/src/observableClient/chainHead/chainHead.ts
@@ -37,6 +37,7 @@ import {
 } from "./enhancers"
 import { withDefaultValue } from "@/utils"
 import { getRecoveralStorage$ } from "./storage-queries"
+import { getTrackTx } from "./track-tx"
 
 export type { RuntimeContext, SystemEvent }
 export type { FollowEventWithRuntime }
@@ -192,6 +193,7 @@ export const getChainHead$ = (chainHead: ChainHead) => {
 
   const _body$ = commonEnhancer(lazyFollower("body"))
   const body$ = (hash: string) => upsertCachedStream(hash, "body", _body$(hash))
+  const trackTx$ = getTrackTx(pinnedBlocks$, body$)
 
   const _storage$ = commonEnhancer(lazyFollower("storage"))
 
@@ -269,6 +271,7 @@ export const getChainHead$ = (chainHead: ChainHead) => {
     storageQueries$,
     eventsAt$,
 
+    trackTx$,
     withRuntime,
     getRuntimeContext$: withOptionalHash$(getRuntimeContext$),
     unfollow,

--- a/packages/client/src/observableClient/chainHead/track-tx.ts
+++ b/packages/client/src/observableClient/chainHead/track-tx.ts
@@ -1,0 +1,96 @@
+import {
+  Observable,
+  concat,
+  concatMap,
+  distinct,
+  distinctUntilChanged,
+  filter,
+  map,
+  mergeMap,
+  of,
+  take,
+  takeUntil,
+  takeWhile,
+} from "rxjs"
+import { PinnedBlocks } from "./streams"
+import {
+  TxBestChainBlockIncluded,
+  TxFinalized,
+} from "@polkadot-api/substrate-client"
+
+export const getTrackTx = (
+  blocks$: Observable<PinnedBlocks>,
+  getBody: (block: string) => Observable<string[]>,
+) => {
+  const findBestOrFinalized = (blockHash: string, type: "best" | "finalized") =>
+    blocks$.pipe(
+      takeWhile((b) => b.blocks.has(blockHash)),
+      distinctUntilChanged((a, b) => a[type] === b[type]),
+      filter(
+        (x) => x.blocks.get(x[type])!.number >= x.blocks.get(blockHash)!.number,
+      ),
+      map((pinned) => {
+        const { number } = pinned.blocks.get(blockHash)!
+        let current = pinned.blocks.get(pinned[type])!
+        while (current.number > number)
+          current = pinned.blocks.get(current.parent)!
+        return current.hash === blockHash
+      }),
+      filter(Boolean),
+      take(1),
+    )
+
+  return (tx: string): Observable<TxBestChainBlockIncluded | TxFinalized> =>
+    blocks$.pipe(
+      take(1),
+      concatMap((x) => {
+        const alreadyPresent = new Set(x.blocks.keys())
+
+        const findInBody = (hash: string): Observable<number> =>
+          alreadyPresent.has(hash)
+            ? of(-1)
+            : getBody(hash).pipe(
+                takeUntil(
+                  blocks$.pipe(filter(({ blocks }) => !blocks.has(hash))),
+                ),
+                map((txs) => txs.indexOf(tx)),
+              )
+
+        const findInBranch = (
+          hash: string,
+        ): Observable<{ hash: string; idx: number }> =>
+          findInBody(hash).pipe(
+            concatMap((idx) =>
+              idx > -1
+                ? of({ hash, idx })
+                : blocks$.pipe(
+                    takeWhile((x) => x.blocks.has(hash)),
+                    mergeMap((x) => x.blocks.get(hash)!.children),
+                    distinct(),
+                    mergeMap(findInBranch),
+                  ),
+            ),
+          )
+
+        return findInBranch(x.finalized).pipe(
+          mergeMap(({ hash, idx }) =>
+            concat(
+              findBestOrFinalized(hash, "best").pipe(
+                map(() => ({
+                  type: "bestChainBlockIncluded" as const,
+                  block: { hash, index: idx },
+                })),
+              ),
+              findBestOrFinalized(hash, "finalized").pipe(
+                map(() => ({
+                  type: "finalized" as const,
+                  block: { hash, index: idx },
+                })),
+              ),
+            ),
+          ),
+        )
+      }),
+      takeWhile((x) => x.type !== "finalized", true),
+    )
+}


### PR DESCRIPTION
One of the challenging things about #247 is the fact that it will be on us to track down the transaction in a performant manner. This PR adds that functionality.

Basically, what this PR does is to use the "old" [`transactionWatch_unstable_submitAndWatch`](https://paritytech.github.io/json-rpc-interface-spec/api/transactionWatch_unstable_submitAndWatch.html#transactionwatch_unstable_submitandwatch) method, but then it stops the operation as soon as it has emitted the "broadcasted" event, at which point it starts tracking down the transaction. This is a temporary workaround while we wait for smoldot to implement the new "transaction broadcast" API.