### PR TITLE
feat: hinted "signed extensions"

### DIFF
--- a/packages/cli/src/io/createDescriptorsFile.ts
+++ b/packages/cli/src/io/createDescriptorsFile.ts
@@ -36,6 +36,7 @@ export const createDescriptorsFile = async (
     >
   },
   enums: Array<string>,
+  asset: null | { checksum: string; type: string },
 ) => {
   const { pallets, apis } = descriptors
 
@@ -164,8 +165,16 @@ export const createDescriptorsFile = async (
     )};\n`,
   )
 
+  const assetIdType = `PlainDescriptor<${asset?.type ?? "void"}>`
+  const assetIdVarName = "ChargeAssetTxPaymentAsset"
   addLine(
-    `type I${key}Descriptors = { pallets: I${key}DescriptorsPallets, apis: I${key}DescriptorsApis };\n`,
+    `const ${assetIdVarName}: ${assetIdType} = "${
+      asset?.checksum ?? ""
+    }" as ${assetIdType}`,
+  )
+
+  addLine(
+    `type I${key}Descriptors = { pallets: I${key}DescriptorsPallets, apis: I${key}DescriptorsApis, asset: ${assetIdType} };\n`,
   )
 
   addLine(
@@ -191,7 +200,7 @@ export const createDescriptorsFile = async (
   )
 
   addLine(
-    `const _allDescriptors: I${key}Descriptors = { pallets: _allPalletDescriptors, apis: _allApiDescriptors }`,
+    `const _allDescriptors: I${key}Descriptors = { pallets: _allPalletDescriptors, apis: _allApiDescriptors, asset: ${assetIdVarName} }`,
   )
 
   addLine(`export default _allDescriptors`)

--- a/packages/cli/src/io/getCodegenInfo.ts
+++ b/packages/cli/src/io/getCodegenInfo.ts
@@ -151,8 +151,30 @@ export const getCodegenInfo = (
     }
   }
 
+  const assetPayment = metadata.extrinsic.signedExtensions.find(
+    (x) => x.identifier === "ChargeAssetTxPayment",
+  )
+  let _assetId: null | number = null
+  if (assetPayment) {
+    const assetTxPayment = getLookup(assetPayment.type)
+    if (assetTxPayment.type === "struct") {
+      const optionalAssetId = assetTxPayment.value.asset_id
+      if (optionalAssetId.type === "option") _assetId = optionalAssetId.value.id
+    }
+  }
+
+  const assetId =
+    _assetId === null
+      ? null
+      : {
+          checksum: checksumBuilder.buildDefinition(_assetId)!,
+          type: staticBuilder.getTypeFromVarName(
+            staticBuilder.buildDefinition(_assetId),
+          ),
+        }
+
   const code = staticBuilder.getCode() + "\n\n" + exportedTypes.join("\n")
   const enums = staticBuilder.getEnums()
 
-  return { descriptorsData, code, enums }
+  return { descriptorsData, code, enums, assetId }
 }

