### PR TITLE
feat(sm-provider): improve public API

### DIFF
--- a/experiments/src/migrate-known-types.ts
+++ b/experiments/src/migrate-known-types.ts
@@ -57,10 +57,12 @@ async function getMetadatas() {
       : undefined
 
     const result = await getMetadataFromProvider(
-      getSmProvider(smoldot, {
-        chainSpec: chain,
-        potentialRelayChains,
-      }),
+      getSmProvider(
+        smoldot.addChain({
+          chainSpec: chain,
+          potentialRelayChains,
+        }),
+      ),
     )
     smoldot.terminate()
     return result

--- a/integration-tests/zombie-tests/src/main.spec.ts
+++ b/integration-tests/zombie-tests/src/main.spec.ts
@@ -25,7 +25,7 @@ const getChainspec = async (count = 1): Promise<{}> => {
   }
 }
 
-const chainspec = JSON.stringify(await getChainspec())
+const chainSpec = JSON.stringify(await getChainspec())
 rawClient.destroy()
 
 const accountIdDec = AccountId().dec
@@ -35,7 +35,7 @@ console.log("got the chainspec")
 
 describe("E2E", async () => {
   console.log("starting the client")
-  const client = createClient(getSmProvider(smoldot, chainspec))
+  const client = createClient(getSmProvider(smoldot.addChain({ chainSpec })))
   const api = client.getTypedApi(roc)
 
   console.log("getting the latest runtime")


### PR DESCRIPTION
With this improvement on the public API of the `@polkadot-api/sm-provider` the `getSmProvider` function expects just the `smoldot` `Chain` as its input. It can be either a `Promise<Chain>` or a `Chain`.

This is possible thanks to the fact that in order to listen to the messages of the chain, the consumer doesn't have to register the callback function when setting it up. Instead the chain exposes a `nextJsonRpcResponse` function which returns a Promise that should resolve when there is a new message.

Thanks to this change, it will now be simpler to create para-chain connections, as the consumer won't have to create a redundant relay-chain.