### PR TITLE
Separate `@substrate/connect` from sc-provider

### DIFF
--- a/examples/commonjs/package.json
+++ b/examples/commonjs/package.json
@@ -16,6 +16,6 @@
     "@polkadot-api/client": "workspace:*",
     "@polkadot-api/sc-provider": "workspace:*",
     "@polkadot-api/utils": "workspace:*",
-    "@substrate/connect": "^0.8.4"
+    "@substrate/connect": "^0.8.8"
   }
 }

--- a/examples/commonjs/src/index.js
+++ b/examples/commonjs/src/index.js
@@ -1,8 +1,9 @@
 const { createClient } = require("@polkadot-api/client")
 const { ksm } = require("@polkadot-api/descriptors")
-const { WellKnownChain, getScProvider } = require("@polkadot-api/sc-provider")
+const { getScProvider } = require("@polkadot-api/sc-provider")
+const { WellKnownChain, createScClient } = require("@substrate/connect")
 
-const scProvider = getScProvider()
+const scProvider = getScProvider(createScClient())
 
 const client = createClient(scProvider(WellKnownChain.ksmcc3).relayChain)
 

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -21,7 +21,7 @@
     "@polkadot-api/pjs-signer": "workspace:*",
     "@polkadot-api/sc-provider": "workspace:*",
     "@polkadot-api/utils": "workspace:*",
