### PR TITLE
feat(client): improve unpinning logic

### DIFF
--- a/packages/client/src/observableClient/chainHead/streams/pinned-blocks.ts
+++ b/packages/client/src/observableClient/chainHead/streams/pinned-blocks.ts
@@ -32,8 +32,8 @@ const deleteBlock = (blocks: PinnedBlocks["blocks"], blockHash: string) => {
   blocks.delete(blockHash)
 }
 
-const getBlocksToUnpin = (blocks: PinnedBlocks, prunned: string[]) => {
-  const result: string[] = []
+const getBlocksToUnpin = (blocks: PinnedBlocks, pruned: string[]) => {
+  const result: string[] = [...pruned]
   let current = blocks.blocks.get(blocks.blocks.get(blocks.finalized)!.parent)
 
   const trail: string[] = []
@@ -47,7 +47,7 @@ const getBlocksToUnpin = (blocks: PinnedBlocks, prunned: string[]) => {
     current = blocks.blocks.get(current.parent)
   }
 
-  const deletedBlocks = [...prunned]
+  const deletedBlocks = [...pruned]
   for (let i = trail.length - 1; i >= 0; i--) {
     current = blocks.blocks.get(trail[i])!
     if (!current.unpinned) return result
@@ -65,8 +65,8 @@ const getBlocksToUnpin = (blocks: PinnedBlocks, prunned: string[]) => {
     }))
     .filter((x) => x.usages === 0)
     .map((x) => x.key)
-    .forEach((unsusedRuntime) => {
-      delete blocks.runtimes[unsusedRuntime]
+    .forEach((unusedRuntime) => {
+      delete blocks.runtimes[unusedRuntime]
     })
   return result
 }

--- a/packages/client/src/observableClient/index.ts
+++ b/packages/client/src/observableClient/index.ts
@@ -1,2 +1,6 @@
 export * from "./getObservableClient"
-export { BlockPrunedError, NotBestBlockError } from "./chainHead"
+export {
+  BlockNotPinnedError,
+  BlockPrunedError,
+  NotBestBlockError,
+} from "./chainHead"

--- a/packages/client/tests/observableClient.spec.ts
+++ b/packages/client/tests/observableClient.spec.ts
@@ -147,9 +147,6 @@ describe("observableClient chainHead", () => {
         finalizedBlockHashes: firstChain.map((v) => v.blockHash),
       })
 
-      expect(mockClient.chainHead.mock.unpinnedHashes).toEqual(new Set())
-      await mockClient.chainHead.mock.unpin.waitNextCall()
-
       const expected = [
         initialHash,
         ...firstChain.slice(0, -1).map((v) => v.blockHash),
@@ -161,12 +158,6 @@ describe("observableClient chainHead", () => {
       sendFinalized(mockClient, {
         finalizedBlockHashes: followingChain.map((v) => v.blockHash),
       })
-
-      expect(mockClient.chainHead.mock.unpinnedHashes).toEqual(
-        new Set(expected),
-      )
-
-      await mockClient.chainHead.mock.unpin.waitNextCall()
 
       expect(mockClient.chainHead.mock.unpinnedHashes).toEqual(
         new Set([
@@ -204,7 +195,6 @@ describe("observableClient chainHead", () => {
         prunedBlockHashes: deadChain.map((v) => v.blockHash),
       })
 
-      await mockClient.chainHead.mock.unpin.waitNextCall()
       expect(mockClient.chainHead.mock.unpinnedHashes).toEqual(
         new Set([
           initialHash,

--- a/packages/substrate-client/src/chainhead/unpin.ts
+++ b/packages/substrate-client/src/chainhead/unpin.ts
@@ -2,11 +2,13 @@ import { ClientInnerRequest } from "./public-types"
 
 export const createUnpinFn =
   (request: ClientInnerRequest<null, unknown>) => (hashes: string[]) =>
-    new Promise<void>((res, rej) => {
-      request("chainHead_unstable_unpin", [hashes], {
-        onSuccess() {
-          res()
-        },
-        onError: rej,
-      })
-    })
+    hashes.length > 0
+      ? new Promise<void>((res, rej) => {
+          request("chainHead_unstable_unpin", [hashes], {
+            onSuccess() {
+              res()
+            },
+            onError: rej,
+          })
+        })
+      : Promise.resolve()


### PR DESCRIPTION
The unpinning logic was a bit too convoluted, mainly because of the "cleaner" which happened on a time interval... Therefore, making it more challenging to get deterministic behaviours based on logs.

These changes make the unpinning logic a lot more straightforward, at the same time that they ensure that blocks get unpinned in the very same moment when the "unpinning condition" is met (the time interval has been removed). There is also a new well-known-error named `BlockNotPinned` which will get triggered if the consumer tries to perform an operation against a non-pinned block.