### PR TITLE
feat(enum): make enums assignable to other enum types if they are compatible

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -5,13 +5,8 @@
 ### Added
 
 - `getChainSpecData: () => Promise<{name: string, genesisHash: string, properties: any}>`.
-
-### Breaking
-
-- Remove discriminant utilities (`is`, `as`) from `Enum`s. They have been moved to the `Enum(type, value)` function:
-  - `result.is('V2')` becomes `Enum.is(result, 'V2')`
-  - `result.as('V2')` becomes `Enum.as(result, 'V2')`
-- The generic for `Enum<T>` is now an object of `{ [type: string]: any }`, rather than a union of `{ type: string, value: any } | ... | { type: string, value: any }`
+- New type `EnumVariant<T, K>` to select one specific variant from an enum.
+- Improved Enum type inference so that they can be assigned between types as long as they are compatible.
 
 ## 0.4.0 - 2024-04-23
 

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -8,6 +8,10 @@
 - New type `EnumVariant<T, K>` to select one specific variant from an enum.
 - Improved Enum type inference so that they can be assigned between types as long as they are compatible.
 
+### Breaking
+
+- The generic for `Enum<T>` is now an object of `{ [type: string]: any }`, rather than a union of `{ type: string, value: any } | ... | { type: string, value: any }`
+
 ## 0.4.0 - 2024-04-23
 
 ### Added

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 - `getChainSpecData: () => Promise<{name: string, genesisHash: string, properties: any}>`.
 
+### Breaking
+
+- Remove discriminant utilities (`is`, `as`) from `Enum`s. They have been moved to the `Enum(type, value)` function:
+  - `result.is('V2')` becomes `Enum.is(result, 'V2')`
+  - `result.as('V2')` becomes `Enum.as(result, 'V2')`
+- The generic for `Enum<T>` is now an object of `{ [type: string]: any }`, rather than a union of `{ type: string, value: any } | ... | { type: string, value: any }`
+
 ## 0.4.0 - 2024-04-23
 
 ### Added

--- a/packages/client/src/re-exports.ts
+++ b/packages/client/src/re-exports.ts
@@ -20,6 +20,5 @@ export {
   AccountId,
   Binary,
   Enum,
-  OutputEnum,
   _Enum,
 } from "@polkadot-api/substrate-bindings"

--- a/packages/client/src/re-exports.ts
+++ b/packages/client/src/re-exports.ts
@@ -20,6 +20,6 @@ export {
   AccountId,
   Binary,
   Enum,
-  EnumVariant,
+  type EnumVariant,
   _Enum,
 } from "@polkadot-api/substrate-bindings"

--- a/packages/client/src/re-exports.ts
+++ b/packages/client/src/re-exports.ts
@@ -20,5 +20,6 @@ export {
   AccountId,
   Binary,
   Enum,
+  OutputEnum,
   _Enum,
 } from "@polkadot-api/substrate-bindings"

--- a/packages/client/src/re-exports.ts
+++ b/packages/client/src/re-exports.ts
@@ -20,5 +20,6 @@ export {
   AccountId,
   Binary,
   Enum,
+  EnumVariant,
   _Enum,
 } from "@polkadot-api/substrate-bindings"

--- a/packages/client/src/tx.ts
+++ b/packages/client/src/tx.ts
@@ -130,13 +130,13 @@ export type Transaction<
   signAndSubmit: TxFunction<Asset>
   getEncodedData: TxCall
   getEstimatedFees: () => Promise<bigint>
-  decodedCall: Enum<{
+  decodedCall: {
     type: Pallet
-    value: Enum<{
+    value: {
       type: Name
       value: Arg
-    }>
-  }>
+    }
+  }
 }
 
 export interface TxEntry<
