### PR TITLE
build: bump `ws`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -58,7 +58,7 @@
     "tsup": "^8.0.2",
     "typescript": "^5.4.5",
     "write-package": "^7.0.1",
-    "ws": "^8.17.0"
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@polkadot-api/json-rpc-provider": "workspace:*",

--- a/packages/json-rpc/ws-provider/package.json
+++ b/packages/json-rpc/ws-provider/package.json
@@ -40,6 +40,6 @@
   "dependencies": {
     "@polkadot-api/json-rpc-provider": "workspace:*",
     "@polkadot-api/json-rpc-provider-proxy": "workspace:*",
-    "ws": "^8.14.2"
+    "ws": "^8.18.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,7 +262,7 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1
       ws:
-        specifier: ^8.17.0
+        specifier: ^8.18.0
         version: 8.18.0
     devDependencies:
       '@types/ws':
@@ -392,7 +392,7 @@ importers:
         specifier: workspace:*
         version: link:../json-rpc-provider-proxy
       ws:
-        specifier: ^8.14.2
+        specifier: ^8.18.0
         version: 8.18.0
 
   packages/known-chains: {}


### PR DESCRIPTION
There's a `high` (7.5 / 10 CVSS) DoS security vulnerability being reported by dependabot, affecting `ws` verson `>= 8.0.0, < 8.17.1`. That was fixed with version `8.17.1`.

Reference: websockets/ws#2230