### PR TITLE
fix(ci): zombienet flaky test

### DIFF
--- a/packages/client/src/observableClient/chainHead/chainHead.ts
+++ b/packages/client/src/observableClient/chainHead/chainHead.ts
@@ -2,6 +2,7 @@ import { concatMapEager, shareLatest } from "@/utils"
 import { blockHeader } from "@polkadot-api/substrate-bindings"
 import {
   ChainHead,
+  DisjointError,
   FollowEventWithRuntime,
   StorageItemInput,
   StorageResult,
@@ -79,7 +80,14 @@ export const getChainHead$ = (chainHead: ChainHead) => {
 
   const getHeader = (hash: string) =>
     getFollower().header(hash).then(blockHeader.dec)
-  const unpin = (hashes: string[]) => getFollower().unpin(hashes)
+
+  const unpin = (hashes: string[]) =>
+    getFollower()
+      .unpin(hashes)
+      .catch((e) => {
+        if (e instanceof DisjointError) return
+        throw e
+      })
 
   const commonEnhancer = <A extends Array<any>, T>(
     fn: (


### PR DESCRIPTION
If when the consumer calls `chainhead.unfollow()`, like the [zombienet tests currently do](https://github.com/polkadot-api/polkadot-api/blob/9a68a6a6512cdb6d0cac0a5c178a09b036bb58d3/zombie-tests/src/0001-check-tx.ts#L251) while there is an `unpin` request on the fly, then that request will be rejected with a `DisjointError`, which is obviously not a big deal.

The problem, though, is precisely that we are treating `unpin` requests like fire-and-forget requests, so that triggers an unhandled rejection which makes the tests not pass when that occurs. This change avoids the issue. It's totally fine to ignore `DisjointError`s on `unpin` requests, because if it's disjoined, meaning that the block is certainly no longer pinned.