### PR TITLE
build: set correct output path for turbo on CLI

### DIFF
--- a/packages/cli/turbo.json
+++ b/packages/cli/turbo.json
@@ -4,7 +4,7 @@
   "pipeline": {
     "build": {
       "inputs": ["tsconfig.build.json", "tsconfig.build.json", "src/**"],
-      "outputs": ["bin/**"]
+      "outputs": ["dist/**"]
     },
     "test": {
       "inputs": ["vitest.config.ts", "test/**"]


### PR DESCRIPTION
This should really fix turbo cache on CI 🙏

I managed to reproduce the turbo cache issue on local:
1. `turbo build | grep cli`
2. Take note of the cli hash
3. Look at turbo cache folder - Every package has a .tar file, and CLI's look suspiciously empty. Extracting it only contains the build logs.
