### PR TITLE
feat(client): improve tx API

### DIFF
--- a/examples/vite/src/main.ts
+++ b/examples/vite/src/main.ts
@@ -60,7 +60,7 @@ function transfer(alexa: Account, billy: Account, amount: bigint) {
     dest: MultiAddress.Id(billy.address),
     value: amount,
   })
-    .submit$(alexa.address)
+    .signSubmitAndWatch(alexa.address)
     .subscribe({
       next: (event) => {
         console.log(event)

--- a/integration-tests/zombie-tests/src/main.spec.ts
+++ b/integration-tests/zombie-tests/src/main.spec.ts
@@ -93,7 +93,7 @@ describe("E2E", async () => {
         api.tx.Balances.transfer_allow_death({
           dest: MultiAddress.Id(to),
           value: amount,
-        }).callData,
+        }).decodedCall,
     )
 
     const aliceTransfer = api.tx.Utility.batch_all({ calls: calls.slice(0, 2) })
@@ -101,7 +101,7 @@ describe("E2E", async () => {
 
     await Promise.all(
       [aliceTransfer, bobTransfer].map((call, idx) =>
-        call.submit(idx === 0 ? alice : bob),
+        call.signAndSubmit(idx === 0 ? alice : bob),
       ),
     )
 
@@ -158,7 +158,7 @@ describe("E2E", async () => {
           api.tx.Balances.transfer_allow_death({
             dest: MultiAddress.Id(to[idx]),
             value: ED,
-          }).submit(from),
+          }).signAndSubmit(from),
         ),
       )
 

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -13,7 +13,7 @@ import { EvClient } from "./event"
 import { BlockInfo } from "./observableClient"
 import { RuntimeApi } from "./runtime"
 import { StorageEntry } from "./storage"
-import { TxEntry } from "./tx"
+import { TxEntry, TxEvents, TxFinalizedPayload } from "./tx"
 import { ConstantEntry } from "./constants"
 import { RuntimeCall } from "./runtime-call"
 
@@ -118,4 +118,6 @@ export interface PolkadotClient {
   getBlockBody: (hash: string) => Observable<HexString[]>
   getTypedApi: <D extends Descriptors>(descriptors: D) => TypedApi<D>
   destroy: () => void
+  submit: (transaction: HexString) => Promise<TxFinalizedPayload>
+  submitAndWatch: (transaction: HexString) => Observable<TxEvents>
 }


### PR DESCRIPTION
This PR introduces a number of changes in order to improve the public API for creating transactions:

- The `client` now exposes 2 new methods (`submit` and `submitAndWatch`) which take a signed transaction as an input and then validate, broadcast and report whether the transaction was included in a finalized block.
- The typed-api transaction methods were very poorly named, so they have been renamed as follows:
  - `getTx` -> `sign`
  - `submit` -> `signAndSubmit`
  - `submit$` -> `signSubmitAndWatch`
  - `callData` -> `decodedCall`
- Additionally, the Observable returned from the `signSubmitAndWatch` function now emits an initial event of type `signed` which reports the "raw" transaction.

It closes #346 (I will elaborate on that in the issue, though)