### PR TITLE
fix(client): types of hinted-sign-extensions

### DIFF
--- a/integration-tests/zombie-tests/src/main.spec.ts
+++ b/integration-tests/zombie-tests/src/main.spec.ts
@@ -156,7 +156,10 @@ describe("E2E", async () => {
           api.tx.Balances.transfer_allow_death({
             dest: MultiAddress.Id(to[idx]),
             value: ED,
-          }).signAndSubmit(from),
+          }).signAndSubmit(from, {
+            mortality: { mortal: true, period: 64 },
+            tip: 5n,
+          }),
         ),
       )
 

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - `pjs-signer`: [SignerPayloadJSON type mismatch - #499](https://github.com/polkadot-api/polkadot-api/issues/449).
+- Correct types of hinted-sign-extensions on transactions.
 
 ## 0.5.2 - 2024-04-25
 

--- a/packages/client/src/tx.ts
+++ b/packages/client/src/tx.ts
@@ -66,36 +66,27 @@ const getTxSuccessFromSystemEvents = (
   return { ok, events }
 }
 
+type HintedSignExtensions<Asset> = Partial<
+  void extends Asset
+    ? {
+        tip: bigint
+        mortality: { mortal: false } | { mortal: true; period: number }
+      }
+    : {
+        tip: bigint
+        mortality: { mortal: false } | { mortal: true; period: number }
+        asset: Asset
+      }
+>
+
 type TxFunction<Asset> = (
   from: PolkadotSigner,
-  hintedSignExtensions?: Partial<
-    void extends Asset
-      ? {
-          tip: bigint
-          mortal: { mortal: false } | { mortal: true; period: number }
-        }
-      : {
-          tip: bigint
-          mortal: { mortal: false } | { mortal: true; period: number }
-          asset: Asset
-        }
-  >,
+  hintedSignExtensions?: HintedSignExtensions<Asset>,
 ) => Promise<TxFinalizedPayload>
 
 type TxObservable<Asset> = (
   from: PolkadotSigner,
-  hintedSignExtensions?: Partial<
-    void extends Asset
-      ? {
-          tip: bigint
-          mortal: { mortal: false } | { mortal: true; period: number }
-        }
-      : {
-          tip: bigint
-          mortal: { mortal: false } | { mortal: true; period: number }
-          asset: Asset
-        }
-  >,
+  hintedSignExtensions?: HintedSignExtensions<Asset>,
 ) => Observable<TxEvent>
 
 interface TxCall {
@@ -105,18 +96,7 @@ interface TxCall {
 
 type TxSigned<Asset> = (
   from: PolkadotSigner,
-  hintedSignExtensions?: Partial<
-    void extends Asset
-      ? {
-          tip: bigint
-          mortal: { mortal: false } | { mortal: true; period: number }
-        }
-      : {
-          tip: bigint
-          mortal: { mortal: false } | { mortal: true; period: number }
-          asset: Asset
-        }
-  >,
+  hintedSignExtensions?: HintedSignExtensions<Asset>,
 ) => Promise<string>
 
 export type Transaction<


### PR DESCRIPTION
While working on #450 I noticed that the typings of the "hinted" sign-extensions were wrong.