### PR TITLE
feat: move `as` and `is` from enum values to `Enum`

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `getEstimatedFee` takes as input the sender's address and optionally the "hinted-sign-extensions"
 - `tx`: now transactions are mortal by default with a 64 blocks period
 - `codegen`: [deduplicate equivalent known types](https://github.com/polkadot-api/polkadot-api/pull/448)
+- Move the `is` and `as` methods from enum values to `Enum`: `Enum.is(value, tag)`, `Enum.as(value, tag)`.
 
 ### Changed
 

--- a/packages/metadata-builders/tests/__snapshots__/dynamic-builder.spec.ts.snap
+++ b/packages/metadata-builders/tests/__snapshots__/dynamic-builder.spec.ts.snap
@@ -4,17 +4,11 @@ exports[`getDynamicBuilder > batched call 1`] = `
 {
   "calls": [
     {
-      "as": [Function],
-      "is": [Function],
       "type": "Balances",
       "value": {
-        "as": [Function],
-        "is": [Function],
         "type": "transfer",
         "value": {
           "dest": {
-            "as": [Function],
-            "is": [Function],
             "type": "Id",
             "value": "HZZ7X3nzKuYpdrT7wSDBb8HqB7cc8z77C8oVi2MACzfAhh4",
           },
@@ -23,18 +17,12 @@ exports[`getDynamicBuilder > batched call 1`] = `
       },
     },
     {
-      "as": [Function],
-      "is": [Function],
       "type": "Staking",
       "value": {
-        "as": [Function],
-        "is": [Function],
         "type": "nominate",
         "value": {
           "targets": [
             {
-              "as": [Function],
-              "is": [Function],
               "type": "Id",
               "value": "HZZ7X3nzKuYpdrT7wSDBb8HqB7cc8z77C8oVi2MACzfAhh4",
             },
@@ -49,14 +37,10 @@ exports[`getDynamicBuilder > batched call 1`] = `
 exports[`getDynamicBuilder > felloship referenda submit 1`] = `
 {
   "enactment_moment": {
-    "as": [Function],
-    "is": [Function],
     "type": "After",
     "value": 1,
   },
   "proposal": {
-    "as": [Function],
-    "is": [Function],
     "type": "Inline",
     "value": _Binary {
       "asBytes": [Function],
@@ -65,12 +49,8 @@ exports[`getDynamicBuilder > felloship referenda submit 1`] = `
     },
   },
   "proposal_origin": {
-    "as": [Function],
-    "is": [Function],
     "type": "Origins",
     "value": {
-      "as": [Function],
-      "is": [Function],
       "type": "Fellows",
       "value": undefined,
     },

--- a/packages/substrate-bindings/CHANGELOG.md
+++ b/packages/substrate-bindings/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking
+
+- Move the `is` and `as` methods from enum values to `Enum`: `Enum.is(value, tag)`, `Enum.as(value, tag)`.
+
 ## 0.3.0 - 2024-04-25
 
 ### Added

--- a/packages/view-builder/tests/__snapshots__/view-builder.spec.ts.snap
+++ b/packages/view-builder/tests/__snapshots__/view-builder.spec.ts.snap
@@ -23,8 +23,6 @@ exports[`getViewBuilder > batched call 1`] = `
                 "RuntimeCall",
               ],
               "value": {
-                "as": [Function],
-                "is": [Function],
                 "type": "Balances",
                 "value": {
                   "codec": "Enum",
@@ -38,8 +36,6 @@ exports[`getViewBuilder > batched call 1`] = `
                     "Call",
                   ],
                   "value": {
-                    "as": [Function],
-                    "is": [Function],
                     "type": "transfer",
                     "value": {
                       "codec": "Struct",
@@ -59,8 +55,6 @@ exports[`getViewBuilder > batched call 1`] = `
                             "MultiAddress",
                           ],
                           "value": {
-                            "as": [Function],
-                            "is": [Function],
                             "type": "Id",
                             "value": {
                               "codec": "AccountId",
@@ -97,8 +91,6 @@ exports[`getViewBuilder > batched call 1`] = `
                 "RuntimeCall",
               ],
               "value": {
-                "as": [Function],
-                "is": [Function],
                 "type": "Staking",
                 "value": {
                   "codec": "Enum",
@@ -113,8 +105,6 @@ exports[`getViewBuilder > batched call 1`] = `
                     "Call",
                   ],
                   "value": {
-                    "as": [Function],
-                    "is": [Function],
                     "type": "nominate",
                     "value": {
                       "codec": "Struct",
@@ -137,8 +127,6 @@ exports[`getViewBuilder > batched call 1`] = `
                                 "MultiAddress",
                               ],
                               "value": {
-                                "as": [Function],
-                                "is": [Function],
                                 "type": "Id",
                                 "value": {
                                   "codec": "AccountId",
@@ -211,8 +199,6 @@ exports[`getViewBuilder > felloship referenda submit 1`] = `
             "DispatchTime",
           ],
           "value": {
-            "as": [Function],
-            "is": [Function],
             "type": "After",
             "value": {
               "codec": "u32",
@@ -232,8 +218,6 @@ exports[`getViewBuilder > felloship referenda submit 1`] = `
             "Bounded",
           ],
           "value": {
-            "as": [Function],
-            "is": [Function],
             "type": "Inline",
             "value": {
               "codec": "Bytes",
@@ -251,8 +235,6 @@ exports[`getViewBuilder > felloship referenda submit 1`] = `
             "OriginCaller",
           ],
           "value": {
-            "as": [Function],
-            "is": [Function],
             "type": "Origins",
             "value": {
               "codec": "Enum",
@@ -266,8 +248,6 @@ exports[`getViewBuilder > felloship referenda submit 1`] = `
                 "Origin",
               ],
               "value": {
-                "as": [Function],
-                "is": [Function],
                 "type": "Fellows",
                 "value": {
                   "codec": "_void",


### PR DESCRIPTION
This PR moves the methods in the enum values `is` and `as` into the `Enum` function, so it can be imported and used as a utility.

It's a breaking change, with a simple migration:

```ts
declare const multiAddress: MultiAddress;

if (multiAddress.is("Raw"))
  console.log(multiAddress.value.asHex())
else
  console.log(multiAddress.as("Index"))

// Becomes
if (Enum.is(multiAddress, "Raw"))
  console.log(multiAddress.value.asHex())
else
  console.log(Enum.as(multiAddress, "Index"))


```