### PR TITLE
fix(observable-client): caching issue

### DIFF
--- a/packages/observable-client/CHANGELOG.md
+++ b/packages/observable-client/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix caching bug [#556](https://github.com/polkadot-api/polkadot-api/pull/556)
+
 ## 0.3.1 - 2024-07-03
+
+### Fixed
 
 - Declare `@polkadot-api/substrate-client` as a peer-dependency
 


### PR DESCRIPTION
I noticed that the cache was working for on-going requests/streams. However, once those observables completed the cache was starting the side-effects again. This PR addresses the issue. I have also added 2 new tests to ensure that we don't have regressions on this.