--- a/packages/cli/src/io/io.ts
+++ b/packages/cli/src/io/io.ts
@@ -131,12 +131,18 @@ export async function outputCodegen(
   key: string,
   selectOnly?: string[],
 ) {
-  const { code, descriptorsData, enums } = getCodegenInfo(
+  const { code, descriptorsData, enums, assetId } = getCodegenInfo(
     metadata,
     key,
     selectOnly,
   )
   await fs.mkdir(outputFolder, { recursive: true })
   await createDtsFile(key, outputFolder, code)
-  await createDescriptorsFile(key, outputFolder, descriptorsData, enums)
+  await createDescriptorsFile(
+    key,
+    outputFolder,
+    descriptorsData,
+    enums,
+    assetId,
+  )
 }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -8,6 +8,7 @@ import {
   CreateClient,
   CreateTx,
   EvApi,
+  HintedSignedExtensions,
   RuntimeCallsApi,
   StorageApi,
   TxApi,
@@ -35,7 +36,7 @@ const createNamespace = (
   client: ReturnType<typeof getObservableClient>,
 ): {
   query: StorageApi<QueryFromDescriptors<Descriptors>>
-  tx: TxApi<TxFromDescriptors<Descriptors>>
+  tx: TxApi<TxFromDescriptors<Descriptors>, Descriptors["asset"]["_type"]>
   event: EvApi<EventsFromDescriptors<Descriptors>>
   apis: RuntimeCallsApi<Descriptors["apis"]>
 } => {
@@ -56,7 +57,7 @@ const createNamespace = (
 
   const tx = {} as Record<
     string,
-    Record<string, (a: any) => Transaction<any, any, any>>
+    Record<string, (a: any) => Transaction<any, any, any, any>>
   >
   for (const pallet in pallets) {
     tx[pallet] ||= {}
@@ -66,6 +67,7 @@ const createNamespace = (
         txEntries[name],
         pallet,
         name,
+        descriptors.asset,
         chainHead,
         client,
         createTxFromAddress,
@@ -122,6 +124,7 @@ export const createClient: CreateClient = (connect, descriptors) => {
   const createTxFromAddress = async (
     address: string | Uint8Array,
     callData: Uint8Array,
+    hinted?: HintedSignedExtensions,
   ) => {
     let publicKey: Uint8Array
 
@@ -133,7 +136,7 @@ export const createClient: CreateClient = (connect, descriptors) => {
       publicKey = accountId.enc(address)
     }
 
-    return createTx(publicKey, callData)
+    return createTx(publicKey, callData, hinted)
   }
 
   return {

--- a/packages/legacy-polkadot-provider/src/get-tx-creator/get-tx-creator.ts
+++ b/packages/legacy-polkadot-provider/src/get-tx-creator/get-tx-creator.ts
@@ -36,10 +36,10 @@ export const getTxCreator: GetTxCreator = (
       }),
     )
 
-    const createTx: CreateTx = async (from, callData) => {
+    const createTx: CreateTx = async (from, callData, hinted = {}) => {
       const { extra, pjs } = await firstValueFrom(
         metaCtx$.pipe(
-          mergeMap(getTxData(from, callData, chainHead, onCreateTx)),
+          mergeMap(getTxData(from, callData, chainHead, hinted, onCreateTx)),
         ),
       )
 

--- a/packages/legacy-polkadot-provider/src/get-tx-creator/get-tx-data.ts
+++ b/packages/legacy-polkadot-provider/src/get-tx-creator/get-tx-data.ts
@@ -3,6 +3,7 @@ import {
   UserSignedExtensionsData,
   OnCreateTxCtx,
   UserSignedExtensionName,
+  HintedSignedExtensions,
 } from ".."
 import { getInput$ } from "./input"
 import { combineLatest, map } from "rxjs"
@@ -41,6 +42,7 @@ export const getTxData =
     from: Uint8Array,
     callData: Uint8Array,
     chainHead: ReturnType<ReturnType<typeof getObservableClient>["chainHead$"]>,
+    hintedSignedExtensions: HintedSignedExtensions,
     onCreateTx: (
       context: OnCreateTxCtx<T>,
       callback: (value: null | UserSignedExtensionsData<T>) => void,
@@ -52,6 +54,7 @@ export const getTxData =
       {
         from,
         callData,
+        hintedSignedExtensions,
         userSingedExtensionsName: user as any,
         unknownSignedExtensions: unknown,
       },

--- a/packages/legacy-polkadot-provider/src/get-tx-creator/signed-extensions/user/ChargeAssetTxPayment.ts
+++ b/packages/legacy-polkadot-provider/src/get-tx-creator/signed-extensions/user/ChargeAssetTxPayment.ts
@@ -1,10 +1,15 @@
 import { map } from "rxjs"
-import { Option, Struct, compact, u32 } from "@polkadot-api/substrate-bindings"
+import {
+  Option,
+  Struct,
+  compact,
+  Bytes,
+} from "@polkadot-api/substrate-bindings"
 import type { GetUserSignedExtension } from "@/types/internal-types"
 
 const encoder = Struct({
   tip: compact,
-  assetId: Option(u32),
+  assetId: Option(Bytes(Infinity)),
 }).enc
 
 export const ChargeAssetTxPayment: GetUserSignedExtension<

--- a/packages/legacy-polkadot-provider/src/legacy-provider.ts
+++ b/packages/legacy-polkadot-provider/src/legacy-provider.ts
@@ -18,21 +18,25 @@ import { Signer } from "@polkadot/api/types"
 import { mapObject } from "@polkadot-api/utils"
 
 const defaultOnCreateTx: CreateTxCallback = (
-  { userSingedExtensionsName },
+  {
+    userSingedExtensionsName,
+    hintedSignedExtensions: { mortality, tip, assetId },
+  },
   callback,
 ) => {
   const userSignedExtensionsData = Object.fromEntries(
     userSingedExtensionsName.map((x) => {
       if (x === "CheckMortality") {
-        const result: UserSignedExtensions["CheckMortality"] = {
+        const result: UserSignedExtensions["CheckMortality"] = mortality ?? {
           mortal: true,
           period: 64,
         }
         return [x, result]
       }
 
-      if (x === "ChargeTransactionPayment") return [x, 0n]
-      return [x, { tip: 0n }]
+      if (x === "ChargeTransactionPayment") return [x, tip ?? 0n]
+
+      return [x, { tip: tip ?? 0n, assetId }]
     }),
   )
 

--- a/packages/legacy-polkadot-provider/src/types/internal-types.ts
+++ b/packages/legacy-polkadot-provider/src/types/internal-types.ts
@@ -6,6 +6,7 @@ import {
   CreateTxCallback,
   UserSignedExtensionName,
   UserSignedExtensions,
+  HintedSignedExtensions,
 } from "./public-types"
 
 export type Callback<T> = (value: T) => void
@@ -36,6 +37,11 @@ export type OnCreateTxCtx<
   // different chains may require a different set of these.
   userSingedExtensionsName: UserSignedExtensionsName
 
+  // The dApp may suggested some default values for the signed extensions
+  // that require from user input. The user interface should take these
+  // values under consideration while allowing the user to alter them.
+  hintedSignedExtensions: HintedSignedExtensions
+
   // An Array containing a list of the signed extensions which are unknown
   // to the library and that require for a value on the "extra" field
   // and/or additionally signed data. This will give the consumer the opportunity
@@ -46,6 +52,7 @@ export type OnCreateTxCtx<
 export type CreateTx = (
   from: Uint8Array, // The public-key of the sender
   callData: Uint8Array,
+  hintedSignedExtensions?: HintedSignedExtensions,
 ) => Promise<Uint8Array>
 
 export type SigningType = "Ed25519" | "Sr25519" | "Ecdsa"

--- a/packages/legacy-polkadot-provider/src/types/public-types.ts
+++ b/packages/legacy-polkadot-provider/src/types/public-types.ts
@@ -14,6 +14,11 @@ export type OnCreateTxCtx<
   // different chains may require a different set of these.
   userSingedExtensionsName: UserSignedExtensionsName
 
+  // The dApp may suggested some default values for the signed extensions
+  // that require from user input. The user interface should take these
+  // values under consideration while allowing the user to alter them.
+  hintedSignedExtensions: HintedSignedExtensions
+
   // An Array containing a list of the signed extensions which are unknown
   // to the library and that require for a value on the "extra" field
   // and/or additionally signed data. This will give the consumer the opportunity
@@ -34,8 +39,14 @@ export type CreateTxCallback = <
 export type UserSignedExtensions = {
   CheckMortality: { mortal: false } | { mortal: true; period: number }
   ChargeTransactionPayment: bigint
-  ChargeAssetTxPayment: { tip: bigint; assetId?: number }
+  ChargeAssetTxPayment: { tip: bigint; assetId?: Uint8Array }
 }
+
+export type HintedSignedExtensions = Partial<{
+  tip: bigint
+  mortality: { mortal: false } | { mortal: true; period: number }
+  assetId: Uint8Array
+}>
 
 export type UserSignedExtensionName = keyof UserSignedExtensions
 

--- a/packages/node-polkadot-provider/src/types/json-rpc-provider.ts
+++ b/packages/node-polkadot-provider/src/types/json-rpc-provider.ts
@@ -1,6 +1,12 @@
 export type Callback<T> = (value: T) => void
 type UnsubscribeFn = () => void
 
+export type HintedSignedExtensions = Partial<{
+  tip: bigint
+  mortality: { mortal: false } | { mortal: true; period: number }
+  assetId: Uint8Array
+}>
+
 export interface JsonRpcProvider {
   // it sends messages to the JSON RPC Server
   send: (message: string) => void
@@ -8,7 +14,11 @@ export interface JsonRpcProvider {
   // `publicKey` is the SS58Formated public key
   // `callData` is the scale encoded call-data
   // (module index, call index and args)
-  createTx: (publicKey: Uint8Array, callData: Uint8Array) => Promise<Uint8Array>
+  createTx: (
+    publicKey: Uint8Array,
+    callData: Uint8Array,
+    hintedSignedExtensions: HintedSignedExtensions,
+  ) => Promise<Uint8Array>
 
   // it disconnects from the JSON RPC Server and it de-registers
   // the `onMessage` and `onStatusChange` callbacks that

--- a/packages/node-polkadot-provider/src/types/public-types.ts
+++ b/packages/node-polkadot-provider/src/types/public-types.ts
@@ -13,7 +13,7 @@ export type KeyPair = {
   sign: (input: Uint8Array) => Promise<Uint8Array>
 }
 
-export type CreateTxParams = NonNullable<Parameters<CreateTx>[2]>
+export type CreateTxParams = NonNullable<Parameters<CreateTx>[3]>
 export type CreateTxContext = Parameters<CreateTxParams>[0]
 export type CustomizeTxResult<T extends Array<UserSignedExtensionName>> = {
   userSignedExtensionsData: ConsumerCallback<T>["userSignedExtensionsData"]

--- a/packages/substrate-bindings/src/descriptors.ts
+++ b/packages/substrate-bindings/src/descriptors.ts
@@ -27,6 +27,7 @@ export type Descriptors = {
     ]
   >
   apis: Record<string, Record<string, RuntimeDescriptor<any, any>>>
+  asset: PlainDescriptor<any>
 }
 
 type PickDescriptors<

--- a/packages/tx-helper/src/get-tx-creator/get-tx-creator.ts
+++ b/packages/tx-helper/src/get-tx-creator/get-tx-creator.ts
@@ -36,12 +36,21 @@ export const getTxCreator: GetTxCreator = (chainProvider, onCreateTx) => {
     }),
   )
 
-  const createTx: CreateTx = async (from, callData, cb = onCreateTx) => {
+  const createTx: CreateTx = async (
+    from,
+    callData,
+    hintedSignedExtensions = {},
+    cb = onCreateTx,
+  ) => {
     const {
       signer,
       signedExtensions: { value: extra, additionalSigned },
     } = await firstValueFrom(
-      metaCtx$.pipe(mergeMap(getTxData(from, callData, chainHead, cb))),
+      metaCtx$.pipe(
+        mergeMap(
+          getTxData(from, callData, chainHead, hintedSignedExtensions, cb),
+        ),
+      ),
     )
 
     const toSign = mergeUint8(callData, extra, additionalSigned)

--- a/packages/tx-helper/src/get-tx-creator/get-tx-data.ts
+++ b/packages/tx-helper/src/get-tx-creator/get-tx-data.ts
@@ -1,5 +1,10 @@
 import { V15, v15 } from "@polkadot-api/substrate-bindings"
-import { ConsumerCallback, OnCreateTxCtx, UserSignedExtensionName } from ".."
+import {
+  ConsumerCallback,
+  HintedSignedExtensions,
+  OnCreateTxCtx,
+  UserSignedExtensionName,
+} from ".."
 import { getInput$ } from "./input"
 import { combineLatest, filter, map, startWith, take } from "rxjs"
 import type { FlattenSignedExtension } from "@/internal-types"
@@ -26,6 +31,7 @@ export const getTxData =
     from: Uint8Array,
     callData: Uint8Array,
     chainHead: ReturnType<ReturnType<typeof getObservableClient>["chainHead$"]>,
+    hintedSignedExtensions: HintedSignedExtensions,
     onCreateTx: (
       context: OnCreateTxCtx<T>,
       callback: (value: null | ConsumerCallback<T>) => void,
@@ -38,6 +44,7 @@ export const getTxData =
         from,
         callData,
         metadata: v15.enc(metadata),
+        hintedSignedExtensions,
         userSingedExtensionsName: user as any,
         unknownSignedExtensions: unknown,
       },

--- a/packages/tx-helper/src/signed-extensions/user/ChargeAssetTxPayment.ts
+++ b/packages/tx-helper/src/signed-extensions/user/ChargeAssetTxPayment.ts
@@ -1,11 +1,16 @@
 import { map } from "rxjs"
-import { Option, Struct, compact, u32 } from "@polkadot-api/substrate-bindings"
+import {
+  Bytes,
+  Option,
+  Struct,
+  compact,
+} from "@polkadot-api/substrate-bindings"
 import type { GetUserSignedExtension } from "@/internal-types"
 import { empty$ } from "../utils"
 
 const encoder = Struct({
   tip: compact,
-  assetId: Option(u32),
+  assetId: Option(Bytes(Infinity)),
 }).enc
 
 export const ChargeAssetTxPayment: GetUserSignedExtension<

--- a/packages/tx-helper/src/types.ts
+++ b/packages/tx-helper/src/types.ts
@@ -34,12 +34,17 @@ export type OnCreateTxCtx<
   // different chains may require a different set of these.
   userSingedExtensionsName: UserSignedExtensionsName
 
+  // The dApp may suggested some default values for the signed extensions
+  // that require from user input. The user interface should take these
+  // values under consideration while allowing the user to alter them.
+  hintedSignedExtensions: HintedSignedExtensions
+
   // An Array containing a list of the signed extensions which are unknown
   // to the library and that require for a value on the "extra" field
   // and/or additionally signed data. This will give the consumer the opportunity
   // to provide that data via the `overrides` field of the callback.
-
   unknownSignedExtensions: Array<string>
+
   // The user interface may need the metadata for many different reasons:
   // knowing how to decode and present the arguments of the call to the user,
   // validate the user input, later decode the singer data, etc, etc.
@@ -60,9 +65,16 @@ export type ConsumerCallback<T extends Array<UserSignedExtensionName>> = {
   signer: (input: Uint8Array) => Promise<Uint8Array>
 }
 
+export type HintedSignedExtensions = Partial<{
+  tip: bigint
+  mortality: { mortal: false } | { mortal: true; period: number }
+  assetId: Uint8Array
+}>
+
 export type CreateTx = (
   from: Uint8Array, // The public-key of the sender
   callData: Uint8Array,
+  hintedSignedExtensions?: HintedSignedExtensions,
   cb?: <UserSignedExtensionsName extends Array<UserSignedExtensionName>>(
     context: OnCreateTxCtx<UserSignedExtensionsName>,
     callback: Callback<null | ConsumerCallback<UserSignedExtensionsName>>,
@@ -74,7 +86,7 @@ export type SigningType = "Ed25519" | "Sr25519" | "Ecdsa"
 export type UserSignedExtensions = {
   CheckMortality: { mortal: false } | { mortal: true; period: number }
   ChargeTransactionPayment: bigint
-  ChargeAssetTxPayment: { tip: bigint; assetId?: number }
+  ChargeAssetTxPayment: { tip: bigint; assetId?: Uint8Array }
 }
 
 export type UserSignedExtensionName = keyof UserSignedExtensions


### PR DESCRIPTION
These changes allow dApp developers to "hint" some values for the sign-extensions that require from user input while creating a TX.

The trickiest part was the `asset` hint, which will only be available for chains that support the `ChargeAssetTxPayment` signed extension, but in the end I think that it's working quite nicely.