### PR TITLE
feat: compact size of generated descriptor values

### DIFF
--- a/integration-tests/log-replays/turbo.json
+++ b/integration-tests/log-replays/turbo.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "pipeline": {
+    "build": {
+      "outputs": ["node_modules/@polkadot-api/descriptors/**"]
+    },
+    "test": {
+      "inputs": ["src/**", "node_modules/@polkadot-api/descriptors/**"]
+    }
+  }
+}

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update patch dependencies
+
 ## 0.4.1 - 2024-05-11
 
 ### Fixed

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Compact the data when generating descriptor from multiple chains [#516](https://github.com/polkadot-api/polkadot-api/pull/516)
+
 ## 0.7.2 - 2024-05-11
 
 - `chains`: update relay-chain chainSpecs

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -474,6 +474,7 @@
     "@polkadot-api/smoldot": "workspace:*"
   },
   "devDependencies": {
+    "@polkadot-api/codegen": "workspace:*",
     "rxjs": "^7.8.1"
   }
 }

--- a/packages/client/src/descriptors.ts
+++ b/packages/client/src/descriptors.ts
@@ -1,3 +1,5 @@
+import type { DescriptorValues } from "@polkadot-api/codegen"
+
 export type PlainDescriptor<T> = { _type?: T }
 export type AssetDescriptor<T> = string & { _type?: T }
 export type StorageDescriptor<
@@ -15,22 +17,6 @@ export type RuntimeDescriptor<Args extends Array<any>, T> = [Args, T]
 // pallet -> name -> descriptor
 export type DescriptorEntry<T> = Record<string, Record<string, T>>
 
-export type PalletDescriptors = Record<
-  string,
-  [
-    // storage
-    Record<string, number>,
-    // tx
-    Record<string, number>,
-    // event
-    Record<string, number>,
-    // error
-    Record<string, number>,
-    // const
-    Record<string, number>,
-  ]
->
-
 export type PalletsTypedef<
   St extends DescriptorEntry<StorageDescriptor<any, any, any>>,
   Tx extends DescriptorEntry<TxDescriptor<any>>,
@@ -45,18 +31,14 @@ export type PalletsTypedef<
   __const: Ct
 }
 
-export type ApisDescriptors = DescriptorEntry<number>
 export type ApisTypedef<
   T extends DescriptorEntry<RuntimeDescriptor<any, any>>,
 > = T
 
