### PR TITLE
refactor(types-builder): merge types from multiple chains into one file (WIP)

### DIFF
--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -64,19 +64,26 @@ async function outputCodegen(
 ) {
   console.log(`Generating code`)
 
-  const { descriptorsFileContent, checksums } = generateMultipleDescriptors(
-    chains,
-    {
+  const { descriptorsFileContent, checksums, typesFileContent, publicTypes } =
+    generateMultipleDescriptors(chains, {
       client: "@polkadot-api/client",
       checksums: "./checksums.json",
-    },
-  )
+      types: "./common-types",
+    })
 
   console.log("Writing code")
   await fs.mkdir(outputFolder, { recursive: true })
   await fs.writeFile(
     path.join(outputFolder, "checksums.json"),
     JSON.stringify(checksums),
+  )
+  await fs.writeFile(
+    path.join(outputFolder, "common-types.ts"),
+    typesFileContent,
+  )
+  await fs.writeFile(
+    path.join(outputFolder, "public-types.ts"),
+    `export { ${publicTypes.join(",\n")} } from './common-types';`,
   )
   await Promise.all(
     chains.map((chain, i) =>
@@ -104,5 +111,8 @@ const createDtsFile = async (key: string, dest: string, code: string) => {
 
   if (await fsExists(`${tscFileName}.ts`)) await fs.rm(`${tscFileName}.ts`)
 
-  await fs.writeFile(`${tscFileName}.ts`, code)
+  await fs.writeFile(
+    `${tscFileName}.ts`,
+    code + ";\n export * from './public-types'; ",
+  )
 }

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -113,6 +113,6 @@ const createDtsFile = async (key: string, dest: string, code: string) => {
 
   await fs.writeFile(
     `${tscFileName}.ts`,
-    code + ";\n export * from './public-types'; ",
+    code + "\nexport * from './public-types'",
   )
 }

--- a/packages/codegen/src/generate-descriptors.ts
+++ b/packages/codegen/src/generate-descriptors.ts
@@ -53,6 +53,7 @@ export const generateDescriptors = (
   checksums: string[],
   typesBuilder: ReturnType<typeof getTypesBuilder>,
   checksumBuilder: ReturnType<typeof getChecksumBuilder>,
+  prefix: string,
   paths: {
     client: string
     checksums: string
@@ -364,10 +365,10 @@ const _allDescriptors: IDescriptors = { pallets, apis, asset, checksums };
 export default _allDescriptors;
 
 
-type Queries = QueryFromDescriptors<IDescriptors>
-type Calls = TxFromDescriptors<IDescriptors>
-type Events = EventsFromDescriptors<IDescriptors>
-type Errors = ErrorsFromDescriptors<IDescriptors>
-type Constants = ConstFromDescriptors<IDescriptors>
+export type ${prefix}Queries = QueryFromDescriptors<IDescriptors>
+export type ${prefix}Calls = TxFromDescriptors<IDescriptors>
+export type ${prefix}Events = EventsFromDescriptors<IDescriptors>
+export type ${prefix}Errors = ErrorsFromDescriptors<IDescriptors>
+export type ${prefix}Constants = ConstFromDescriptors<IDescriptors>
 `
 }

--- a/packages/codegen/src/generate-types.ts
+++ b/packages/codegen/src/generate-types.ts
@@ -1,0 +1,68 @@
+import { CodeDeclarations } from "./types-builder"
+
+export const generateTypes = (
+  declarations: CodeDeclarations,
+  paths: {
+    client: string
+  },
+) => {
+  const clientImports = ["Enum", "_Enum", "GetEnum", ...declarations.imports]
+
+  const imports = `import {${clientImports.join(", ")}} from "${paths.client}";`
+
+  const baseTypes = [...declarations.variables.values()]
+    .map(({ name, type }) =>
+      type.startsWith("Enum<")
+        ? `export type ${name} = ${type};\nexport const ${name} = _Enum as unknown as GetEnum<${name}>;`
+        : `export type ${name} = ${type};`,
+    )
+    .join("\n\n")
+
+  return `${imports}
+  
+  type AnonymousEnum<T extends {}> = T & {
+    __anonymous: true
+  }
+  
+  type IEnum<T extends {}> = Enum<{
+    [K in keyof T & string]: { type: K, value: T[K] }
+  }[keyof T & string]>
+  
+  type MyTuple<T> = [T, ...T[]]
+  
+  type SeparateUndefined<T> = undefined extends T
+    ? undefined | Exclude<T, undefined>
+    : T
+  
+  type Anonymize<T> = SeparateUndefined<
+    T extends
+      | string
+      | number
+      | bigint
+      | boolean
+      | void
+      | undefined
+      | null
+      | symbol
+      | Binary
+      | Uint8Array
+      | Enum<{ type: string; value: any }>
+      ? T
+      : T extends AnonymousEnum<infer V>
+        ? IEnum<V>
+        : T extends MyTuple<any>
+          ? {
+              [K in keyof T]: T[K]
+            }
+          : T extends []
+            ? []
+            : T extends Array<infer A>
+              ? Array<A>
+              : {
+                  [K in keyof T & string]: T[K]
+                }
+  >
+  
+  ${baseTypes}
+  `
+}

--- a/packages/codegen/src/get-new-types.ts
+++ b/packages/codegen/src/get-new-types.ts
@@ -3,7 +3,7 @@ import {
   getLookupFn,
 } from "@polkadot-api/metadata-builders"
 import type { V15 } from "@polkadot-api/substrate-bindings"
-import { getTypesBuilder } from "./types-builder"
+import { defaultDeclarations, getTypesBuilder } from "./types-builder"
 
 type ArraVal<T extends Array<any>> = T extends Array<infer V> ? V : unknown
 
@@ -13,8 +13,8 @@ export const getNewTypes = (
   getTypeName: (data: ArraVal<V15["lookup"]>) => string | null,
 ) => {
   const checksumBuilder = getChecksumBuilder(metadata)
-  let typesBuilder = getTypesBuilder(metadata, knownTypes)
-  let declarations = typesBuilder.getDeclarations()
+  let declarations = defaultDeclarations()
+  let typesBuilder = getTypesBuilder(declarations, metadata, knownTypes)
   const lookup = getLookupFn(metadata.lookup)
 
   let ignoredIds = new Set<number>([
@@ -62,8 +62,8 @@ export const getNewTypes = (
     })
   })
 
-  typesBuilder = getTypesBuilder(metadata, wannabes)
-  declarations = typesBuilder.getDeclarations()
+  declarations = defaultDeclarations()
+  typesBuilder = getTypesBuilder(declarations, metadata, wannabes)
 
   metadata.lookup.forEach(({ id }) => {
     typesBuilder.buildDefinition(id)

--- a/packages/codegen/src/types-builder.ts
+++ b/packages/codegen/src/types-builder.ts
@@ -286,9 +286,7 @@ export const getTypesBuilder = (
 
     if (knownTypes.has(checksum)) return variable.name
 
-    return variable.type.startsWith("AnonymousEnum")
-      ? `Anonymize<${variable.type}>`
-      : variable.type
+    return `Anonymize<${variable.name}>`
   }
 
   const buildStorage = (pallet: string, entry: string) => {

--- a/packages/codegen/src/types-builder.ts
+++ b/packages/codegen/src/types-builder.ts
@@ -64,17 +64,35 @@ export interface CodeDeclarations {
   takenNames: Set<string>
 }
 
+export const defaultDeclarations = (): CodeDeclarations => ({
+  imports: new Set(),
+  variables: new Map(),
+  takenNames: new Set(),
+})
+
+interface TypeForEntry {
+  type: string
+  import?: "globalTypes" | "client"
+}
+const typesImport = (varName: string): TypeForEntry => ({
+  type: varName,
+  import: "globalTypes",
+})
+const clientImport = (varName: string): TypeForEntry => ({
+  type: varName,
+  import: "client",
+})
+
 const _buildSyntax = (
   input: LookupEntry,
-  cache: Map<number, string>,
+  cache: Map<number, TypeForEntry>,
   stack: Set<number>,
   declarations: CodeDeclarations,
   getChecksum: (id: number | StructVar | TupleVar | VoidVar) => string | null,
   knownTypes: Map<string, string>,
-): string => {
-  const addImport = (varName: string) => {
-    declarations.imports.add(varName)
-    return varName
+): TypeForEntry => {
+  const addImport = (entry: TypeForEntry) => {
+    if (entry.import === "client") declarations.imports.add(entry.type)
   }
 
   const getName = (checksum: string) => {
@@ -97,30 +115,31 @@ const _buildSyntax = (
       : varName
   }
 
-  if (input.type === "primitive") return primitiveTypes[input.value]
-  if (input.type === "AccountId32") return addImport("SS58String")
-  if (input.type === "compact") return input.isBig ? "bigint" : "number"
+  if (input.type === "primitive") return { type: primitiveTypes[input.value] }
+  if (input.type === "AccountId32") return clientImport("SS58String")
+  if (input.type === "compact")
+    return { type: input.isBig ? "bigint" : "number" }
   if (input.type === "bitSequence")
-    return "{bytes: Uint8Array, bitsLen: number}"
+    return { type: "{bytes: Uint8Array, bitsLen: number}" }
 
   if (
     input.type === "sequence" &&
     input.value.type === "primitive" &&
     input.value.value === "u8"
   )
-    return addImport("Binary")
+    return clientImport("Binary")
 
   const checksum = getChecksum(input.id)!
 
   if (declarations.variables.has(checksum)) {
     const entry = declarations.variables.get(checksum)!
-    return entry.name ?? entry.type
+    return typesImport(entry.name)
   }
 
-  const buildNextSyntax = (nextInput: LookupEntry): string =>
+  const buildNextSyntax = (nextInput: LookupEntry) =>
     buildSyntax(nextInput, cache, stack, declarations, getChecksum, knownTypes)
 
-  const buildVector = (id: string, inner: LookupEntry) => {
+  const buildVector = (id: string, inner: LookupEntry): TypeForEntry => {
     const name = getName(id)
     const variable: Variable = {
       checksum: id,
@@ -129,12 +148,13 @@ const _buildSyntax = (
     }
     declarations.variables.set(id, variable)
     const innerType = buildNextSyntax(inner)
+    addImport(innerType)
 
-    variable.type = `Array<${anonymize(innerType)}>`
-    return name
+    variable.type = `Array<${anonymize(innerType.type)}>`
+    return typesImport(name)
   }
 
-  const buildTuple = (id: string, value: LookupEntry[]) => {
+  const buildTuple = (id: string, value: LookupEntry[]): TypeForEntry => {
     const name = getName(id)
     const variable: Variable = {
       checksum: id,
@@ -142,11 +162,17 @@ const _buildSyntax = (
       name,
     }
     declarations.variables.set(id, variable)
-    variable.type = `[${value.map(buildNextSyntax).map(anonymize).join(", ")}]`
-    return name
+    const innerTypes = value.map(buildNextSyntax)
+    innerTypes.forEach(addImport)
+    variable.type = `[${innerTypes.map((v) => anonymize(v.type)).join(", ")}]`
+
+    return typesImport(name)
   }
 
-  const buildStruct = (id: string, value: StringRecord<LookupEntry>) => {
+  const buildStruct = (
+    id: string,
+    value: StringRecord<LookupEntry>,
+  ): TypeForEntry => {
     const name = getName(id)
     const variable: Variable = {
       checksum: id,
@@ -155,16 +181,18 @@ const _buildSyntax = (
     }
     declarations.variables.set(id, variable)
     const deps = mapObject(value, buildNextSyntax)
+    Object.values(deps).forEach(addImport)
     variable.type = `{${Object.entries(deps)
-      .map(([key, val]) => `${key}: ${anonymize(val)}`)
+      .map(([key, val]) => `${key}: ${anonymize(val.type)}`)
       .join(", ")}}`
-    return name
+
+    return typesImport(name)
   }
 
   if (input.type === "array") {
     // Bytes case
     if (input.value.type === "primitive" && input.value.value === "u8")
-      return "Binary"
+      return clientImport("Binary")
 
     // non-fixed size Vector case
     return buildVector(checksum, input.value)
@@ -183,12 +211,15 @@ const _buildSyntax = (
     }
     declarations.variables.set(checksum, variable)
 
-    variable.type = `${anonymize(buildNextSyntax(input.value))} | undefined`
-    return name
+    const innerType = buildNextSyntax(input.value)
+    addImport(innerType)
+
+    variable.type = `${anonymize(innerType.type)} | undefined`
+    return typesImport(name)
   }
 
   if (input.type === "result") {
-    addImport("ResultPayload")
+    declarations.imports.add("ResultPayload")
     const name = getName(checksum)
     const variable: Variable = {
       checksum,
@@ -198,8 +229,12 @@ const _buildSyntax = (
     declarations.variables.set(checksum, variable)
     const ok = buildNextSyntax(input.value.ok)
     const ko = buildNextSyntax(input.value.ko)
-    variable.type = `ResultPayload<${anonymize(ok)}, ${anonymize(ko)}>`
-    return name
+    ;[ok, ko].forEach(addImport)
+    variable.type = `ResultPayload<${anonymize(ok.type)}, ${anonymize(
+      ko.type,
+    )}>`
+
+    return typesImport(name)
   }
 
   // it has to be an enum by now
@@ -221,12 +256,16 @@ const _buildSyntax = (
 
     if (value.type === "tuple" && value.value.length === 1) {
       innerChecksum = getChecksum(value.value[0].id)!
-      return anonymize(buildNextSyntax(value.value[0]))
+      const inner = buildNextSyntax(value.value[0])
+      addImport(inner)
+      return anonymize(inner.type)
     }
     innerChecksum = getChecksum(input.value[key])!
 
     const builder = value.type === "tuple" ? buildTuple : buildStruct
-    return anonymize(builder(innerChecksum, value.value as any))
+    const inner = builder(innerChecksum, value.value as any)
+    addImport(inner)
+    return anonymize(inner.type)
   })
 
   variable.type = isKnown
@@ -236,25 +275,32 @@ const _buildSyntax = (
     : `AnonymousEnum<{${Object.keys(input.value)
         .map((key, idx) => `"${key}": ${dependencies[idx]}`)
         .join(" , ")}}>`
-  return name
+  return typesImport(name)
 }
 
 const buildSyntax = withCache(
   _buildSyntax,
-  (_getter, entry, declarations, getChecksum) =>
-    declarations.variables.get(getChecksum(entry.id)!)!.name,
+  (_getter, entry, declarations, getChecksum): TypeForEntry =>
+    typesImport(declarations.variables.get(getChecksum(entry.id)!)!.name),
   (x) => x,
 )
 
 export const getTypesBuilder = (
+  declarations: CodeDeclarations,
   metadata: V15,
   // checksum -> desired-name
   knownTypes: Map<string, string>,
 ) => {
-  const declarations: CodeDeclarations = {
-    imports: new Set(),
-    variables: new Map(),
-    takenNames: new Set(),
+  const typeFileImports = new Set<string>()
+  const clientFileImports = new Set<string>()
+
+  const importType = (entry: TypeForEntry) => {
+    if (entry.import === "client") {
+      clientFileImports.add(entry.type)
+    } else if (entry.import === "globalTypes") {
+      typeFileImports.add(entry.type)
+    }
+    return entry.type
   }
 
   const lookupData = metadata.lookup
@@ -279,14 +325,14 @@ export const getTypesBuilder = (
 
   const buildTypeDefinition = (id: number) => {
     const tmp = buildDefinition(id)
+    importType(tmp)
+
+    if (!tmp.import || tmp.import === "client") return tmp.type
 
     const checksum = checksumBuilder.buildDefinition(id)!
-    const variable = declarations.variables.get(checksum)
-    if (!variable) return tmp
+    if (knownTypes.has(checksum)) return tmp.type
 
-    if (knownTypes.has(checksum)) return variable.name
-
-    return `Anonymize<${variable.name}>`
+    return `Anonymize<${tmp.type}>`
   }
 
   const buildStorage = (pallet: string, entry: string) => {
@@ -341,7 +387,16 @@ export const getTypesBuilder = (
       if (innerLookup.type === "tuple" && innerLookup.value.length === 1)
         return buildTypeDefinition(innerLookup.value[0].id)
 
-      return declarations.variables.get(getChecksum(innerLookup))!.type
+      const newReturn = declarations.variables.get(
+        getChecksum(innerLookup),
+      )!.name
+      typeFileImports.add(newReturn)
+
+      // TODO
+      const old = declarations.variables.get(getChecksum(innerLookup))!.type
+      console.log(`${old} => Anonymize<${newReturn}>`)
+
+      return `Anonymize<${newReturn}>`
     }
 
   const buildConstant = (pallet: string, constantName: string) => {
@@ -361,6 +416,7 @@ export const getTypesBuilder = (
     buildCall: buildVariant("calls"),
     buildRuntimeCall,
     buildConstant,
-    getDeclarations: () => declarations,
+    getTypeFileImports: () => Array.from(typeFileImports),
+    getClientFileImports: () => Array.from(clientFileImports),
   }
 }

--- a/packages/metadata-builders/src/checksum-builder.ts
+++ b/packages/metadata-builders/src/checksum-builder.ts
@@ -459,6 +459,7 @@ export const getChecksumBuilder = (metadata: V15) => {
         const callsLookup = getLookupEntryDef(
           palletEntry[variantType]! as number,
         )
+        buildDefinition(callsLookup.id)
 
         if (callsLookup.type !== "enum") throw null
         return buildComposite(callsLookup.value[name])


### PR DESCRIPTION
Next PR of the ongoing rework to the codegen.

This PR moves all the type definitions and enums out from the descriptor file into a separate file, which will be common for all chains (each chain will have one descriptor file, that imports types from the common type file, similar to #339)

WIP.... I changed a couple of things I want to check I'm not exposing any private name outside (`I{checksum}` types)