### PR TITLE
fix(client): detect invalid tx after broadcast

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -12,6 +12,10 @@
   not yet finalized. [#486](https://github.com/polkadot-api/polkadot-api/pull/486)
 - Allow users to manually pass the `nonce` when creating a transaction. [#498](https://github.com/polkadot-api/polkadot-api/pull/498)
 
+### Changed
+
+- The payload of the transaction `bestChainBlockIncluded` event is now consistent with the payload of the `finalized` event. [#500](https://github.com/polkadot-api/polkadot-api/pull/500)
+
 ### Fixed
 
 - `substrate-client`: improve the cancelation logic on operations that have not yet received its operationId [#484](https://github.com/polkadot-api/polkadot-api/pull/484)
@@ -21,6 +25,7 @@
   Closes [#492](https://github.com/polkadot-api/polkadot-api/issues/492)
 - Recover from stop events when runtime hasn't loaded and finalized block changes
 - `pjs-signer`: Ensure SignerPayloadJSON to be the same as PJS api
+- Keeps on validating transactions after they have been broadcasted. [#500](https://github.com/polkadot-api/polkadot-api/pull/500)
 
 ## 0.6.0 - 2024-05-03
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -6,6 +6,6 @@ export type { PolkadotClient, TypedApi, FixedSizeArray } from "./types"
 export type {
   TxBroadcastEvent,
   TxEvent,
-  TxFinalizedPayload,
+  TxEventsPayload as TxFinalizedPayload,
   Transaction,
 } from "./tx"

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -14,7 +14,7 @@ import { ChainSpecData } from "@polkadot-api/substrate-client"
 import { BlockInfo } from "@polkadot-api/observable-client"
 import { RuntimeApi } from "./runtime"
 import { StorageEntry } from "./storage"
-import { TxEntry, TxBroadcastEvent, TxFinalizedPayload } from "./tx"
+import { TxEntry, TxBroadcastEvent, TxEventsPayload } from "./tx"
 import { ConstantEntry } from "./constants"
 import { RuntimeCall } from "./runtime-call"
 
@@ -172,10 +172,7 @@ export interface PolkadotClient {
    *                     and create the mortality taking that block into
    *                     account.
    */
-  submit: (
-    transaction: HexString,
-    at?: HexString,
-  ) => Promise<TxFinalizedPayload>
+  submit: (transaction: HexString, at?: HexString) => Promise<TxEventsPayload>
   /**
    * Broadcast a transaction and returns an Observable. The observable will
    * complete as soon as the transaction is in a finalized block.

--- a/packages/observable-client/CHANGELOG.md
+++ b/packages/observable-client/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Changed
+
+- `trackTx`: has a more granular and useful API
+- expose `isBestOrFinalizedBlock` helper
+
 ### Fixed
 
 - ensure `bestBlocks$` always start with latest known `finalizedBlock` [#491](https://github.com/polkadot-api/polkadot-api/pull/491)

--- a/packages/observable-client/src/chainHead/streams/block-operations.ts
+++ b/packages/observable-client/src/chainHead/streams/block-operations.ts
@@ -1,41 +1,17 @@
-import {
-  Observable,
-  distinctUntilChanged,
-  filter,
-  map,
-  take,
-  takeWhile,
-} from "rxjs"
+import { Observable, distinctUntilChanged, filter, map, takeWhile } from "rxjs"
 import { PinnedBlocks } from "./pinned-blocks"
-
-export const isFinalized =
-  (blockHash: string) => (blocks$: Observable<PinnedBlocks>) =>
-    blocks$.pipe(
-      takeWhile((b) => b.blocks.has(blockHash)),
-      distinctUntilChanged((a, b) => a.finalized === b.finalized),
-      filter(
-        (x) =>
-          x.blocks.get(x.finalized)!.number >= x.blocks.get(blockHash)!.number,
-      ),
-      take(1),
-      map((pinned) => {
-        const { number } = pinned.blocks.get(blockHash)!
-        let current = pinned.blocks.get(pinned.finalized)!
-        while (current.number > number)
-          current = pinned.blocks.get(current.parent)!
-        return current.hash === blockHash
-      }),
-    )
 
 export const isBestOrFinalizedBlock =
   (blockHash: string) => (blocks$: Observable<PinnedBlocks>) =>
     blocks$.pipe(
       takeWhile((b) => b.blocks.has(blockHash)),
-      distinctUntilChanged((a, b) => a.best === b.best),
+      distinctUntilChanged(
+        (a, b) => a.finalized === b.finalized && a.best === b.best,
+      ),
       filter(
         (x) => x.blocks.get(x.best)!.number >= x.blocks.get(blockHash)!.number,
       ),
-      map((pinned) => {
+      map((pinned): "best" | "finalized" | null => {
         const { number } = pinned.blocks.get(blockHash)!
         let current = pinned.blocks.get(pinned.best)!
         let isFinalized = pinned.finalized === current.hash
@@ -43,8 +19,9 @@ export const isBestOrFinalizedBlock =
           current = pinned.blocks.get(current.parent)!
           isFinalized = isFinalized || pinned.finalized === current.hash
         }
-        return { isBest: current.hash === blockHash, isFinalized }
+        if (isFinalized) return "finalized"
+        return current.hash === blockHash ? "best" : null
       }),
-      takeWhile(({ isFinalized }) => !isFinalized, true),
-      map(({ isBest }) => isBest),
+      distinctUntilChanged(),
+      takeWhile((x) => x !== "finalized", true),
     )

--- a/packages/observable-client/src/chainHead/validate-tx.ts
+++ b/packages/observable-client/src/chainHead/validate-tx.ts
@@ -14,7 +14,7 @@ export const getValidateTx =
       parameters: string,
     ) => Observable<string>,
   ) =>
-  (tx: string, blockHash: string) =>
+  (blockHash: string, tx: string) =>
     call$(
       blockHash,
       "TaggedTransactionQueue_validate_transaction",

--- a/packages/observable-client/src/index.ts
+++ b/packages/observable-client/src/index.ts
@@ -3,5 +3,5 @@ export {
   BlockNotPinnedError,
   BlockPrunedError,
   NotBestBlockError,
-  TrackedTx,
+  AnalyzedBlock,
 } from "./chainHead"


### PR DESCRIPTION
This PR fixes 2 important issues:
- It keeps on validating the transaction after it has been broadcasted
- It makes the payload of the `bestChainBlockIncluded` consistent with the payload of the `finalized` event

It also sets the ground to make the rest of the TX improvements much simpler.