### PR TITLE
perf(client): avoid storage operation on `System.Number`

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `client`: rename `watchBlockBlody` to `watchBlockBody`
 
+### Changed
+
+- performance optimization: avoid creating a storage operation on `System.Number` storage entry.
+
 ### Fixed
 
 - json-rpc-proxy: Ensure that the proxy works with all the known versions of the JSON-RPC spec


### PR DESCRIPTION
While we were investigating a performance bottleneck on a DApp created by @0xKheops we ended up realizing that the culprit was the subscription the `Sytem.Number` storage entry which was triggering [this issue on smoldot](https://github.com/smol-dot/smoldot/issues/1804).

I showed @0xKheops that he didn't have to use `System.Number`, because the client already offers a way for accessing the block-number, which is much more performant... Then I realized that it would be a good idea to bake-in this performance optimization into our typed-api storage entry. Which is to avoid running the storage operation of the consumer is accessing the storage entry `System.Number`.