### PR TITLE
fix(observable-client): reference correct parent

### DIFF
--- a/packages/observable-client/CHANGELOG.md
+++ b/packages/observable-client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- The first block on the `finalizedBlockHashes` list of the `initialized` event was not referencing its correct parent when the list had more than one item.
+
 ## 0.0.1 - 2024-04-03
 
 ### Changed

--- a/packages/observable-client/src/chainHead/streams/pinned-blocks.ts
+++ b/packages/observable-client/src/chainHead/streams/pinned-blocks.ts
@@ -229,12 +229,10 @@ const withInitializedNumber =
       concatMap((event) => {
         return event.type !== "initialized"
           ? of(event)
-          : getHeader(event.finalizedBlockHashes.slice(-1)[0]).then(
-              (header) => ({
-                ...event,
-                number: header.number,
-                parentHash: header.parentHash,
-              }),
-            )
+          : getHeader(event.finalizedBlockHashes[0]).then((header) => ({
+              ...event,
+              number: header.number,
+              parentHash: header.parentHash,
+            }))
       }),
     )

--- a/packages/observable-client/tests/fixtures.ts
+++ b/packages/observable-client/tests/fixtures.ts
@@ -105,7 +105,7 @@ export const initialize = async (
   overrides: Partial<InitializedWithRuntime> = newInitialized(),
 ) => {
   const initialized = sendInitialized(mockClient, overrides)
-  const initialHash = initialized.finalizedBlockHashes.at(-1)!
+  const initialHash = initialized.finalizedBlockHashes.at(0)!
 
   const header = createHeader({
     parentHash: newHash(),

--- a/packages/observable-client/tests/observableClient-stopError.spec.ts
+++ b/packages/observable-client/tests/observableClient-stopError.spec.ts
@@ -260,7 +260,7 @@ describe("observableClient stopError recovery", () => {
     expect(mockClient.chainHead.mock.call).toHaveBeenCalledTimes(3)
 
     expect(runtimeObs.error).not.toHaveBeenCalled()
-    expect(runtimeObs.next).toHaveBeenCalledTimes(2)
+    expect(runtimeObs.next).toHaveBeenCalledTimes(1)
 
     await mockClient.chainHead.mock.body.reply(newBlock.blockHash, ["result"])
     expect(body.error).not.toHaveBeenCalled()


### PR DESCRIPTION
The first block on the `finalizedBlockHashes` list of the `initialized` event was not referencing its correct parent when the list had more than one item.