### PR TITLE
fix(cli): download metadata in parallel plus generate all

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.4.1 - 2024-05-11
+
+### Fixed
+
+- Update metadata files in parallel and perform a single `generate` afterwords.
+
 ## 0.4.0 - 2024-05-10
 
 ### Added

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot-api/cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": "Ryan Lee (https://github.com/ryanleecode)",
   "license": "MIT",
   "sideEffects": true,

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.7.1 - 2024-05-11
+
+- `cli`: Update metadata files in parallel and perform a single `generate` afterwords.
+
 ## 0.7.0 - 2024-05-10
 
 ### Added

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polkadot-api",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": "Josep M Sobrepere (https://github.com/josepot)",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #511 and improves the post-update `generate`.