### PR TITLE
feat(cli): reuse checksums across multiple chains

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -28,6 +28,8 @@ const createTypedApi = <D extends Descriptors>(
   chainHead: ReturnType<ReturnType<typeof getObservableClient>["chainHead$"]>,
   client: ReturnType<typeof getObservableClient>,
 ): TypedApi<D> => {
+  const getChecksum = (idx: number) => descriptors.checksums[idx]
+
   const { pallets, apis: runtimeApis } = descriptors
   const query = {} as Record<string, Record<string, StorageEntry<any, any>>>
   for (const pallet in pallets) {
@@ -35,7 +37,7 @@ const createTypedApi = <D extends Descriptors>(
     const [stgEntries] = pallets[pallet]
     for (const name in stgEntries) {
       query[pallet][name] = createStorageEntry(
-        stgEntries[name],
+        getChecksum(stgEntries[name]),
         pallet,
         name,
         chainHead,
@@ -49,7 +51,7 @@ const createTypedApi = <D extends Descriptors>(
     const [, txEntries] = pallets[pallet]
     for (const name in txEntries) {
       tx[pallet][name] = createTxEntry(
-        txEntries[name],
+        getChecksum(txEntries[name]),
         pallet,
         name,
         descriptors.asset,
@@ -66,7 +68,7 @@ const createTypedApi = <D extends Descriptors>(
     const [, , evEntries] = pallets[pallet]
     for (const name in evEntries) {
       events[pallet][name] = createEventEntry(
-        evEntries[name],
+        getChecksum(evEntries[name]),
         pallet,
         name,
         chainHead,
@@ -80,7 +82,7 @@ const createTypedApi = <D extends Descriptors>(
     const [, , , , ctEntries] = pallets[pallet]
     for (const name in ctEntries) {
       constants[pallet][name] = createConstantEntry(
-        ctEntries[name],
+        getChecksum(ctEntries[name]),
         pallet,
         name,
         chainHead,
@@ -94,7 +96,7 @@ const createTypedApi = <D extends Descriptors>(
     const methods = runtimeApis[api]
     for (const method in methods) {
       apis[api][method] = createRuntimeCallEntry(
-        methods[method],
+        getChecksum(methods[method]),
         api,
         method,
         chainHead,

--- a/packages/client/src/constants.ts
+++ b/packages/client/src/constants.ts
@@ -1,12 +1,11 @@
-import { PlainDescriptor } from "@polkadot-api/substrate-bindings"
+import { filter, firstValueFrom, map } from "rxjs"
+import { RuntimeContext, getObservableClient } from "./observableClient"
 import {
   IsCompatible,
   Runtime,
   createIsCompatible,
   getRuntimeContext,
 } from "./runtime"
-import { RuntimeContext, getObservableClient } from "./observableClient"
-import { filter, firstValueFrom, map } from "rxjs"
 
 export interface ConstantEntry<T> {
   (): Promise<T>
@@ -15,7 +14,7 @@ export interface ConstantEntry<T> {
 }
 
 export const createConstantEntry = <T>(
-  checksum: PlainDescriptor<T>,
+  checksum: string,
   palletName: string,
   name: string,
   chainHead: ReturnType<ReturnType<typeof getObservableClient>["chainHead$"]>,

--- a/packages/client/src/event.ts
+++ b/packages/client/src/event.ts
@@ -1,12 +1,11 @@
-import { PlainDescriptor } from "@polkadot-api/substrate-bindings"
 import { Observable, firstValueFrom, map, mergeMap } from "rxjs"
-import { concatMapEager, shareLatest } from "./utils"
 import {
-  getObservableClient,
   BlockInfo,
   RuntimeContext,
+  getObservableClient,
 } from "./observableClient"
 import { IsCompatible, createIsCompatible } from "./runtime"
+import { concatMapEager, shareLatest } from "./utils"
 
 export type EventPhase =
   | { type: "ApplyExtrinsic"; value: number }
@@ -53,7 +52,7 @@ type SystemEvent = {
 }
 
 export const createEventEntry = <T>(
-  checksum: PlainDescriptor<T>,
+  checksum: string,
   pallet: string,
   name: string,
   chainHead: ReturnType<ReturnType<typeof getObservableClient>["chainHead$"]>,

--- a/packages/client/src/re-exports.ts
+++ b/packages/client/src/re-exports.ts
@@ -4,6 +4,7 @@ export type {
   HexString,
   GetEnum,
   PlainDescriptor,
+  AssetDescriptor,
   TxDescriptor,
   StorageDescriptor,
   QueryFromDescriptors,

--- a/packages/client/src/tx.ts
+++ b/packages/client/src/tx.ts
@@ -1,9 +1,8 @@
 import {
+  AssetDescriptor,
   Binary,
   Enum,
-  PlainDescriptor,
   SS58String,
-  TxDescriptor,
 } from "@polkadot-api/substrate-bindings"
 import { mergeUint8, toHex } from "@polkadot-api/utils"
 import {
@@ -141,9 +140,9 @@ export const createTxEntry = <
   Arg extends {} | undefined,
   Pallet extends string,
   Name extends string,
-  Asset extends PlainDescriptor<any>,
+  Asset extends AssetDescriptor<any>,
 >(
-  descriptor: TxDescriptor<Arg>,
+  checksum: string,
   pallet: Pallet,
   name: Name,
   assetChecksum: Asset,
@@ -157,7 +156,7 @@ export const createTxEntry = <
 ): TxEntry<Arg, Pallet, Name, Asset["_type"]> => {
   const hasSameChecksum = (
     checksumBuilder: RuntimeContext["checksumBuilder"],
-  ) => checksumBuilder.buildCall(pallet, name) === descriptor
+  ) => checksumBuilder.buildCall(pallet, name) === checksum
   const isCompatible = createIsCompatible(chainHead, (ctx) =>
     hasSameChecksum(ctx.checksumBuilder),
   )
@@ -196,7 +195,7 @@ export const createTxEntry = <
       hinted: Partial<{ asset: any }> = {},
     ) => {
       const checksum = checksumBuilder.buildCall(pallet, name)
-      if (checksum !== descriptor)
+      if (checksum !== checksum)
         throw new Error(`Incompatible runtime entry Tx(${pallet}.${name})`)
 
       let returnHinted = hinted

--- a/packages/codegen/src/generate-multiple-descriptors.ts
+++ b/packages/codegen/src/generate-multiple-descriptors.ts
@@ -1,0 +1,87 @@
+import { V15 } from "@polkadot-api/substrate-bindings"
+import { getUsedChecksums } from "./get-used-checksums"
+import {
+  generateDescriptors,
+  getKnownTypesFromFileContent,
+} from "./generate-descriptors"
+import knownTypesContent from "./known-types"
+import { getChecksumBuilder } from "@polkadot-api/metadata-builders"
+
+export const generateMultipleDescriptors = (
+  chains: Array<{
+    key: string
+    metadata: V15
+    knownDeclarations: string
+  }>,
+  paths: {
+    client: string
+    checksums: string
+  },
+) => {
+  const chainData = chains.map((chain) => {
+    const builder = getChecksumBuilder(chain.metadata)
+    return {
+      ...chain,
+      builder,
+      checksums: getUsedChecksums(chain.metadata, builder),
+      knownTypes: getKnownTypesFromFileContent(
+        knownTypesContent + "\n\n" + chain.knownDeclarations,
+      ),
+    }
+  })
+  resolveConflicts(chainData)
+
+  const checksums = Array.from(
+    new Set(chainData.flatMap((chain) => Array.from(chain.checksums))),
+  )
+
+  return {
+    descriptorsFileContent: chainData.map((chain) =>
+      generateDescriptors(
+        chain.metadata,
+        chain.knownTypes,
+        checksums,
+        chain.builder,
+        paths,
+      ),
+    ),
+    checksums,
+  }
+}
+
+function resolveConflicts(
+  chainData: Array<{
+    key: string
+    checksums: Set<string>
+    knownTypes: Map<string, string>
+  }>,
+) {
+  const usedNames = new Map<string, Set<string>>()
+
+  chainData.forEach((chain) =>
+    chain.checksums.forEach((checksum) => {
+      const name = chain.knownTypes.get(checksum)
+      if (!name) return
+      if (!usedNames.has(name)) {
+        usedNames.set(name, new Set())
+      }
+      usedNames.get(name)!.add(checksum)
+    }),
+  )
+  const conflictedChecksums = Array.from(usedNames.values())
+    .filter((checksums) => checksums.size > 1)
+    .flatMap((checksums) => Array.from(checksums))
+
+  conflictedChecksums.forEach((checksum) =>
+    chainData.forEach((chain) => {
+      const name = chain.knownTypes.get(checksum)
+      if (name) {
+        chain.knownTypes.set(checksum, capitalize(chain.key) + name)
+      }
+    }),
+  )
+}
+
+function capitalize(value: string) {
+  return value.slice(0, 1).toUpperCase() + value.slice(1)
+}

--- a/packages/codegen/src/get-used-checksums.ts
+++ b/packages/codegen/src/get-used-checksums.ts
@@ -1,0 +1,43 @@
+import { getChecksumBuilder } from "@polkadot-api/metadata-builders"
+import { V15 } from "@polkadot-api/substrate-bindings"
+
+export const getUsedChecksums = (
+  metadata: V15,
+  builder = getChecksumBuilder(metadata),
+) => {
+  const buildEnum = (val: number | undefined, cb: (name: string) => void) => {
+    if (val === undefined) return
+
+    const lookup = metadata.lookup[val]
+    if (lookup.def.tag !== "variant") throw null
+    lookup.def.value.forEach((x) => cb(x.name))
+  }
+
+  const checksums = new Set<string>()
+
+  metadata.pallets.forEach((pallet) => {
+    pallet.storage?.items.forEach(({ name }) =>
+      checksums.add(builder.buildStorage(pallet.name, name)!),
+    ) ?? []
+    pallet.constants.forEach(({ name }) =>
+      checksums.add(builder.buildConstant(pallet.name, name)!),
+    )
+    buildEnum(pallet.calls, (name) =>
+      checksums.add(builder.buildCall(pallet.name, name)!),
+    )
+    buildEnum(pallet.events, (name) =>
+      checksums.add(builder.buildEvent(pallet.name, name)!),
+    )
+    buildEnum(pallet.errors, (name) =>
+      checksums.add(builder.buildError(pallet.name, name)!),
+    )
+  })
+
+  metadata.apis.forEach((api) =>
+    api.methods.forEach((method) =>
+      checksums.add(builder.buildRuntimeCall(api.name, method.name)!),
+    ),
+  )
+
+  return new Set([...checksums, ...builder.getAllGeneratedChecksums()])
+}

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./types-builder"
 export * from "./get-new-types"
 export * from "./generate-descriptors"
+export * from "./generate-multiple-descriptors"

--- a/packages/metadata-builders/src/checksum-builder.ts
+++ b/packages/metadata-builders/src/checksum-builder.ts
@@ -499,5 +499,7 @@ export const getChecksumBuilder = (metadata: V15) => {
     buildConstant: toStringEnhancer(buildConstant),
     buildComposite: toStringEnhancer(buildComposite),
     buildNamedTuple: toStringEnhancer(buildNamedTuple),
+    getAllGeneratedChecksums: () =>
+      Array.from(cache.values()).map((v) => v.toString(32)),
   }
 }

--- a/packages/substrate-bindings/src/types/descriptors.ts
+++ b/packages/substrate-bindings/src/types/descriptors.ts
@@ -1,15 +1,16 @@
-export type PlainDescriptor<T> = string & { _type?: T }
+export type PlainDescriptor<T> = number & { _type?: T }
+export type AssetDescriptor<T> = string & { _type?: T }
 export type StorageDescriptor<
   Args extends Array<any>,
   T,
   Optional extends true | false,
-> = string & { _type: T; _args: Args; _optional: Optional }
+> = number & { _type: T; _args: Args; _optional: Optional }
 
-export type TxDescriptor<Args extends {} | undefined> = string & {
+export type TxDescriptor<Args extends {} | undefined> = number & {
   ___: Args
 }
 
-export type RuntimeDescriptor<Args extends Array<any>, T> = string & {
+export type RuntimeDescriptor<Args extends Array<any>, T> = number & {
   __: [Args, T]
 }
 
@@ -25,7 +26,8 @@ export type Descriptors = {
     ]
   >
   apis: Record<string, Record<string, RuntimeDescriptor<any, any>>>
-  asset: PlainDescriptor<any>
+  asset: AssetDescriptor<any>
+  checksums: string[]
 }
 
 type PickDescriptors<


### PR DESCRIPTION
This is the first PR of a rework on the codegen, with the ultimate goal of reducing the initial bundle size.

This PR separates the combined checksum values from multiple chains into a separate file, and makes the descriptor file just reference the index.

Also solves conflicts of different types having the same name across multiple chains, which will be useful for the next change which will bring all the type/enums out from the descriptor file.