-    "@substrate/connect": "^0.8.4",
+    "@substrate/connect": "^0.8.8",
     "rxjs": "^7.8.1"
   },
   "polkadot-api": {

--- a/examples/vite/src/main.ts
+++ b/examples/vite/src/main.ts
@@ -5,10 +5,11 @@ import {
   connectInjectedExtension,
   InjectedPolkadotAccount,
 } from "@polkadot-api/pjs-signer"
-import { WellKnownChain, getScProvider } from "@polkadot-api/sc-provider"
+import { getScProvider } from "@polkadot-api/sc-provider"
+import { WellKnownChain, createScClient } from "@substrate/connect"
 import "./style.css"
 
-const scProvider = getScProvider()
+const scProvider = getScProvider(createScClient({}))
 
 const connection: PolkadotClient = createClient(
   scProvider(WellKnownChain.westend2).relayChain,

--- a/experiments/package.json
+++ b/experiments/package.json
@@ -38,6 +38,7 @@
     "@polkadot-api/substrate-client": "workspace:*",
     "@polkadot-api/utils": "workspace:*",
     "@polkadot-api/view-builder": "workspace:*",
+    "@substrate/connect": "^0.8.8",
     "@substrate/connect-known-chains": "^1.1.2",
     "rxjs": "^7.8.1",
     "smoldot": "^2.0.21"

--- a/experiments/src/all-nominators.ts
+++ b/experiments/src/all-nominators.ts
@@ -1,4 +1,5 @@
-import { JsonRpcProvider, WellKnownChain } from "@polkadot-api/sc-provider"
+import { JsonRpcProvider } from "@polkadot-api/sc-provider"
+import { WellKnownChain } from "@substrate/connect"
 import { createClient } from "@polkadot-api/substrate-client"
 import { createProvider } from "./smolldot-worker"
 import { getObservableClient } from "@polkadot-api/client"

--- a/experiments/src/best-blocks.ts
+++ b/experiments/src/best-blocks.ts
@@ -1,8 +1,9 @@
 import { getObservableClient } from "@polkadot-api/client"
-import { getScProvider, WellKnownChain } from "@polkadot-api/sc-provider"
+import { getScProvider } from "@polkadot-api/sc-provider"
+import { WellKnownChain, createScClient } from "@substrate/connect"
 import { createClient } from "@polkadot-api/substrate-client"
 
-const scProvider = getScProvider()
+const scProvider = getScProvider(createScClient())
 const { relayChain } = scProvider(WellKnownChain.polkadot)
 
 const client = getObservableClient(createClient(relayChain))

--- a/experiments/src/client.ts
+++ b/experiments/src/client.ts
@@ -1,9 +1,10 @@
-import { getScProvider, WellKnownChain } from "@polkadot-api/sc-provider"
+import { getScProvider } from "@polkadot-api/sc-provider"
+import { WellKnownChain, createScClient } from "@substrate/connect"
 import { createClient, Binary } from "@polkadot-api/client"
 
 // hint: remember to run the `codegen` script
 import { KsmQueries, ksm } from "@polkadot-api/descriptors"
-const scProvider = getScProvider()
+const scProvider = getScProvider(createScClient())
 
 const relayChain = createClient(scProvider(WellKnownChain.ksmcc3).relayChain)
 

--- a/experiments/src/getMetadata.ts
+++ b/experiments/src/getMetadata.ts
@@ -1,8 +1,5 @@
-import {
-  getScProvider,
-  WellKnownChain,
-  JsonRpcProvider,
-} from "@polkadot-api/sc-provider"
+import { getScProvider, JsonRpcProvider } from "@polkadot-api/sc-provider"
+import { WellKnownChain, createScClient } from "@substrate/connect"
 import { Runtime, createClient } from "@polkadot-api/substrate-client"
 import {
   compact,
@@ -14,7 +11,7 @@ import {
 } from "@polkadot-api/substrate-bindings"
 import { toHex } from "@polkadot-api/utils"
 
-const scProvider = getScProvider()
+const scProvider = getScProvider(createScClient())
 
 const smProvider = scProvider(
   WellKnownChain.polkadot /*, {

--- a/experiments/src/headers.ts
+++ b/experiments/src/headers.ts
@@ -1,8 +1,9 @@
-import { getScProvider, WellKnownChain } from "@polkadot-api/sc-provider"
+import { getScProvider } from "@polkadot-api/sc-provider"
+import { WellKnownChain, createScClient } from "@substrate/connect"
 import { blockHeader } from "@polkadot-api/substrate-bindings"
 import { createClient } from "@polkadot-api/substrate-client"
 
-const scProvider = getScProvider()
+const scProvider = getScProvider(createScClient())
 const { relayChain } = scProvider(WellKnownChain.polkadot)
 
 const { chainHead } = createClient(relayChain)

--- a/experiments/src/smolldot-worker.ts
+++ b/experiments/src/smolldot-worker.ts
@@ -1,12 +1,14 @@
 import { Worker } from "node:worker_threads"
-import { JsonRpcProvider, WellKnownChain } from "@polkadot-api/sc-provider"
+import { JsonRpcProvider } from "@polkadot-api/sc-provider"
+import type { WellKnownChain } from "@substrate/connect"
 
 const PROVIDER_WORKER_CODE = `
 const { parentPort, workerData } = require("node:worker_threads")
 const { getScProvider } = require("@polkadot-api/sc-provider")
+const { createScClient } = require("@substrate/connect")
 
 const chain = workerData
-const scProvider = getScProvider()
+const scProvider = getScProvider(createScClient())
 const getProvider = scProvider(chain).relayChain
 
 if (!parentPort) {

--- a/packages/json-rpc/sc-provider/package.json
+++ b/packages/json-rpc/sc-provider/package.json
@@ -47,10 +47,13 @@
     "trailingComma": "all"
   },
   "dependencies": {
-    "@polkadot-api/json-rpc-provider-proxy": "workspace:*",
+    "@polkadot-api/json-rpc-provider-proxy": "workspace:*"
+  },
+  "peerDependencies": {
     "@substrate/connect": "^0.8.8"
   },
   "devDependencies": {
-    "@polkadot-api/json-rpc-provider": "workspace:*"
+    "@polkadot-api/json-rpc-provider": "workspace:*",
+    "@substrate/connect": "^0.8.8"
   }
 }

--- a/packages/json-rpc/sc-provider/src/index.ts
+++ b/packages/json-rpc/sc-provider/src/index.ts
@@ -3,13 +3,16 @@ import type {
   JsonRpcConnection,
 } from "@polkadot-api/json-rpc-provider"
 import { getSyncProvider } from "@polkadot-api/json-rpc-provider-proxy"
-import type { Config, Chain } from "@substrate/connect"
-import { WellKnownChain, createScClient } from "@substrate/connect"
+import type { WellKnownChain, Chain, ScClient } from "@substrate/connect"
 
-export { WellKnownChain }
 export type { JsonRpcProvider, JsonRpcConnection }
 
-export const wellKnownChains = new Set(Object.values(WellKnownChain))
+const wellKnownChains = new Set([
+  "polkadot",
+  "ksmcc3",
+  "rococo_v2_2",
+  "westend2",
+])
 const noop = () => {}
 type AddChain = (input: WellKnownChain | string) => {
   relayChain: JsonRpcProvider
@@ -48,9 +51,7 @@ const getProvider = (
     }
   })
 
-export const getScProvider = (config?: Config): AddChain => {
-  const client = createScClient(config)
-
+export const getScProvider = (client: ScClient): AddChain => {
   return (input: WellKnownChain | string) => {
     const getRelayChain = (onMessage?: (data: string) => void) =>
       wellKnownChains.has(input as any)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,7 +60,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/utils
       '@substrate/connect':
-        specifier: ^0.8.4
+        specifier: ^0.8.8
         version: 0.8.8
 
   examples/decode-viewer:
@@ -151,8 +151,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/utils
       '@substrate/connect':
-        specifier: ^0.8.4
-        version: 0.8.4
+        specifier: ^0.8.8
+        version: 0.8.8
       rxjs:
         specifier: ^7.8.1
         version: 7.8.1
@@ -211,6 +211,9 @@ importers:
       '@polkadot-api/view-builder':
         specifier: workspace:*
         version: link:../packages/view-builder
+      '@substrate/connect':
+        specifier: ^0.8.8
+        version: 0.8.8
       '@substrate/connect-known-chains':
         specifier: ^1.1.2
         version: 1.1.2
@@ -461,13 +464,13 @@ importers:
       '@polkadot-api/json-rpc-provider-proxy':
         specifier: workspace:*
         version: link:../json-rpc-provider-proxy
-      '@substrate/connect':
-        specifier: ^0.8.8
-        version: 0.8.8
     devDependencies:
       '@polkadot-api/json-rpc-provider':
         specifier: workspace:*
         version: link:../json-rpc-provider
+      '@substrate/connect':
+        specifier: ^0.8.8
+        version: 0.8.8
 
   packages/json-rpc/sm-provider:
     dependencies:
@@ -2940,7 +2943,6 @@ packages:
   /@noble/hashes@1.3.2:
     resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
     engines: {node: '>= 16'}
-    dev: false
 
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2980,64 +2982,18 @@ packages:
       '@polkadot-api/substrate-client': 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
       '@polkadot-api/utils': 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
       rxjs: 7.8.1
-    dev: false
-
-  /@polkadot-api/client@0.0.1-4bc9bd71f8f37f800fec7a42775f403271903870.1.0(rxjs@7.8.1):
-    resolution: {integrity: sha512-0QUQcyurhI5L3lcXvGHIqgWWZIQEMKMBx/gZIgqJxF3GZJoZMpeDs7w9VY8mrfZ6HiKN7jlMMSMN+zYlIAYRVA==}
-    peerDependencies:
-      rxjs: '>=7.8.0'
-    dependencies:
-      '@polkadot-api/metadata-builders': 0.0.1-4bc9bd71f8f37f800fec7a42775f403271903870.1.0
-      '@polkadot-api/substrate-bindings': 0.0.1-4bc9bd71f8f37f800fec7a42775f403271903870.1.0
-      '@polkadot-api/substrate-client': 0.0.1-4bc9bd71f8f37f800fec7a42775f403271903870.1.0
-      '@polkadot-api/utils': 0.0.1-4bc9bd71f8f37f800fec7a42775f403271903870.1.0
-      rxjs: 7.8.1
-    dev: false
 
   /@polkadot-api/json-rpc-provider-proxy@0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0:
     resolution: {integrity: sha512-0hZ8vtjcsyCX8AyqP2sqUHa1TFFfxGWmlXJkit0Nqp9b32MwZqn5eaUAiV2rNuEpoglKOdKnkGtUF8t5MoodKw==}
-    dev: false
-
-  /@polkadot-api/json-rpc-provider-proxy@0.0.1-4bc9bd71f8f37f800fec7a42775f403271903870.1.0:
-    resolution: {integrity: sha512-+laeeYlqH+NicD0dvW0hmNb2eCacrD6TSjqQ1jQExYjIjUehQvWbQU2opHsAxsKsRcG9pV97caceTi7fo2uGvg==}
-    dev: false
 
   /@polkadot-api/json-rpc-provider@0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0:
     resolution: {integrity: sha512-EaUS9Fc3wsiUr6ZS43PQqaRScW7kM6DYbuM/ou0aYjm8N9MBqgDbGm2oL6RE1vAVmOfEuHcXZuZkhzWtyvQUtA==}
-    dev: false
-
-  /@polkadot-api/json-rpc-provider@0.0.1-4bc9bd71f8f37f800fec7a42775f403271903870.1.0:
-    resolution: {integrity: sha512-E7gVrZFs0GezKm+5x2AK07kzwGeKUBgeUwdv65pzhPFOhmPJu28fFLG8an3aZHtQXUkOV6os/KW4UY5KPRMKJg==}
-    dev: false
-
-  /@polkadot-api/light-client-extension-helpers@0.0.1-4bc9bd71f8f37f800fec7a42775f403271903870.1.0(smoldot@2.0.23):
-    resolution: {integrity: sha512-ivBA+TbGFVAw+0ijQXGrxbzsvAuBjSzhjpLyToKGkPG4speCOcCzv/piifkwDC8gfausHA7JVXXgb7AS5u8tRg==}
-    peerDependencies:
-      smoldot: 2.0.23
-    dependencies:
-      '@polkadot-api/client': 0.0.1-4bc9bd71f8f37f800fec7a42775f403271903870.1.0(rxjs@7.8.1)
-      '@polkadot-api/json-rpc-provider': 0.0.1-4bc9bd71f8f37f800fec7a42775f403271903870.1.0
-      '@polkadot-api/json-rpc-provider-proxy': 0.0.1-4bc9bd71f8f37f800fec7a42775f403271903870.1.0
-      '@polkadot-api/substrate-client': 0.0.1-4bc9bd71f8f37f800fec7a42775f403271903870.1.0
-      '@substrate/connect-extension-protocol': 1.0.1
-      '@substrate/connect-known-chains': 1.1.2
-      rxjs: 7.8.1
-      smoldot: 2.0.23
-    dev: false
 
   /@polkadot-api/metadata-builders@0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0:
     resolution: {integrity: sha512-BD7rruxChL1VXt0icC2gD45OtT9ofJlql0qIllHSRYgama1CR2Owt+ApInQxB+lWqM+xNOznZRpj8CXNDvKIMg==}
     dependencies:
       '@polkadot-api/substrate-bindings': 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
       '@polkadot-api/utils': 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
-    dev: false
-
-  /@polkadot-api/metadata-builders@0.0.1-4bc9bd71f8f37f800fec7a42775f403271903870.1.0:
-    resolution: {integrity: sha512-zz+vFWQAS2WV0OLA3QP+RgntCfeU3OXxh9fvaagEszv9dEd1709WR8HHchdbtAucXfjewHCnXsu+vkYf+RpGDw==}
-    dependencies:
-      '@polkadot-api/substrate-bindings': 0.0.1-4bc9bd71f8f37f800fec7a42775f403271903870.1.0
-      '@polkadot-api/utils': 0.0.1-4bc9bd71f8f37f800fec7a42775f403271903870.1.0
-    dev: false
 
   /@polkadot-api/substrate-bindings@0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0:
     resolution: {integrity: sha512-N4vdrZopbsw8k57uG58ofO7nLXM4Ai7835XqakN27MkjXMp5H830A1KJE0L9sGQR7ukOCDEIHHcwXVrzmJ/PBg==}
@@ -3046,32 +3002,12 @@ packages:
       '@polkadot-api/utils': 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
       '@scure/base': 1.1.6
       scale-ts: 1.6.0
-    dev: false
-
-  /@polkadot-api/substrate-bindings@0.0.1-4bc9bd71f8f37f800fec7a42775f403271903870.1.0:
-    resolution: {integrity: sha512-en+QHK/0NYGn0F4thNbdWxLopmlQ65LId3MXSE5pvYjdMIwh+tJVcU/+cM7Vm3DUx4OBosZ+8c7qGY3tIStjVQ==}
-    dependencies:
-      '@noble/hashes': 1.3.2
-      '@polkadot-api/utils': 0.0.1-4bc9bd71f8f37f800fec7a42775f403271903870.1.0
-      '@scure/base': 1.1.3
-      scale-ts: 1.6.0
-    dev: false
 
   /@polkadot-api/substrate-client@0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0:
     resolution: {integrity: sha512-lcdvd2ssUmB1CPzF8s2dnNOqbrDa+nxaaGbuts+Vo8yjgSKwds2Lo7Oq+imZN4VKW7t9+uaVcKFLMF7PdH0RWw==}
-    dev: false
-
-  /@polkadot-api/substrate-client@0.0.1-4bc9bd71f8f37f800fec7a42775f403271903870.1.0:
-    resolution: {integrity: sha512-XhPnda3ILBI20HwcdwMUd2EkGMFVc9ogKdQ1euZrqQEZeOHRkFN6sNmUgg+jZvm8ekA/0+RJXrtm5xyOciEV4Q==}
-    dev: false
 
   /@polkadot-api/utils@0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0:
     resolution: {integrity: sha512-0CYaCjfLQJTCRCiYvZ81OncHXEKPzAexCMoVloR+v2nl/O2JRya/361MtPkeNLC6XBoaEgLAG9pWQpH3WePzsw==}
-    dev: false
-
-  /@polkadot-api/utils@0.0.1-4bc9bd71f8f37f800fec7a42775f403271903870.1.0:
-    resolution: {integrity: sha512-1qexCG1KNs6J62HRwgkRbMw3tO0mRXuGAX7bxRZWZDI/WwzCa4M27/sHlwTy0ukgo6+8Rpz8nQlVJEwpx7Q11w==}
-    dev: false
 
   /@polkadot-cloud/assets@0.1.34:
     resolution: {integrity: sha512-qsXlinOgVlChbMTdBXCDaQM59jDZWrKKMizR7LR8qL2yhzLh0Ohouf0POURhuCsJ1zUjHwbsZg+4ezsKZBM+nA==}
@@ -4214,7 +4150,6 @@ packages:
 
   /@scure/base@1.1.6:
     resolution: {integrity: sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g==}
-    dev: false
 
   /@sinclair/typebox@0.27.8:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -5160,11 +5095,9 @@ packages:
 
   /@substrate/connect-extension-protocol@2.0.0:
     resolution: {integrity: sha512-nKu8pDrE3LNCEgJjZe1iGXzaD6OSIDD4Xzz/yo4KO9mQ6LBvf49BVrt4qxBFGL6++NneLiWUZGoh+VSd4PyVIg==}
-    dev: false
 
   /@substrate/connect-known-chains@1.1.2:
     resolution: {integrity: sha512-XvyemTVqon+6EF2G7QL0fEXxjuz3nUNFgFV0TSWhSVpPb+Sfs+vfipbEZxGNouxvjCoJdr6CF0rwgGsrrKOnAA==}
-    dev: false
 
   /@substrate/connect@0.7.33:
     resolution: {integrity: sha512-1B984/bmXVQvTT9oV3c3b7215lvWmulP9rfP3T3Ri+OU3uIsyCzYw0A+XG6J8/jgO2FnroeNIBWlgoLaUM1uzw==}
@@ -5189,18 +5122,6 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@substrate/connect@0.8.4:
-    resolution: {integrity: sha512-kLc584rPV0zXKn7ETroOB0IsbhexzcPEodrjI6/T7aQoRNaA334g7PnbuWRZ8mtj101krK2riZnVsLonPRFcKw==}
-    dependencies:
-      '@polkadot-api/light-client-extension-helpers': 0.0.1-4bc9bd71f8f37f800fec7a42775f403271903870.1.0(smoldot@2.0.23)
-      '@substrate/connect-extension-protocol': 2.0.0
-      '@substrate/connect-known-chains': 1.1.2
-      smoldot: 2.0.23
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-    dev: false
-
   /@substrate/connect@0.8.8:
     resolution: {integrity: sha512-zwaxuNEVI9bGt0rT8PEJiXOyebLIo6QN1SyiAHRPBOl6g3Sy0KKdSN8Jmyn++oXhVRD8aIe75/V8ZkS81T+BPQ==}
     dependencies:
@@ -5211,7 +5132,6 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-    dev: false
 
   /@substrate/light-client-extension-helpers@0.0.4(smoldot@2.0.23):
     resolution: {integrity: sha512-vfKcigzL0SpiK+u9sX6dq2lQSDtuFLOxIJx2CKPouPEHIs8C+fpsufn52r19GQn+qDhU8POMPHOVoqLktj8UEA==}
@@ -5226,7 +5146,6 @@ packages:
       '@substrate/connect-known-chains': 1.1.2
       rxjs: 7.8.1
       smoldot: 2.0.23
-    dev: false
 
   /@substrate/ss58-registry@1.43.0:
     resolution: {integrity: sha512-USEkXA46P9sqClL7PZv0QFsit4S8Im97wchKG0/H/9q3AT/S76r40UHfCr4Un7eBJPE23f7fU9BZ0ITpP9MCsA==}
@@ -9962,7 +9881,6 @@ packages:
 
   /scale-ts@1.6.0:
     resolution: {integrity: sha512-Ja5VCjNZR8TGKhUumy9clVVxcDpM+YFjAnkMuwQy68Hixio3VRRvWdE3g8T/yC+HXA0ZDQl2TGyUmtmbcVl40Q==}
-    dev: false
 
   /scheduler@0.23.0:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}


### PR DESCRIPTION
The reason why this is necessary is because of bundle-sizes. The thing is that `@substrate/connnect` performs various dynamic imports in order to generate smaller bundle-sizes (which automatically triggers bundlers to generate different dynamic chunks). However, in order to leverage this optimization `@substrate/connect` can't be a transient dependency, it must be installed directly as a dependency of the project that it's being bundled. Otherwise, all the different bundlers (vite, parcel, webpack, etc) will just create a humongous chunk with all the `@substrate/connect` assets.