### PR TITLE
feat: lazy load descriptor values

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -12,6 +12,7 @@
   not yet finalized. [#486](https://github.com/polkadot-api/polkadot-api/pull/486)
 - Allow users to manually pass the `nonce` when creating a transaction. [#498](https://github.com/polkadot-api/polkadot-api/pull/498)
 - Decouple descriptor types from descriptor values: Now operations won't show empty pallets.
+- Lazy load descriptor values
 
 ### Changed
 

--- a/packages/client/src/constants.ts
+++ b/packages/client/src/constants.ts
@@ -1,11 +1,6 @@
 import { firstValueFrom, map } from "rxjs"
 import { ChainHead$, RuntimeContext } from "@polkadot-api/observable-client"
-import {
-  CompatibilityHelper,
-  IsCompatible,
-  Runtime,
-  getRuntimeContext,
-} from "./runtime"
+import { CompatibilityHelper, IsCompatible, Runtime } from "./runtime"
 
 export interface ConstantEntry<T> {
   (): Promise<T>
@@ -43,7 +38,7 @@ export const createConstantEntry = <T>(
   const fn = (runtime?: Runtime): any => {
     if (runtime) {
       if (!isCompatible(runtime)) throw checksumError()
-      return getValueWithContext(getRuntimeContext(runtime))
+      return getValueWithContext(runtime._getCtx())
     }
     return firstValueFrom(
       compatibleRuntime$(chainHead, null, checksumError).pipe(

--- a/packages/client/src/descriptors.ts
+++ b/packages/client/src/descriptors.ts
@@ -50,8 +50,13 @@ export type ApisTypedef<
   T extends DescriptorEntry<RuntimeDescriptor<any, any>>,
 > = T
 
+export type DescriptorsValue = {
+  pallets: PalletDescriptors
+  apis: ApisDescriptors
+}
+
 export type ChainDefinition = {
-  descriptors: {
+  descriptors: Promise<DescriptorsValue> & {
     pallets: PalletsTypedef<any, any, any, any, any>
     apis: ApisTypedef<any>
   }

--- a/packages/client/src/runtime.ts
+++ b/packages/client/src/runtime.ts
@@ -1,27 +1,66 @@
-import { Observable, combineLatest, filter, map } from "rxjs"
 import {
   ChainHead$,
   RuntimeContext,
   getObservableClient,
 } from "@polkadot-api/observable-client"
+import {
+  Observable,
+  ReplaySubject,
+  combineLatest,
+  connectable,
+  filter,
+  firstValueFrom,
+  map,
+} from "rxjs"
+import { DescriptorsValue } from "./descriptors"
+
+export enum OpType {
+  Storage = 0,
+  Tx = 1,
+  Event = 2,
+  Error = 3,
+  Const = 4,
+}
 
 export class Runtime {
-  protected _ctx: unknown
-  protected _checksums: string[]
+  private constructor(
+    private _ctx: RuntimeContext,
+    private _checksums: string[],
+    private _descriptors: DescriptorsValue,
+  ) {}
 
-  private constructor(ctx: RuntimeContext, checksums: string[]) {
-    this._ctx = ctx
-    this._checksums = checksums
+  /**
+   * Internal implementation detail. Do not use
+   */
+  static _create(
+    ctx: RuntimeContext,
+    checksums: string[],
+    descriptors: DescriptorsValue,
+  ) {
+    return new Runtime(ctx, checksums, descriptors)
+  }
+
+  /**
+   * Internal implementation detail. Do not use
+   */
+  _getCtx() {
+    return this._ctx
+  }
+
+  /**
+   * Internal implementation detail. Do not use
+   */
+  _getPalletChecksum(opType: OpType, pallet: string, name: string) {
+    return this._checksums[this._descriptors.pallets[pallet][opType][name]]
+  }
+
+  /**
+   * Internal implementation detail. Do not use
+   */
+  _getApiChecksum(name: string, method: string) {
+    return this._checksums[this._descriptors.apis[name][method]]
   }
 }
-export function getRuntimeContext(runtime: Runtime): RuntimeContext {
-  return (runtime as any)._ctx
-}
-function getImportedChecksum(runtime: Runtime, idx: number): string {
-  return (runtime as any)._checksums[idx]
-}
-const createRuntime = (ctx: RuntimeContext, checksums: string[]) =>
-  new (Runtime as any)(ctx, checksums)
 
 export type RuntimeApi = Observable<Runtime> & {
   latest: () => Promise<Runtime>
@@ -29,37 +68,25 @@ export type RuntimeApi = Observable<Runtime> & {
 
 export const getRuntimeApi = (
   checksums: Promise<string[]>,
+  descriptors: Promise<DescriptorsValue>,
   chainHead: ReturnType<ReturnType<typeof getObservableClient>["chainHead$"]>,
 ): RuntimeApi => {
-  let latestRuntime: Promise<Runtime>
-  let resolve: ((r: Runtime) => void) | null = null
-
-  latestRuntime = new Promise<Runtime>((res) => {
-    resolve = res
-  })
-
-  const runtimeWithChecksums$ = combineLatest([chainHead.runtime$, checksums])
-  runtimeWithChecksums$.subscribe(([x, checksums]) => {
-    if (x) {
-      const runtime = createRuntime(x, checksums)
-      if (resolve) {
-        resolve(runtime)
-        resolve = null
-      } else {
-        latestRuntime = Promise.resolve(runtime)
-      }
-    } else if (!resolve) {
-      latestRuntime = new Promise<Runtime>((res) => {
-        resolve = res
-      })
-    }
-  })
+  const runtimeWithChecksums$ = connectable(
+    combineLatest([chainHead.runtime$, checksums, descriptors]).pipe(
+      map(([x, checksums, descriptors]) =>
+        x ? Runtime._create(x, checksums, descriptors) : null,
+      ),
+    ),
+    {
+      connector: () => new ReplaySubject(1),
+    },
+  )
+  runtimeWithChecksums$.connect()
 
   const result = runtimeWithChecksums$.pipe(
-    filter(([x]) => Boolean(x)),
-    map(([x, checksums]) => createRuntime(x!, checksums)),
+    filter((v) => Boolean(v)),
   ) as RuntimeApi
-  result.latest = () => latestRuntime
+  result.latest = () => firstValueFrom(result)
 
   return result
 }
@@ -70,12 +97,13 @@ export interface IsCompatible {
 }
 
 export const compatibilityHelper =
-  (runtimeApi: RuntimeApi, checksumIdx: number) =>
+  (
+    runtimeApi: RuntimeApi,
+    getDescriptorChecksum: (runtime: Runtime) => string,
+  ) =>
   (getChecksum: (ctx: RuntimeContext) => string | null) => {
     function isCompatibleSync(runtime: Runtime) {
-      const ctx = getRuntimeContext(runtime)
-      const checksum = getImportedChecksum(runtime, checksumIdx)
-      return getChecksum(ctx) === checksum
+      return getChecksum(runtime._getCtx()) === getDescriptorChecksum(runtime)
     }
 
     const isCompatible: IsCompatible = (runtime?: Runtime): any => {
@@ -88,7 +116,7 @@ export const compatibilityHelper =
     const waitChecksums = async () => {
       const runtime = await runtimeApi.latest()
       return (ctx: RuntimeContext) =>
-        getChecksum(ctx) === getImportedChecksum(runtime, checksumIdx)
+        getChecksum(ctx) === getDescriptorChecksum(runtime)
     }
     const compatibleRuntime$ = (
       chainHead: ChainHead$,

--- a/packages/client/src/runtime.ts
+++ b/packages/client/src/runtime.ts
@@ -14,7 +14,7 @@ import {
 } from "rxjs"
 import { DescriptorsValue } from "./descriptors"
 
-export enum OpType {
+export const enum OpType {
   Storage = 0,
   Tx = 1,
   Event = 2,
@@ -30,7 +30,7 @@ export class Runtime {
   ) {}
 
   /**
-   * Internal implementation detail. Do not use
+   * @access package  - Internal implementation detail. Do not use.
    */
   static _create(
     ctx: RuntimeContext,
@@ -41,21 +41,21 @@ export class Runtime {
   }
 
   /**
-   * Internal implementation detail. Do not use
+   * @access package  - Internal implementation detail. Do not use.
    */
   _getCtx() {
     return this._ctx
   }
 
   /**
-   * Internal implementation detail. Do not use
+   * @access package  - Internal implementation detail. Do not use.
    */
   _getPalletChecksum(opType: OpType, pallet: string, name: string) {
     return this._checksums[this._descriptors.pallets[pallet][opType][name]]
   }
 
   /**
-   * Internal implementation detail. Do not use
+   * @access package  - Internal implementation detail. Do not use.
    */
   _getApiChecksum(name: string, method: string) {
     return this._checksums[this._descriptors.apis[name][method]]

--- a/packages/client/src/tx/tx.ts
+++ b/packages/client/src/tx/tx.ts
@@ -23,7 +23,7 @@ import {
   RuntimeContext,
   getObservableClient,
 } from "@polkadot-api/observable-client"
-import { CompatibilityHelper, Runtime, getRuntimeContext } from "../runtime"
+import { CompatibilityHelper, Runtime } from "../runtime"
 import { PolkadotSigner } from "@polkadot-api/polkadot-signer"
 import { getPolkadotSigner } from "@polkadot-api/signer"
 import { AssetDescriptor } from "../descriptors"
@@ -97,7 +97,7 @@ export const createTxEntry = <
         if (!isCompatible(runtime)) {
           throw checksumError()
         }
-        return getCallDataWithContext(getRuntimeContext(runtime), arg).callData
+        return getCallDataWithContext(runtime._getCtx(), arg).callData
       }
       return firstValueFrom(getCallData$(arg).pipe(map((x) => x.callData)))
     }

--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking
 
 - Decouple descriptor types from descriptor values
+- Lazy load descriptor values
 
 ## 0.4.0 - 2024-05-03
 

--- a/packages/codegen/src/generate-descriptors.ts
+++ b/packages/codegen/src/generate-descriptors.ts
@@ -289,8 +289,8 @@ export const generateDescriptors = (
   import {${typesBuilder.getTypeFileImports().join(", ")}} from "${
     paths.types
   }";
-  import { ${prefix} as descriptorValues } from "${paths.descriptorValues}";
 
+  const descriptorValues = import("${paths.descriptorValues}").then(module => module["${prefix}"]);
   const checksums = import("${paths.checksums}").then(module => 'default' in module ? module.default : module);
   `
 
@@ -362,7 +362,7 @@ type IDescriptors = {
   descriptors: {
     pallets: PalletsTypedef,
     apis: IRuntimeCalls
-  },
+  } & Promise<any>,
   asset: IAsset,
   checksums: Promise<string[]>
 };
@@ -384,7 +384,7 @@ export type ${prefix}WhitelistEntry =
   | \`error.\${NestedKey<PalletsTypedef['__error']>}\`
   | \`const.\${NestedKey<PalletsTypedef['__const']>}\`
 
-type PalletKey = \`*.\${keyof (typeof descriptorValues)['pallets'] & string}\`
+type PalletKey = \`*.\${keyof PalletsTypedef & string}\`
 type NestedKey<D extends Record<string, Record<string, any>>> =
   | "*"
   | {
@@ -404,13 +404,6 @@ type ApiKey<D extends Record<string, Record<string, any>>> =
             [N in keyof D[P] & string]: \`api.\${P}.\${N}\`
           }[keyof (keyof D[P]) & string]
     }[keyof D & string]
-
-type PickDescriptors<
-  Idx extends 0 | 1 | 2 | 3 | 4,
-  T extends Record<string, Record<number, any>>
-> = {
-  [K in keyof T]: T[K][Idx]
-}
 `
 
   return { descriptorTypes, descriptorValues }


### PR DESCRIPTION
This will have a really good effect on dApps using multiple chains without the need for a whitelist. On papi-teleporter, without whitelist:

```sh
# Previous
dist/index.html                                           0.45 kB │ gzip:   0.31 kB
dist/assets/index-BB_EzF1Y.css                           17.16 kB │ gzip:   4.00 kB
dist/assets/checksums-G76RJU2V-DxShV170.js               24.33 kB │ gzip:  14.42 kB
dist/assets/index-DkOWvDP3.js                           693.08 kB │ gzip: 237.72 kB

# With this change
dist/index.html                                           0.45 kB │ gzip:   0.31 kB
dist/assets/index-BB_EzF1Y.css                           17.16 kB │ gzip:   4.00 kB
dist/assets/checksums-G76RJU2V-DxShV170.js               24.33 kB │ gzip:  14.42 kB
dist/assets/descriptors-2PSCKWSU-C0Cze290.js            213.73 kB │ gzip:  51.05 kB
dist/assets/index-BjAS4uGf.js                           396.91 kB │ gzip: 130.48 kB
```

(omitted smoldot and chainspec chunks for clarity)

for more context, papi-teleporter with whitelist has a minimal effect on main bundle size:
```sh
# Previous + whitelist
dist/index.html                                           0.45 kB │ gzip:   0.31 kB
dist/assets/index-BB_EzF1Y.css                           17.16 kB │ gzip:   4.00 kB
dist/assets/checksums-KDHRGMNB-DddHFHAu.js                7.56 kB │ gzip:   4.54 kB
dist/assets/index-ChgqX87D.js                           399.96 kB │ gzip: 131.86 kB

# With this change + whitelist
dist/index.html                                           0.45 kB │ gzip:   0.31 kB
dist/assets/index-BB_EzF1Y.css                           17.16 kB │ gzip:   4.00 kB
dist/assets/descriptors-ZSPVYJMS-BiXzoCjz.js              1.40 kB │ gzip:   0.24 kB
dist/assets/checksums-KDHRGMNB-DddHFHAu.js                7.56 kB │ gzip:   4.54 kB
dist/assets/index-DxsoYi34.js                           396.91 kB │ gzip: 130.48 kB
```

But it's always better, and users won't have to maintain a whitelist to have a small main chunk. The whitelist now is to reduce the size of the descriptor+checksum chunks.