### PR TITLE
fix(logs-provider): support logs with transactions

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- logs-provider: [Support logs with transactions](https://github.com/polkadot-api/polkadot-api/pull/414)
+
 ## 0.1.2 - 2024-04-11
 
 ### Fixed

--- a/packages/json-rpc/logs-provider/CHANGELOG.md
+++ b/packages/json-rpc/logs-provider/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.0.2 - 2024-04-12
+
 ### Fixed
 
 - [Support logs with transactions](https://github.com/polkadot-api/polkadot-api/pull/414)

--- a/packages/json-rpc/logs-provider/CHANGELOG.md
+++ b/packages/json-rpc/logs-provider/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- [Support logs with transactions](https://github.com/polkadot-api/polkadot-api/pull/414)
+
 ## 0.0.1 - 2024-04-03
 
 ### Changed

--- a/packages/json-rpc/logs-provider/package.json
+++ b/packages/json-rpc/logs-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot-api/logs-provider",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": "Josep M Sobrepere (https://github.com/josepot)",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Sr25519 signatures are not referentially transparent, because of that the logs-provider was failing when there were transactions involved because it found messages that didn't match with what it was on the logs. This is a workaround to prevent that from happening.