### PR TITLE
`polkadot-api` -> `polkadot-connect`

### DIFF
--- a/packages/polkadot-api/README.md
+++ b/packages/polkadot-api/README.md
@@ -1,3 +1,3 @@
-# polkadot-api
+# polkadot-connect
 
 Docs: coming soon(ish)!

--- a/packages/polkadot-api/package.json
+++ b/packages/polkadot-api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "polkadot-api",
+  "name": "polkadot-connect",
   "version": "0.0.1",
   "author": "Josep M Sobrepere (https://github.com/josepot)",
   "repository": {


### PR DESCRIPTION
Despite the fact that we own the `@polkadot-api/*` npm org, we have not been able to publish under the `polkadot-api` npm package due to the fact that [there is someone squatting on a package with an almost identical name](https://github.com/Ajay-Dhore/polkadot_npm). Therefore, for now we will use the `polkadot-connect` package name.