@@ -327,10 +327,10 @@ export const createTxEntry = <
 
     return {
       getEstimatedFees,
-      decodedCall: Enum(pallet, Enum(name, arg as any)) as Enum<{
-        type: Pallet
-        value: any
-      }>,
+      decodedCall: {
+        type: pallet,
+        value: Enum(name, arg as any),
+      },
       getEncodedData,
       sign,
       signSubmitAndWatch,

--- a/packages/codegen/src/generate-descriptors.ts
+++ b/packages/codegen/src/generate-descriptors.ts
@@ -254,7 +254,6 @@ export const generateDescriptors = (
     "TxDescriptor",
     "RuntimeDescriptor",
     "Enum",
-    "OutputEnum",
     "_Enum",
     "Binary",
     "FixedSizeBinary",
@@ -321,7 +320,7 @@ type Anonymize<T> = SeparateUndefined<
     | symbol
     | Binary
     | Uint8Array
-    | OutputEnum<Enum<any>>
+    | Enum<any>
     ? T
     : T extends AnonymousEnum<infer V>
       ? Enum<V>

--- a/packages/codegen/src/generate-descriptors.ts
+++ b/packages/codegen/src/generate-descriptors.ts
@@ -254,6 +254,7 @@ export const generateDescriptors = (
     "TxDescriptor",
     "RuntimeDescriptor",
     "Enum",
+    "OutputEnum",
     "_Enum",
     "Binary",
     "FixedSizeBinary",
@@ -301,10 +302,6 @@ type AnonymousEnum<T extends {}> = T & {
   __anonymous: true
 }
 
-type IEnum<T extends {}> = Enum<{
-  [K in keyof T & string]: { type: K, value: T[K] }
-}[keyof T & string]>
-
 type MyTuple<T> = [T, ...T[]]
 
 type SeparateUndefined<T> = undefined extends T
@@ -324,10 +321,10 @@ type Anonymize<T> = SeparateUndefined<
     | symbol
     | Binary
     | Uint8Array
-    | Enum<{ type: string; value: any }>
+    | OutputEnum<Enum<any>>
     ? T
     : T extends AnonymousEnum<infer V>
-      ? IEnum<V>
+      ? Enum<V>
       : T extends MyTuple<any>
         ? {
             [K in keyof T]: T[K]

--- a/packages/codegen/src/generate-types.ts
+++ b/packages/codegen/src/generate-types.ts
@@ -8,6 +8,7 @@ export const generateTypes = (
 ) => {
   const clientImports = [
     "Enum",
+    "OutputEnum",
     "_Enum",
     "GetEnum",
     "FixedSizeBinary",
@@ -32,10 +33,6 @@ export const generateTypes = (
     __anonymous: true
   }
   
-  type IEnum<T extends {}> = Enum<{
-    [K in keyof T & string]: { type: K, value: T[K] }
-  }[keyof T & string]>
-  
   type MyTuple<T> = [T, ...T[]]
   
   type SeparateUndefined<T> = undefined extends T
@@ -55,10 +52,10 @@ export const generateTypes = (
       | symbol
       | Binary
       | Uint8Array
-      | Enum<{ type: string; value: any }>
+      | OutputEnum<{ type: string; value: any }>
       ? T
       : T extends AnonymousEnum<infer V>
-        ? IEnum<V>
+        ? Enum<V>
         : T extends MyTuple<any>
           ? {
               [K in keyof T]: T[K]

--- a/packages/codegen/src/generate-types.ts
+++ b/packages/codegen/src/generate-types.ts
@@ -8,7 +8,6 @@ export const generateTypes = (
 ) => {
   const clientImports = [
     "Enum",
-    "OutputEnum",
     "_Enum",
     "GetEnum",
     "FixedSizeBinary",
@@ -52,7 +51,7 @@ export const generateTypes = (
       | symbol
       | Binary
       | Uint8Array
-      | OutputEnum<{ type: string; value: any }>
+      | Enum<any>
       ? T
       : T extends AnonymousEnum<infer V>
         ? Enum<V>

--- a/packages/codegen/src/types-builder.ts
+++ b/packages/codegen/src/types-builder.ts
@@ -296,13 +296,10 @@ const _buildSyntax = (
     return anonymize(inner.type)
   })
 
-  variable.type = isKnown
-    ? `Enum<${Object.keys(input.value)
-        .map((key, idx) => `{ type: "${key}", value: ${dependencies[idx]} }`)
-        .join(" | ")}>`
-    : `AnonymousEnum<{${Object.keys(input.value)
-        .map((key, idx) => `"${key}": ${dependencies[idx]}`)
-        .join(" , ")}}>`
+  const obj = Object.keys(input.value)
+    .map((key, idx) => `"${key}": ${dependencies[idx]}`)
+    .join(", ")
+  variable.type = isKnown ? `Enum<{${obj}}>` : `AnonymousEnum<{${obj}}>`
   return typesImport(name)
 }
 

--- a/packages/substrate-bindings/CHANGELOG.md
+++ b/packages/substrate-bindings/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Breaking
+
+- Separate `Enum` from `OutputEnum`
+  - `Enum<T>` is only `{ type: string, value: any }` without the discriminants `as`, `is`.
+  - `OutputEnum<Enum<T>>` is `Enum<T> & Discriminant<Enum<T>>` (with `as`, `is` functions)
+  - The generic for `Enum<T>` is now an object of `{ [type: string]: any }`, rather than a union of `{ type: string, value: any } | ... | { type: string, value: any }`
+
 ## 0.2.0 - 2024-04-23
 
 ### Added

--- a/packages/substrate-bindings/CHANGELOG.md
+++ b/packages/substrate-bindings/CHANGELOG.md
@@ -2,12 +2,10 @@
 
 ## Unreleased
 
-### Breaking
+### Added
 
-- Remove discriminant utilities (`is`, `as`) from `Enum`s. They have been moved to the `Enum(type, value)` function:
-  - `myEnum.is('V2')` becomes `Enum.is(myEnum, 'V2')`
-  - `myEnum.as('V2')` becomes `Enum.as(myEnum, 'V2')`
-- The generic for `Enum<T>` is now an object of `{ [type: string]: any }`, rather than a union of `{ type: string, value: any } | ... | { type: string, value: any }`
+- New type `EnumVariant<T, K>` to select one specific variant from an enum.
+- Improved Enum type inference so that they can be assigned between types as long as they are compatible.
 
 ## 0.2.0 - 2024-04-23
 

--- a/packages/substrate-bindings/CHANGELOG.md
+++ b/packages/substrate-bindings/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ### Breaking
 
-- Separate `Enum` from `OutputEnum`
-  - `Enum<T>` is only `{ type: string, value: any }` without the discriminants `as`, `is`.
-  - `OutputEnum<Enum<T>>` is `Enum<T> & Discriminant<Enum<T>>` (with `as`, `is` functions)
-  - The generic for `Enum<T>` is now an object of `{ [type: string]: any }`, rather than a union of `{ type: string, value: any } | ... | { type: string, value: any }`
+- Remove discriminant utilities (`is`, `as`) from `Enum`s. They have been moved to the `Enum(type, value)` function:
+  - `myEnum.is('V2')` becomes `Enum.is(myEnum, 'V2')`
+  - `myEnum.as('V2')` becomes `Enum.as(myEnum, 'V2')`
+- The generic for `Enum<T>` is now an object of `{ [type: string]: any }`, rather than a union of `{ type: string, value: any } | ... | { type: string, value: any }`
 
 ## 0.2.0 - 2024-04-23
 

--- a/packages/substrate-bindings/CHANGELOG.md
+++ b/packages/substrate-bindings/CHANGELOG.md
@@ -7,6 +7,10 @@
 - New type `EnumVariant<T, K>` to select one specific variant from an enum.
 - Improved Enum type inference so that they can be assigned between types as long as they are compatible.
 
+### Breaking
+
+- The generic for `Enum<T>` is now an object of `{ [type: string]: any }`, rather than a union of `{ type: string, value: any } | ... | { type: string, value: any }`
+
 ## 0.2.0 - 2024-04-23
 
 ### Added

--- a/packages/substrate-bindings/src/types/GetEnum.ts
+++ b/packages/substrate-bindings/src/types/GetEnum.ts
@@ -1,9 +1,0 @@
-import type { ExtractEnumValue, Enum } from "../codecs"
-
-export type GetEnum<T extends Enum<{ type: string; value: any }>> = {
-  [K in T["type"]]: (
-    ...args: ExtractEnumValue<T, K> extends undefined
-      ? []
-      : [value: ExtractEnumValue<T, K>]
-  ) => T
-}

--- a/packages/substrate-bindings/src/types/enum.ts
+++ b/packages/substrate-bindings/src/types/enum.ts
@@ -1,0 +1,54 @@
+export type Enum<T extends {}> = {
+  [K in keyof T & string]: { type: K; value: T[K] }
+}[keyof T & string]
+
+export type ExtractEnumValue<
+  T extends { type: string; value?: any },
+  K extends string,
+> = (T & { type: K })["value"]
+
+export interface Discriminant<T extends Enum<any>> {
+  is<K extends T["type"]>(this: T, type: K): this is T & { type: K }
+  as<K extends T["type"]>(type: K): ExtractEnumValue<T, K>
+}
+
+export type OutputEnum<T extends Enum<any>> = T & Discriminant<T>
+
+type ValueArg<V> = V extends undefined ? [value?: undefined] : [value: V]
+
+export function Enum<
+  T extends { type: string; value: any },
+  K extends T["type"],
+>(type: K, ...[value]: ValueArg<ExtractEnumValue<T, K>>): T & { type: K } {
+  return {
+    type,
+    value,
+  } as any
+}
+
+// type FooInput = Enum<{
+//   foo: "foo"
+//   bar: "bar" | undefined
+//   baz: number
+//   wtf: boolean
+// }>
+
+// declare function foo(foo: FooInput): void
+// foo(Enum("bar"))
+
+// well-known enums
+export type GetEnum<T extends Enum<any>> = {
+  [K in T["type"]]: (
+    ...args: ExtractEnumValue<T, K> extends undefined
+      ? []
+      : [value: ExtractEnumValue<T, K>]
+  ) => T
+}
+export const _Enum = new Proxy(
+  {},
+  {
+    get(_, prop: string) {
+      return (value: string) => Enum(prop, value)
+    },
+  },
+)

--- a/packages/substrate-bindings/src/types/enum.ts
+++ b/packages/substrate-bindings/src/types/enum.ts
@@ -38,23 +38,17 @@ export const Enum: EnumFn = (type, value?) => {
   return {
     type,
     value,
+    as(_type: string) {
+      if (type !== _type)
+        // TODO: fix error
+        throw new Error(`Enum.as(${_type}) used with actual type ${type}`)
+      return value
+    },
+    is(_type: string) {
+      return type === _type
+    },
   } as any
 }
-
-// type Bar = Enum<{
-//   Kaka: 1
-//   Bar: 2
-// }>
-
-// type FooInput = Enum<{
-//   foo: "foo" | undefined
-//   bar: Bar
-//   baz: number
-//   wtf: boolean
-// }>
-
-// declare function foo(foo: FooInput): void
-// foo(Enum("bar", Enum("Bar", 2)))
 
 // well-known enums
 export type GetEnum<T extends Enum<any>> = {
@@ -72,3 +66,21 @@ export const _Enum = new Proxy(
     },
   },
 )
+
+// type Bar = Enum<{
+//   Kaka: 1
+//   Bar: 2
+// }>
+
+// type FooInput = Enum<{
+//   foo: "foo" | undefined
+//   bar: Bar
+//   baz: number
+//   wtf: boolean
+// }>
+
+// declare function foo(foo: FooInput): void
+// foo(Enum("bar", Enum("Bar", 2)))
+
+// const InputEnum: GetEnum<FooInput> = null as any;
+// InputEnum.bar(Enum('Bar', 2))

--- a/packages/substrate-bindings/src/types/index.ts
+++ b/packages/substrate-bindings/src/types/index.ts
@@ -1,2 +1,2 @@
 export * from "./descriptors"
-export * from "./GetEnum"
+export * from "./enum"


### PR DESCRIPTION
As a small example, `XcmV4JunctionNetworkId` added an additional variant `PolkadotBulletin`. In this case:

<img width="1099" alt="image" src="https://github.com/polkadot-api/polkadot-api/assets/5365487/8449a505-f01b-406c-9e9b-6fb059c22583">

Another change this includes is that `Enum<T>` has a a `{ [type]: value }` shape for the generic, so we don't need the `IEnum<T>` anymore:

<img width="1207" alt="image" src="https://github.com/polkadot-api/polkadot-api/assets/5365487/1a610857-e010-4403-85e3-06508d1d2af8">
