### PR TITLE
refactor: `FixedSizeArray` type

### DIFF
--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -218,4 +218,12 @@ export interface PolkadotClient {
   ) => Promise<Reply>
 }
 
-export type FixedSizeArray<L extends number, T> = Array<T> & { length: L }
+type _FixedSizeArray<
+  L extends number,
+  T,
+  A extends unknown[],
+> = A["length"] extends L ? A : _FixedSizeArray<L, T, [T, ...A]>
+
+export type FixedSizeArray<L extends number, T> = (number extends L
+  ? T[]
+  : _FixedSizeArray<L, T, []>) & { length: L }


### PR DESCRIPTION
Create a tuple of `L` length instead of just setting the length to `L` Previously, because of this, type inference wouldn't work for storage keyed by `FixedSizeArray`