### PR TITLE
ci: log test failures on log-replay tests

### DIFF
--- a/integration-tests/log-replays/src/main.ts
+++ b/integration-tests/log-replays/src/main.ts
@@ -2,6 +2,8 @@ import { ChildProcessWithoutNullStreams, spawn } from "child_process"
 
 function txWithCompetingForks(childProcess: ChildProcessWithoutNullStreams) {
   return new Promise<void>((resolve, reject) => {
+    childProcess.stderr.pipe(process.stderr)
+
     childProcess.on("exit", (e) => {
       if (e !== 0) {
         reject(new Error("`txWithCompetingForks` errored"))


### PR DESCRIPTION
This will show the errors thrown on the spawned processes of log-replay tests onto the CI logs.

We had a test failing on #427 which was probably due to the build cache, as only after clearing it, it passed. But we were getting that the "process exited with status -1" instead of the detailed error, which would help understanding the issue.
