### PR TITLE
feat(client): support "optimistic" transactions

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -7,6 +7,9 @@
 - The `client` now exposes a `_request` method, which is meant as an "escape hatch"
   to allow the consumers of the JSON-RPC provider have access to debugging endpoints
   such as `system_version`, and other useful endpoints that are not spec compliant.
+- Suppot for "optimistic" transactions via the `at` option when creating/broadcasting
+  transactions. This makes it possible to create transactions against blocks that are
+  not yet finalized. [#486](https://github.com/polkadot-api/polkadot-api/pull/486)
 
 ## 0.6.0 - 2024-05-03
 

--- a/packages/client/src/get-create-tx.ts
+++ b/packages/client/src/get-create-tx.ts
@@ -1,6 +1,5 @@
 import { Observable, combineLatest, mergeMap, of, take } from "rxjs"
 import { BlockInfo, ChainHead$ } from "@polkadot-api/observable-client"
-import { HintedSignedExtensions } from "./types"
 import {
   ChargeAssetTxPayment,
   ChargeTransactionPayment,
@@ -10,6 +9,7 @@ import * as chainSignedExtensions from "./signed-extensions/chain"
 import type { PolkadotSigner } from "@polkadot-api/polkadot-signer"
 import { _void } from "@polkadot-api/substrate-bindings"
 import { empty } from "./signed-extensions/utils"
+import { HintedSignedExtensions } from "./types"
 
 export const getCreateTx = (
   chainHead: ChainHead$,

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -26,12 +26,6 @@ export type HintedSignedExtensions = Partial<{
   asset: Uint8Array
 }>
 
-export type CreateTx = (
-  publicKey: Uint8Array,
-  callData: Uint8Array,
-  hintedSignedExtensions?: HintedSignedExtensions,
-) => Promise<Uint8Array>
-
 export type StorageApi<
   A extends Record<
     string,
@@ -118,8 +112,14 @@ export interface PolkadotClient {
 
   getBlockHeader: (hash?: string) => Promise<BlockHeader>
 
-  submit: (transaction: HexString) => Promise<TxFinalizedPayload>
-  submitAndWatch: (transaction: HexString) => Observable<TxBroadcastEvent>
+  submit: (
+    transaction: HexString,
+    at?: HexString,
+  ) => Promise<TxFinalizedPayload>
+  submitAndWatch: (
+    transaction: HexString,
+    at?: HexString,
+  ) => Observable<TxBroadcastEvent>
 
   getTypedApi: <D extends Descriptors>(descriptors: D) => TypedApi<D>
 


### PR DESCRIPTION
It partially solves #477. However, there is one more thing that I want to do before closing #477.

What this PR does is to add the ability to create (and validate, broadcast, etc) "optimistic" transactions. What I mean by that is that by default a transaction gets created against the currently finalized block. Which means that the mortality of the transaction, its nonce and its validation will take place against the currently finalized block. However, there are instances where a block that just got announced (and that it's not yet finalized) changes the state in a way that we may want to submit a transaction against that block ASAP, which means that if the block in question ends up becoming finalized, then the "optimistic" transaction should also get into a block that will eventually be finalized. However, if that block ends up being pruned, then the transaction will become invalid (which in these cases is also what's desirable).

The way to create an optimistic transaction is to pass the newly added `at` property to the `TxOptions`.