### PR TITLE
fix(client)!: make mortality default to be mortal

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `client`: rename `watchBlockBlody` to `watchBlockBody`
 - `getEstimatedFee` takes as input a PolkadotSigner and optionally the "hinted-sign-extensions"
+- `tx`: now transactions are mortal by default with a 64 blocks period
 
 ### Changed
 

--- a/packages/client/src/get-create-tx.ts
+++ b/packages/client/src/get-create-tx.ts
@@ -31,9 +31,12 @@ export const getCreateTx = (
           from: signer.publicKey,
         }
 
-        const mortality = hinted?.mortality?.mortal
-          ? { period: hinted.mortality.period, blockNumber: atBlock.number }
-          : undefined
+        const mortality: Parameters<typeof CheckMortality>[0] =
+          !hinted?.mortality
+            ? { period: 64, blockNumber: atBlock.number }
+            : hinted.mortality.mortal
+              ? { period: hinted.mortality.period, blockNumber: atBlock.number }
+              : undefined // immortal
 
         return combineLatest(
           ctx.metadata.extrinsic.signedExtensions.map(


### PR DESCRIPTION
BREAKING CHANGE: From now on, we consider the default for a transaction
to be mortal, with a period of 64 blocks. This will prevent potential
reply attacks.