### PR TITLE
fix(client): improve `getEstimateFees`

### DIFF
--- a/integration-tests/zombie-tests/src/main.spec.ts
+++ b/integration-tests/zombie-tests/src/main.spec.ts
@@ -99,7 +99,7 @@ describe("E2E", async () => {
 
     const [aliceEstimatedFee, bobEstimatedFee] = await Promise.all(
       [aliceTransfer, bobTransfer].map((call, idx) =>
-        call.getEstimatedFees(idx === 0 ? alice : bob),
+        call.getEstimatedFees((idx === 0 ? alice : bob).publicKey),
       ),
     )
 

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Breaking
 
 - `client`: rename `watchBlockBlody` to `watchBlockBody`
-- `getEstimatedFee` takes as input a PolkadotSigner and optionally the "hinted-sign-extensions"
+- `getEstimatedFee` takes as input the sender's address and optionally the "hinted-sign-extensions"
 - `tx`: now transactions are mortal by default with a 64 blocks period
 - `codegen`: [deduplicate equivalent known types](https://github.com/polkadot-api/polkadot-api/pull/448)
 

--- a/packages/client/src/tx.ts
+++ b/packages/client/src/tx.ts
@@ -1,8 +1,10 @@
 import {
+  AccountId,
   AssetDescriptor,
   Binary,
   Enum,
   HexString,
+  SS58String,
   Tuple,
   compact,
   u128,
@@ -111,7 +113,7 @@ export type Transaction<
   signAndSubmit: TxFunction<Asset>
   getEncodedData: TxCall
   getEstimatedFees: (
-    from: PolkadotSigner,
+    from: Uint8Array | SS58String,
     hintedSignExtensions?: HintedSignExtensions<Asset>,
   ) => Promise<bigint>
   decodedCall: Enum<{ [P in Pallet]: Enum<{ [N in Name]: Arg }> }>
@@ -128,6 +130,8 @@ export interface TxEntry<
   ): Transaction<Arg, Pallet, Name, Asset>
   isCompatible: IsCompatible
 }
+
+const accountIdEnc = AccountId().enc
 
 export const getSubmitFns = (
   chainHead: ReturnType<ReturnType<typeof getObservableClient>["chainHead$"]>,
@@ -287,9 +291,12 @@ export const createTxEntry = <
         }),
       )
 
-    const getEstimatedFees = async (from: PolkadotSigner, _hinted?: any) => {
+    const getEstimatedFees = async (
+      from: Uint8Array | SS58String,
+      _hinted?: any,
+    ) => {
       const fakeSigner = getPolkadotSigner(
-        from.publicKey,
+        from instanceof Uint8Array ? from : accountIdEnc(from),
         "Sr25519",
         getFakeSignature,
       )


### PR DESCRIPTION
As @carlosala pointed out, it is preferable not to pass the whole signer, because in the end the `getEstimateFees` function should not be calling the `sign` function of the signer. Therefore, since the only thing that we need in order to calculate the fees is the public key (so that we can get its nonce, which can alter the len of the extrinsic and thus its fees), then this PR ensures that's the only thing that's passed into the function.