### PR TITLE
fix(substrate-bindings): improve `Binary` encoder

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -21,6 +21,8 @@
   which were previously being anonymized as`FixedSizeBinary<number>`
 - `getEstimatedFee` now uses the more comon runtime-call: `TransactionPaymentApi_query_info`
 - `pjs-signer`: Ensure blockNumber in SignerPayloadJSON
+- Improve behaviour of a dynamic `Binary` codec, so that if what it receives as an argument
+  is a `FixedSizedBinary` it will honour its size, rather than pre-pepending its len.
 
 ## 0.5.5 - 2024-04-29
 

--- a/packages/metadata-builders/CHANGELOG.md
+++ b/packages/metadata-builders/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- patch dependencies
+
 ### Breaking
 
 - lookup: Normalize `Enum.Variant([T,T,T,T])` into `Enum.Variant([4;T])`

--- a/packages/observable-client/CHANGELOG.md
+++ b/packages/observable-client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- patch dependencies
+
 ## 0.2.1 - 2024-04-25
 
 ### Fixed

--- a/packages/substrate-bindings/CHANGELOG.md
+++ b/packages/substrate-bindings/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixed
+
+- Improve behaviour of a dynamic `Binary` codec, so that if what it receives as an argument
+  is a `FixedSizedBinary` it will honour its size, rather than pre-pepending its len.
+
 ## 0.3.0 - 2024-04-25
 
 ### Added

--- a/packages/substrate-bindings/src/codecs/scale/Binary.ts
+++ b/packages/substrate-bindings/src/codecs/scale/Binary.ts
@@ -49,7 +49,12 @@ export class FixedSizeBinary<_L extends number> extends Binary {
 
 const enc = (nBytes?: number): Encoder<Binary> => {
   const _enc = Bytes.enc(nBytes)
-  return (value) => _enc(value.asBytes())
+  return (value) => {
+    const bytes = value.asBytes()
+    return value instanceof FixedSizeBinary && nBytes == null
+      ? bytes
+      : _enc(bytes)
+  }
 }
 
 const dec = (nBytes?: number): Decoder<Binary> => {

--- a/packages/view-builder/CHANGELOG.md
+++ b/packages/view-builder/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- patch dependencies
+
 ## 0.2.0 - 2024-04-23
 
 ### Added


### PR DESCRIPTION
There are instances when the consumer has to pass a `Binary` input, but what they have is already a `FixedSizeBinary` instance. In those cases, the len should not be prepended twice.