### PR TITLE
fix(substrate-client): add `utils` as dependency

### DIFF
--- a/packages/substrate-client/CHANGELOG.md
+++ b/packages/substrate-client/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.1.3 - 2024-06-19
+
+### Fixed
+
+- Add `@polkadot-api/utils` as `dependecy`.
+
 ## 0.1.2 - 2024-05-10
 
 ### Fixed

--- a/packages/substrate-client/package.json
+++ b/packages/substrate-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot-api/substrate-client",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Josep M Sobrepere (https://github.com/josepot)",
   "repository": {
     "type": "git",
@@ -42,8 +42,10 @@
     "format": "prettier --write README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
     "prepack": "pnpm run build"
   },
-  "devDependencies": {
-    "@polkadot-api/json-rpc-provider": "workspace:*",
+  "dependencies": {
     "@polkadot-api/utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@polkadot-api/json-rpc-provider": "workspace:*"
   }
 }

--- a/packages/substrate-client/src/client/createClient.ts
+++ b/packages/substrate-client/src/client/createClient.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   JsonRpcConnection,
   JsonRpcProvider,
 } from "@polkadot-api/json-rpc-provider"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -534,13 +534,14 @@ importers:
         version: 4.11.0
 
   packages/substrate-client:
+    dependencies:
+      '@polkadot-api/utils':
+        specifier: workspace:*
+        version: link:../utils
     devDependencies:
       '@polkadot-api/json-rpc-provider':
         specifier: workspace:*
         version: link:../json-rpc/json-rpc-provider
-      '@polkadot-api/utils':
-        specifier: workspace:*
-        version: link:../utils
 
   packages/utils: {}
 


### PR DESCRIPTION
- `@polkadot-api/utils` is used during runtime hence should be part of `dependencies`
- Use type import for `@polkadot-api/json-rpc-provider`

Fixes #534 