### PR TITLE
feat(signer)!: add support for `signBytes`

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - re-export `getSs58AddressInfo` from `@polkadot-api/substrate-bindings`
 
+### Changed
+
+- `polkadot-signer`: Add API to sign raw-data and rename `sign` to `signTx`
+
 ## 0.9.1 - 2024-07-03
 
 ### Fixed

--- a/packages/client/src/tx/create-tx.ts
+++ b/packages/client/src/tx/create-tx.ts
@@ -80,7 +80,7 @@ export const createTx: (
         ),
       ).pipe(
         mergeMap((signedExtensions) =>
-          signer.sign(
+          signer.signTx(
             callData,
             Object.fromEntries(
               ctx.metadata.extrinsic.signedExtensions.map(

--- a/packages/signers/pjs-signer/CHANGELOG.md
+++ b/packages/signers/pjs-signer/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Add API to sign raw-data and rename `sign` to `signTx`
+
 ## 0.2.1 - 2024-07-03
 
 ### Fixed

--- a/packages/signers/pjs-signer/src/types.ts
+++ b/packages/signers/pjs-signer/src/types.ts
@@ -1,3 +1,11 @@
+import { PolkadotSigner } from "@polkadot-api/polkadot-signer"
+
+declare global {
+  interface Window {
+    injectedWeb3?: InjectedWeb3
+  }
+}
+
 type HexString = string
 export interface SignerPayloadJSON {
   /**
@@ -80,4 +88,57 @@ export interface SignerPayloadJSON {
    * `singAndSend`, `signAsync`, and `dryRun`.
    */
   withSignedTransaction?: boolean
+}
+
+export type InjectedWeb3 = Record<
+  string,
+  | {
+      enable: () => Promise<PjsInjectedExtension>
+    }
+  | undefined
+>
+
+export type KeypairType = "ed25519" | "sr25519" | "ecdsa"
+
+export interface InjectedAccount {
+  address: string
+  genesisHash?: string | null
+  name?: string
+  type?: KeypairType
+}
+
+export interface InjectedPolkadotAccount {
+  polkadotSigner: PolkadotSigner
+  address: string
+  genesisHash?: string | null
+  name?: string
+  type?: KeypairType
+}
+
+export type SignPayload = (
+  payload: SignerPayloadJSON,
+) => Promise<{ signature: string; signedTransaction?: string | Uint8Array }>
+
+export type SignRaw = (payload: {
+  address: string
+  data: HexString
+  type: "bytes"
+}) => Promise<{ id: number; signature: HexString }>
+
+export interface PjsInjectedExtension {
+  signer: {
+    signPayload: SignPayload
+    signRaw: SignRaw
+  }
+  accounts: {
+    get: () => Promise<InjectedPolkadotAccount[]>
+    subscribe: (cb: (accounts: InjectedPolkadotAccount[]) => void) => () => void
+  }
+}
+
+export interface InjectedExtension {
+  name: string
+  getAccounts: () => InjectedPolkadotAccount[]
+  subscribe: (cb: (accounts: InjectedPolkadotAccount[]) => void) => () => void
+  disconnect: () => void
 }

--- a/packages/signers/polkadot-signer/CHANGELOG.md
+++ b/packages/signers/polkadot-signer/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## Unreleased
 
+### Changed
+
+- Add API to sign raw-data and rename `sign` to `signTx`
+
 ## 0.0.2 - 2024-07-03
+
+### Fixed
 
 - Update dependencies
 

--- a/packages/signers/polkadot-signer/src/types.ts
+++ b/packages/signers/polkadot-signer/src/types.ts
@@ -1,6 +1,6 @@
 export interface PolkadotSigner {
   publicKey: Uint8Array
-  sign: (
+  signTx: (
     callData: Uint8Array,
     signedExtensions: Record<
       string,
@@ -14,4 +14,5 @@ export interface PolkadotSigner {
     atBlockNumber: number,
     hasher?: (data: Uint8Array) => Uint8Array,
   ) => Promise<Uint8Array>
+  signBytes: (data: Uint8Array) => Promise<Uint8Array>
 }

--- a/packages/signers/signer/CHANGELOG.md
+++ b/packages/signers/signer/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Add API to sign arbitrary bytes and rename `sign` to `signTx`
+
 ## 0.0.2 - 2024-07-03
 
 - Update dependencies

--- a/packages/signers/signer/package.json
+++ b/packages/signers/signer/package.json
@@ -36,7 +36,7 @@
   ],
   "scripts": {
     "build": "tsc --noEmit && tsup-node src/index.ts --clean --sourcemap --platform neutral --target=es2020 --format esm,cjs --dts && tsup-node src/index.ts --clean --sourcemap --platform neutral --target=es2020 --format cjs --dts --minify --out-dir dist/min",
-    "test": "echo 'no tests'",
+    "test": "vitest",
     "lint": "tsc --noEmit && prettier --check README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
     "format": "prettier --write README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
     "prepack": "pnpm run build"
@@ -45,5 +45,8 @@
     "@polkadot-api/polkadot-signer": "workspace:*",
     "@polkadot-api/substrate-bindings": "workspace:*",
     "@polkadot-api/utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@noble/curves": "^1.2.0"
   }
 }

--- a/packages/signers/signer/src/index.ts
+++ b/packages/signers/signer/src/index.ts
@@ -1,1 +1,2 @@
+export type { PolkadotSigner } from "@polkadot-api/polkadot-signer"
 export * from "./from-raw-signer"

--- a/packages/signers/signer/tests/signBytes.spec.ts
+++ b/packages/signers/signer/tests/signBytes.spec.ts
@@ -1,0 +1,35 @@
+import { expect, describe, it } from "vitest"
+import { getPolkadotSigner } from "@/from-raw-signer"
+import { fromHex, toHex } from "@polkadot-api/utils"
+import { ed25519 } from "@noble/curves/ed25519"
+import { Binary } from "@polkadot-api/substrate-bindings"
+
+const aliceEd25519PrivKey = fromHex(
+  "0xabf8e5bdbe30c65656c0a3cbd181ff8a56294a69dfedd27982aace4a76909115",
+)
+
+const signer = getPolkadotSigner(
+  ed25519.getPublicKey(aliceEd25519PrivKey),
+  "Ed25519",
+  (input) => ed25519.sign(input, aliceEd25519PrivKey),
+)
+
+describe("signBytes", () => {
+  it("provides the same signature for padded/unpadded", async () => {
+    const unpadded = Binary.fromText("hello world").asBytes()
+    const padded = Binary.fromText("<Bytes>hello world</Bytes>").asBytes()
+
+    expect(toHex(await signer.signBytes(unpadded))).toBe(
+      toHex(await signer.signBytes(padded)),
+    )
+  })
+
+  it("provides the same signature for empty padded/unpadded", async () => {
+    const unpadded = Binary.fromText("").asBytes()
+    const padded = Binary.fromText("<Bytes></Bytes>").asBytes()
+
+    expect(toHex(await signer.signBytes(unpadded))).toBe(
+      toHex(await signer.signBytes(padded)),
+    )
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -521,6 +521,10 @@ importers:
       '@polkadot-api/utils':
         specifier: workspace:*
         version: link:../../utils
+    devDependencies:
+      '@noble/curves':
+        specifier: ^1.2.0
+        version: 1.4.0
 
   packages/smoldot:
     dependencies:


### PR DESCRIPTION
When I came up with the `PolkadotSigner` I thought that it was pointless to add a method for just singing raw data, because the `PolkadotSigner` builds on top of a raw-signer... therefore, I thought it was pointless. However, unsurprisingly, the polkadot-js signer that you get OOTB comes with a rather convoluted signer for singing raw data, which is why I decided to add the "raw" signer into this interface so that Polkadot-API users don't have to deal with the leaky abstractions of PJS.