### PR TITLE
fix(client)!: typo in top-level field

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking
+
+- `client`: rename `watchBlockBlody` to `watchBlockBody`
+
 ## 0.5.5 - 2024-04-29
 
 ### Fixed

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -132,7 +132,7 @@ export function createClient(provider: JsonRpcProvider): PolkadotClient {
     bestBlocks$: chainHead.bestBlocks$,
     getBestBlocks: () => firstValueFrom(chainHead.bestBlocks$),
 
-    watchBlockBlody: chainHead.body$,
+    watchBlockBody: chainHead.body$,
     getBlockBody: (hash: string) => firstValueFrom(chainHead.body$(hash)),
 
     getBlockHeader: (hash?: string) =>

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -113,7 +113,7 @@ export interface PolkadotClient {
   bestBlocks$: Observable<BlockInfo[]>
   getBestBlocks: () => Promise<BlockInfo[]>
 
-  watchBlockBlody: (hash: string) => Observable<HexString[]>
+  watchBlockBody: (hash: string) => Observable<HexString[]>
   getBlockBody: (hash: string) => Promise<HexString[]>
 
   getBlockHeader: (hash?: string) => Promise<BlockHeader>


### PR DESCRIPTION
BREAKING CHANGE: `watchBlockBlody` was renamed to `watchBlockBody` as
expected. A typo appeared and it has been fixed.