### PR TITLE
fix: getInjectedExtension to ignore unsupported account types

### DIFF
--- a/packages/signers/pjs-signer/src/injected-extensions.ts
+++ b/packages/signers/pjs-signer/src/injected-extensions.ts
@@ -67,16 +67,18 @@ export const connectInjectedExtension = async (
   const toPolkadotInjected = (
     accounts: InjectedAccount[],
   ): InjectedPolkadotAccount[] =>
-    accounts.map((x) => {
-      const polkadotSigner = getPolkadotSignerFromPjs(
-        getPublicKey(x.address),
-        signPayload,
-      )
-      return {
-        ...x,
-        polkadotSigner,
-      }
-    })
+    accounts
+      .filter((x) => ["ed25519", "sr25519", "ecdsa"].includes(x.type ?? ""))
+      .map((x) => {
+        const polkadotSigner = getPolkadotSignerFromPjs(
+          getPublicKey(x.address),
+          signPayload,
+        )
+        return {
+          ...x,
+          polkadotSigner,
+        }
+      })
 
   let currentAccounts: InjectedPolkadotAccount[] = toPolkadotInjected(
     await enabledExtension.accounts.get(),

--- a/packages/signers/pjs-signer/src/injected-extensions.ts
+++ b/packages/signers/pjs-signer/src/injected-extensions.ts
@@ -17,6 +17,11 @@ export type InjectedWeb3 = Record<
 >
 
 export type KeypairType = "ed25519" | "sr25519" | "ecdsa"
+const supportedAccountTypes = new Set<KeypairType>([
+  "ed25519",
+  "sr25519",
+  "ecdsa",
+])
 
 interface InjectedAccount {
   address: string
@@ -68,7 +73,7 @@ export const connectInjectedExtension = async (
     accounts: InjectedAccount[],
   ): InjectedPolkadotAccount[] =>
     accounts
-      .filter((x) => ["ed25519", "sr25519", "ecdsa"].includes(x.type ?? ""))
+      .filter(({ type }) => supportedAccountTypes.has(type!))
       .map((x) => {
         const polkadotSigner = getPolkadotSignerFromPjs(
           getPublicKey(x.address),


### PR DESCRIPTION
This PR fixes a bug when connecting a wallet to a dapp: if user connects one or more EVM account, `getInjectedExtension` throws an error. 

Fix: updated the `getInjectedExtension` logic to ignore all accounts that do not have a type expected/supported by PAPI. 