-export type DescriptorsValue = {
-  pallets: PalletDescriptors
-  apis: ApisDescriptors
-}
+export { DescriptorValues }
 
 export type ChainDefinition = {
-  descriptors: Promise<DescriptorsValue> & {
+  descriptors: Promise<DescriptorValues> & {
     pallets: PalletsTypedef<any, any, any, any, any>
     apis: ApisTypedef<any>
   }

--- a/packages/client/src/runtime.ts
+++ b/packages/client/src/runtime.ts
@@ -12,21 +12,21 @@ import {
   firstValueFrom,
   map,
 } from "rxjs"
-import { DescriptorsValue } from "./descriptors"
+import { DescriptorValues } from "./descriptors"
 
 export const enum OpType {
-  Storage = 0,
-  Tx = 1,
-  Event = 2,
-  Error = 3,
-  Const = 4,
+  Storage = "storage",
+  Tx = "tx",
+  Event = "events",
+  Error = "errors",
+  Const = "constants",
 }
 
 export class Runtime {
   private constructor(
     private _ctx: RuntimeContext,
     private _checksums: string[],
-    private _descriptors: DescriptorsValue,
+    private _descriptors: DescriptorValues,
   ) {}
 
   /**
@@ -35,7 +35,7 @@ export class Runtime {
   static _create(
     ctx: RuntimeContext,
     checksums: string[],
-    descriptors: DescriptorsValue,
+    descriptors: DescriptorValues,
   ) {
     return new Runtime(ctx, checksums, descriptors)
   }
@@ -51,7 +51,7 @@ export class Runtime {
    * @access package  - Internal implementation detail. Do not use.
    */
   _getPalletChecksum(opType: OpType, pallet: string, name: string) {
-    return this._checksums[this._descriptors.pallets[pallet][opType][name]]
+    return this._checksums[this._descriptors[opType][pallet][name]]
   }
 
   /**
@@ -68,7 +68,7 @@ export type RuntimeApi = Observable<Runtime> & {
 
 export const getRuntimeApi = (
   checksums: Promise<string[]>,
-  descriptors: Promise<DescriptorsValue>,
+  descriptors: Promise<DescriptorValues>,
   chainHead: ReturnType<ReturnType<typeof getObservableClient>["chainHead$"]>,
 ): RuntimeApi => {
   const runtimeWithChecksums$ = connectable(

--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Compact the data when generating descriptor from multiple chains [#516](https://github.com/polkadot-api/polkadot-api/pull/516)
+
 ## 0.5.0 - 2024-05-10
 
 ### Breaking

--- a/packages/codegen/src/generate-multiple-descriptors.ts
+++ b/packages/codegen/src/generate-multiple-descriptors.ts
@@ -1,11 +1,12 @@
 import { getChecksumBuilder } from "@polkadot-api/metadata-builders"
 import type { V14, V15 } from "@polkadot-api/substrate-bindings"
-import { generateDescriptors } from "./generate-descriptors"
+import { DescriptorValues, generateDescriptors } from "./generate-descriptors"
 import { generateTypes } from "./generate-types"
 import { getUsedChecksums } from "./get-used-checksums"
 import knownTypes, { KnownTypes } from "./known-types"
 import { Variable, defaultDeclarations, getTypesBuilder } from "./types-builder"
 import { applyWhitelist } from "./whitelist"
+import { mapObject } from "@polkadot-api/utils"
 
 export const generateMultipleDescriptors = (
   chains: Array<{
@@ -57,9 +58,11 @@ export const generateMultipleDescriptors = (
     ),
   )
 
-  const descriptorsFileContent = chainFiles
-    .map((file) => file.descriptorValues)
-    .join("\n")
+  const descriptorsFileContent = generateDescriptorValuesContent(
+    Object.fromEntries(
+      chainFiles.map((file, i) => [chainData[i].key, file.descriptorValues]),
+    ),
+  )
 
   return {
     descriptorsFileContent,
@@ -126,4 +129,127 @@ function resolveConflicts(
 
 function capitalize(value: string) {
   return value.slice(0, 1).toUpperCase() + value.slice(1)
+}
+
+function generateDescriptorValuesContent(
+  descriptorValues: Record<string, DescriptorValues>,
+) {
+  const usages: Record<string, number> = {}
+  const countUsages = (obj: Record<string, any>): void =>
+    Object.entries(obj).forEach(([key, value]) => {
+      usages[key] = usages[key] ?? 0
+      usages[key]++
+      if (typeof value === "object") countUsages(value)
+    })
+  countUsages(descriptorValues)
+
+  const tokens: Array<string> = []
+  const tokenToIdx: Record<string, number> = {}
+  const minifyKeys = <T extends Record<string | number, any>>(obj: T): T =>
+    Object.fromEntries(
+      Object.entries(obj).map(([key, value]) => {
+        const newValue = typeof value === "number" ? value : minifyKeys(value)
+        if (usages[key] <= 1) return [key, newValue]
+        if (!(key in tokenToIdx)) {
+          tokenToIdx[key] = tokens.length
+          tokens.push(key)
+        }
+        return [tokenToIdx[key], newValue]
+      }),
+    ) as T
+  const minified = mapObject(descriptorValues, minifyKeys)
+
+  const getTreeKey = (tree: Record<string, unknown>): string =>
+    Object.entries(tree)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(
+        ([key, value]) =>
+          `[${key}:${typeof value === "object" ? getTreeKey(value as any) : value}]`,
+      )
+      .join("")
+
+  type Transformed = Record<string, number | Record<string, number>>
+  /** Modifies in-place, changes type to Transformed */
+  const findCommonTrees = (
+    values: Array<Record<string, Record<string, unknown>>>,
+  ) => {
+    const treeUsages: Record<string, number> = {}
+    const keys = values.map((obj) =>
+      mapObject(obj, (tree) => {
+        const key = getTreeKey(tree)
+        treeUsages[key] = treeUsages[key] ?? 0
+        treeUsages[key]++
+        return key
+      }),
+    )
+
+    const commonTrees: Array<Record<string, unknown>> = []
+    const keyToCommonTree: Record<string, number> = {}
+    values.forEach((obj, i) =>
+      Object.entries(obj).forEach(([objKey, tree]) => {
+        const key = keys[i][objKey]
+        if (treeUsages[key] > 1) {
+          if (!(key in keyToCommonTree)) {
+            keyToCommonTree[key] = commonTrees.length
+            commonTrees.push(tree)
+          }
+          ;(obj as Transformed)[objKey] = keyToCommonTree[key]
+        }
+      }),
+    )
+
+    return commonTrees
+  }
+
+  const commonTrees = findCommonTrees(
+    Object.keys(Object.values(minified)[0]).flatMap((type) =>
+      Object.values(minified).map((d) => d[type as keyof DescriptorValues]),
+    ),
+  )
+
+  const data = JSON.stringify([minified, commonTrees, tokens])
+
+  return `
+    const [minified, commonTrees, tokens] = JSON.parse(\`${data}\`);
+
+    const replaceTokens = <T>(obj: Record<string | number, T>): Record<string, T> =>
+      Object.fromEntries(
+        Object.entries(obj).map(([key, value]) => {
+          const unwrappedValue =
+            typeof value === "object" ? replaceTokens(value as any) : value
+          const numericKey = Number(key)
+          if (Number.isNaN(numericKey)) {
+            return [key, unwrappedValue]
+          }
+          return [tokens[numericKey], unwrappedValue]
+        }),
+      ) as Record<string, T>
+    const tokenizedCommonTrees = commonTrees.map(replaceTokens)
+    
+    const unwrap = (
+      obj: Record<string, object | number>,
+      depth: number,
+    ): Record<string, object> =>
+      depth === 0
+        ? (obj as Record<string, object>)
+        : Object.fromEntries(
+            Object.entries(obj).map(([key, value]) => [
+              key,
+              unwrap(
+                typeof value === "object" ? value : tokenizedCommonTrees[value],
+                depth - 1,
+              ),
+            ]),
+          )
+    
+    const getChainDescriptors = (key: string) =>
+      unwrap(replaceTokens(minified[key]), 2)
+
+    ${Object.keys(descriptorValues)
+      .map(
+        (key) =>
+          `export const ${capitalize(key)} = getChainDescriptors("${key}")`,
+      )
+      .join("\n")}
+  `
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,6 +318,9 @@ importers:
         specifier: workspace:*
         version: link:../json-rpc/ws-provider
     devDependencies:
+      '@polkadot-api/codegen':
+        specifier: workspace:*
+        version: link:../codegen
       rxjs:
         specifier: ^7.8.1
         version: 7.8.1


### PR DESCRIPTION
This changes the format of the generated descriptors to reduce the chunk size when multiple chains are used.

on papi-teleporter, which uses 8 chains, decreases parsed by 56%, gzipped by 50%:
```
dist/assets/descriptors-CAQHISEQ-D2CBgjrG.js            214.72 kB │ gzip:  51.33 kB
// becomes
dist/assets/descriptors-HTVGGBLK--6L_7V2l.js             93.19 kB │ gzip:  26.15 kB
```

Unfortunately, it increases slightly the size of chunks with only one chain. On our vite example, increases parsed by 13%, gzipped by 11%:
```
dist/assets/descriptors-MT2IRGUU-4e79d6ca.js     32.51 kB │ gzip: 11.60 kB
// becomes
dist/assets/descriptors-JIJEZZAP-4573a30e.js     36.59 kB │ gzip: 12.84 kB
```