### PR TITLE
fix(substrate-client): improve compatibility handling

### DIFF
--- a/packages/substrate-client/CHANGELOG.md
+++ b/packages/substrate-client/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `getChainSpecData: () => Promise<{name: string, genesisHash: string, properties: any}>`.
 
+### Fixed
+
+- Improve the compatibility handling with the different versions of the JSON-RPC methods.
+
 ## 0.0.2 - 2024-04-20
 
 ### Fixed

--- a/packages/substrate-client/src/chainhead/body.ts
+++ b/packages/substrate-client/src/chainhead/body.ts
@@ -1,8 +1,9 @@
+import { chainHead } from "@/methods"
 import type { OperationBodyDoneRpc } from "./json-rpc-types"
 import { createOperationPromise } from "./operation-promise"
 
 export const createBodyFn = createOperationPromise(
-  "chainHead_unstable_body",
+  () => chainHead.body,
   (hash: string) => [
     [hash],
     (e: OperationBodyDoneRpc, res: (x: Array<string>) => void) => {

--- a/packages/substrate-client/src/chainhead/call.ts
+++ b/packages/substrate-client/src/chainhead/call.ts
@@ -1,8 +1,9 @@
+import { chainHead } from "@/methods"
 import type { OperationCallDoneRpc } from "./json-rpc-types"
 import { createOperationPromise } from "./operation-promise"
 
 export const createCallFn = createOperationPromise(
-  "chainHead_unstable_call",
+  () => chainHead.call,
   (hash: string, fnName: string, callParameters: string) => [
     [hash, fnName, callParameters],
     (e: OperationCallDoneRpc, res: (output: string) => void) => {

--- a/packages/substrate-client/src/chainhead/chainhead.ts
+++ b/packages/substrate-client/src/chainhead/chainhead.ts
@@ -26,6 +26,7 @@ import { createUnpinFn } from "./unpin"
 import { DisjointError, StopError } from "./errors"
 import { createStorageCb } from "./storage-subscription"
 import { DestroyedError } from "@/client/DestroyedError"
+import { chainHead } from "@/methods"
 
 type FollowEventRpc =
   | FollowEventWithRuntimeRpc
@@ -92,7 +93,7 @@ export function getChainHead(
       subscriptionId: string,
       follow: FollowSubscriptionCb<FollowEventRpc>,
     ) => {
-      const done = follow("chainHead_unstable_followEvent", subscriptionId, {
+      const done = follow(chainHead.followEvent, subscriptionId, {
         next: onAllFollowEventsNext,
         error: onAllFollowEventsError,
       })
@@ -101,7 +102,7 @@ export function getChainHead(
         followSubscription = null
         unfollow = noop
         done()
-        sendUnfollow && request("chainHead_unstable_unfollow", [subscriptionId])
+        sendUnfollow && request(chainHead.unfollow, [subscriptionId])
         subscriptions.errorAll(new DisjointError())
         ongoingRequests.forEach((cb) => {
           cb()
@@ -124,7 +125,7 @@ export function getChainHead(
     }
 
     let unfollow: (internal?: boolean) => void = request(
-      "chainHead_unstable_follow",
+      chainHead.follow,
       [withRuntime],
       { onSuccess: onFollowRequestSuccess, onError: onFollowRequestError },
     )

--- a/packages/substrate-client/src/chainhead/header.ts
+++ b/packages/substrate-client/src/chainhead/header.ts
@@ -1,9 +1,10 @@
+import { chainHead } from "@/methods"
 import { ClientInnerRequest } from "./public-types"
 
 export const createHeaderFn =
   (request: ClientInnerRequest<string, unknown>) => (hash: string) =>
     new Promise<string>((res, rej) => {
-      request("chainHead_unstable_header", [hash], {
+      request(chainHead.header, [hash], {
         onSuccess: res,
         onError: rej,
       })

--- a/packages/substrate-client/src/chainhead/unpin.ts
+++ b/packages/substrate-client/src/chainhead/unpin.ts
@@ -1,10 +1,11 @@
+import { chainHead } from "@/methods"
 import { ClientInnerRequest } from "./public-types"
 
 export const createUnpinFn =
   (request: ClientInnerRequest<null, unknown>) => (hashes: string[]) =>
     hashes.length > 0
       ? new Promise<void>((res, rej) => {
-          request("chainHead_unstable_unpin", [hashes], {
+          request(chainHead.unpin, [hashes], {
             onSuccess() {
               res()
             },

--- a/packages/substrate-client/src/methods.ts
+++ b/packages/substrate-client/src/methods.ts
@@ -1,0 +1,36 @@
+export const chainHead = {
+  body: "",
+  call: "",
+  continue: "",
+  follow: "",
+  header: "",
+  stopOperation: "",
+  storage: "",
+  unfollow: "",
+  unpin: "",
+  followEvent: "",
+}
+
+export const chainSpec = {
+  chainName: "",
+  genesisHash: "",
+  properties: "",
+}
+
+export const transaction = {
+  broadcast: "",
+  stop: "",
+}
+
+export const transactionWatch = {
+  submitAndWatch: "",
+  unwatch: "",
+}
+
+Object.entries({ chainHead, chainSpec, transaction, transactionWatch }).forEach(
+  ([fnGroupName, methods]) => {
+    Object.keys(methods).forEach((methodName) => {
+      ;(methods as any)[methodName] = `${fnGroupName}_v1_${methodName}`
+    })
+  },
+)

--- a/packages/substrate-client/src/request-compatibility-enhancer.ts
+++ b/packages/substrate-client/src/request-compatibility-enhancer.ts
@@ -1,0 +1,68 @@
+import type { ClientRequest } from "@/client"
+import { UnsubscribeFn } from "./common-types"
+import { noop } from "./internal-utils"
+
+export const getCompatibilityEnhancer =
+  <T, E>(rpcMethodsP: Promise<Set<string>>, request: ClientRequest<T, E>) =>
+  (methods: Record<string, string>): ClientRequest<T, E> => {
+    let enhancedRequest: ClientRequest<T, E> | null = null
+
+    return ((method, ...rest) => {
+      if (enhancedRequest) return enhancedRequest(method, ...rest)
+
+      let isRunning = true
+      let cleanup: UnsubscribeFn = () => {
+        isRunning = false
+      }
+
+      rpcMethodsP
+        .then((rpcMethods) => {
+          enhancedRequest = (method, ...iRest) => {
+            if (rpcMethods.has(method)) return request(method, ...iRest)
+            iRest[1]?.onError(new Error(`Unsupported method ${method}`))
+            return noop
+          }
+
+          if (rpcMethods.has(method)) return
+
+          const parts = method.split("_")
+          if (parts[1] !== "v1") return
+
+          parts[1] = "unstable"
+          method = parts.join("_")
+
+          if (rpcMethods.has(method))
+            Object.entries(methods).forEach(([key, value]) => {
+              methods[key] = value.replace("_v1_", "_unstable_")
+            })
+          else if (parts[0] === "transaction") {
+            // old versions of smoldot and Polkadot-SDK don't support transaction_xx_broadcast
+            // some old versions have `transactions_unstable_submitAndWatch` while others have `transaction_xx_submitAndWatch`
+            // if we find any of this options, then we will can use them as if they were broadast/stop
+            let unwatch: string | undefined
+            let version: string | undefined
+
+            const txGroup = ["transactionWatch", "transaction"].find(
+              (group) => {
+                version = ["v1", "unstable"].find((v) =>
+                  rpcMethods.has((unwatch = `${group}_${v}_unwatch`)),
+                )
+                return !!version
+              },
+            )
+
+            if (txGroup) {
+              methods.broadcast = `${txGroup}_${version}_submitAndWatch`
+              methods.stop = unwatch!
+            }
+          }
+        })
+        .then(() => {
+          if (isRunning) cleanup = enhancedRequest!(method, ...rest)
+        })
+
+      return () => {
+        cleanup()
+      }
+    }) as ClientRequest<T, E>
+  }

--- a/packages/substrate-client/src/transaction/transaction.ts
+++ b/packages/substrate-client/src/transaction/transaction.ts
@@ -1,62 +1,25 @@
 import { noop } from "@/internal-utils"
 import { type ClientRequest } from "../client"
-
-const getTxBroadcastNames = (input: Set<string>): [string, string] => {
-  // Proper
-  if (input.has("transaction_v1_broadcast"))
-    return ["transaction_v1_broadcast", "transaction_v1_stop"]
-
-  // Fallback for versions not up-to-date yet
-  if (input.has("transactionWatch_unstable_submitAndWatch"))
-    return [
-      "transactionWatch_unstable_submitAndWatch",
-      "transactionWatch_unstable_unwatch",
-    ]
-
-  // Fallback for very old versions
-  return ["transaction_unstable_submitAndWatch", "transaction_unstable_unwatch"]
-}
+import { transaction } from "@/methods"
 
 export const getTransaction =
-  (
-    request: ClientRequest<string, any>,
-    rpcMethods: Promise<Set<string>> | Set<string>,
-  ) =>
+  (request: ClientRequest<string, any>) =>
   (tx: string, error: (e: Error) => void) => {
-    const broadcast = (
-      tx: string,
-      broadcastFn: string,
-      cancelBroadcastFn: string,
-    ) =>
-      request(broadcastFn, [tx], {
-        onSuccess: (subscriptionId) => {
-          cancel =
-            subscriptionId === null
-              ? noop
-              : () => {
-                  request(cancelBroadcastFn, [subscriptionId])
-                }
+    let cancel = request(transaction.broadcast, [tx], {
+      onSuccess: (subscriptionId) => {
+        cancel =
+          subscriptionId === null
+            ? noop
+            : () => {
+                request(transaction.stop, [subscriptionId])
+              }
 
-          if (subscriptionId === null) {
-            error(
-              new Error("Max # of broadcasted transactions has been reached"),
-            )
-          }
-        },
-        onError: error,
-      })
-
-    let isActive = true
-    let cancel = () => {
-      isActive = false
-    }
-
-    if (rpcMethods instanceof Promise) {
-      rpcMethods.then(getTxBroadcastNames).then((names) => {
-        if (!isActive) return
-        cancel = broadcast(tx, ...names)
-      })
-    } else cancel = broadcast(tx, ...getTxBroadcastNames(rpcMethods))
+        if (subscriptionId === null) {
+          error(new Error("Max # of broadcasted transactions has been reached"))
+        }
+      },
+      onError: error,
+    })
 
     return () => {
       cancel()

--- a/packages/substrate-client/tests/chainHead-functions.spec.ts
+++ b/packages/substrate-client/tests/chainHead-functions.spec.ts
@@ -13,23 +13,23 @@ describe.each([
 ] satisfies Array<[keyof FollowResponse, any[], any, any]>)(
   "chainhead: %s",
   (name, args, result, expectedResult) => {
-    it("sends the correct message", () => {
+    it("sends the correct message", async () => {
       const { provider, SUBSCRIPTION_ID, chainHead } =
-        setupChainHeadWithSubscription()
+        await setupChainHeadWithSubscription()
 
       provider.getNewMessages()
       chainHead[name](...(args as [any]))
 
       expect(provider.getNewMessages()).toMatchObject([
         {
-          method: `chainHead_unstable_${name}`,
+          method: `chainHead_v1_${name}`,
           params: [SUBSCRIPTION_ID, ...args],
         },
       ])
     })
 
-    it("resolves the correct response", () => {
-      const { provider, chainHead } = setupChainHeadWithSubscription()
+    it("resolves the correct response", async () => {
+      const { provider, chainHead } = await setupChainHeadWithSubscription()
 
       const promise = chainHead[name](...(args as [any]))
       provider.replyLast({ result })
@@ -37,8 +37,8 @@ describe.each([
       return expect(promise).resolves.toEqual(expectedResult)
     })
 
-    it("rejects the JSON-RPC Error when the request fails", () => {
-      const { provider, chainHead } = setupChainHeadWithSubscription()
+    it("rejects the JSON-RPC Error when the request fails", async () => {
+      const { provider, chainHead } = await setupChainHeadWithSubscription()
 
       const promise = chainHead[name](...(args as [any]))
       provider.replyLast({ error: parseError })
@@ -46,8 +46,8 @@ describe.each([
       return expect(promise).rejects.toEqual(new RpcError(parseError))
     })
 
-    it("rejects with an `DisjointError` when the function is created after `unfollow`", () => {
-      const { chainHead } = setupChainHead()
+    it("rejects with an `DisjointError` when the function is created after `unfollow`", async () => {
+      const { chainHead } = await setupChainHead()
 
       chainHead.unfollow()
 
@@ -57,7 +57,7 @@ describe.each([
     })
 
     it("rejects an `DisjointError` when the follow subscription fails and the operation is pending", async () => {
-      const { provider, chainHead } = setupChainHead()
+      const { provider, chainHead } = await setupChainHead()
 
       const promise = chainHead[name](...(args as [any]))
       // The errored JSON-RPC response comes **after** the user has called `header`/`unpin`
@@ -69,7 +69,7 @@ describe.each([
     })
 
     it("rejects an `DisjointError` when the follow subscription fails for any subsequent operation", async () => {
-      const { provider, chainHead } = setupChainHead()
+      const { provider, chainHead } = await setupChainHead()
 
       // The errored JSON-RPC response comes **before** the user has called `header`/`unpin`
       provider.replyLast({


### PR DESCRIPTION
There are many different versions in the wild with different permutations of the methods that we want to use, that I decided to handle all that stuff in a "request" enhancer. It's worth pointing out that it was about to get worse, due to the fact that `smoldot` just made the `chainHead` group of functions stable. So, these changes make the library compatible with the new version of smoldot, as well.