### PR TITLE
fix(cli): add `WebSocket` into global scope

### DIFF
--- a/packages/cli/src/metadata.ts
+++ b/packages/cli/src/metadata.ts
@@ -8,6 +8,8 @@ import { Worker } from "node:worker_threads"
 import { WebSocketProvider } from "@polkadot-api/ws-provider"
 import { getObservableClient } from "@polkadot-api/client"
 import { filter, firstValueFrom } from "rxjs"
+import { WebSocket } from "ws"
+;(globalThis as any).WebSocket = WebSocket
 
 const getMetadataCall = async (provider: ConnectProvider) => {
   const client = getObservableClient(createClient(provider))


### PR DESCRIPTION
Currently the `@polkadot-api/ws-provider` assumes that the `WebSocket` interface is present in the global-scope, which is not the case on non-browser environments. Therefore, when we added the `ws-provider` we accidentally broke the `cli` when using the `wsURL` flag. So, this is a quick "fix" to address that issue.

Probably a better fix would be to have the `ws-provider` return a higher-order-function that first receives the `WebSocket` interface and then it returns the actual get-provider function. However, I want to think a bit more about that before making that change.