### PR TITLE
fix: adjust descriptor generic variance on typedApi

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `cli`: Commands `add`, `remove` and `update` run codegen by default after finishing [#577](https://github.com/polkadot-api/polkadot-api/pull/577).
 
+### Fixed
+
+- `typedApi` not being assignable to union of multiple chains.
+
 ## 0.11.2 - 2024-07-19
 
 ### Fixed

--- a/packages/client/src/compatibility.ts
+++ b/packages/client/src/compatibility.ts
@@ -20,8 +20,10 @@ import { Observable, combineLatest, filter, firstValueFrom, map } from "rxjs"
 import { ChainDefinition } from "./descriptors"
 
 export class CompatibilityToken<D = unknown> {
+  private constructor() {}
+
   // @ts-ignore
-  private constructor(protected _descriptors: D) {}
+  protected _phantom(value: D) {}
 }
 
 interface CompatibilityTokenApi {


### PR DESCRIPTION
Closes #580

Previously I added the descriptor type all the way down to the CompatibilityToken to make typescript show an error if someone tries to use one token from one chain into the function of another chain. I did this by setting a private property holding the type of the descriptor in the token, and then making the compatibility function only accept tokens with that property with that type. Reducing to a simple playground:

```ts
class Token<D> {
  constructor(protected _val: D) {}
}

type Api<D> = {
  api: {
    getStuff: (runtime: Token<D>) => boolean
  }
  token: Token<D>
}

const n: Api<number> = null as any
const s: Api<string> = null as any

n.api.getStuff(n.token)
// OK

n.api.getStuff(s.token)
// Argument of type 'Token<string>' is not assignable to parameter of type 'Token<number>'
// Type 'string' is not assignable to type 'number'.
```

However, this adds friction to create unions of chain types, as the union of descriptor properties can't be assigned to a concrete one.

```ts
const combined: Api<number | string> = n
// Type 'Api<number>' is not assignable to type 'Api<string | number>'
// Type '(runtime: Token<number>) => boolean' is not assignable to type '(runtime: Token<string | number>) => boolean'.
// Type 'Token<string | number>' is not assignable to type 'Token<number>'
// Type 'string | number' is not assignable to type 'number'.
```

The fix I did here is to change the variance of the type by moving the Descriptor type from a private property into the argument of a private function. In the example above, this makes it so `Token<string | number>` becomes assignable to `Token<number>`, because the function `Token<string | number>` knows about the both of them.

```ts
class Token<D> {
  protected _innerFn(_val: D) {}
}

n.api.getStuff(n.token)
// OK

n.api.getStuff(s.token)
// Argument of type 'Token<string>' is not assignable to parameter of type 'Token<number>'
// Type 'string' is not assignable to type 'number'.

const combined: Api<number | string> = n
// OK
```

However, there's a small problem: this also makes this check not apply when working with unions, and in both ways:

```ts
combined.api.getStuff(n.token)
n.api.getStuff(combined.token)
// Both are OK from TSC, when in theory they are not really safe...
```

