### PR TITLE
fix(substrate-client): improve operation cancelation logic

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -8,6 +8,10 @@
   to allow the consumers of the JSON-RPC provider have access to debugging endpoints
   such as `system_version`, and other useful endpoints that are not spec compliant.
 
+### Fixed
+
+- `substrate-client`: improve the cancelation logic on operations that have not yet received its operationId [#484](https://github.com/polkadot-api/polkadot-api/pull/484)
+
 ## 0.6.0 - 2024-05-03
 
 ### Breaking

--- a/packages/substrate-client/CHANGELOG.md
+++ b/packages/substrate-client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- fixed: improve the cancelation logic on operations that have not yet received its operationId [#484](https://github.com/polkadot-api/polkadot-api/pull/484)
+
 ## 0.1.1 - 2024-04-25
 
 ### Fixed


### PR DESCRIPTION
Closes #470 

As I mentioned in [this comment](https://github.com/polkadot-api/polkadot-api/issues/470#issuecomment-2091919852):

> To be fair, I now realize that the proper way of canceling an operation for which we haven't received its `started` event should be improved. I.e we should wait until receiving the `started` response and in that same moment trigger the `stopOperation` request.

This is the improvement introduced by this PR.