### PR TITLE
fix(cli): `papi update` runs codegen two times when called

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Yarn berry immutable installation from a clean install [#598](https://github.com/polkadot-api/polkadot-api/pull/598)
+- `papi update` runs codegen two times when called.
 
 ## 0.7.0 - 2024-07-25
 

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -47,15 +47,13 @@ export async function update(
   const spinner = ora(`Updating`).start()
   await Promise.all(keys.map(updateByKey))
 
-  console.log(`Updating descriptors`)
-  await generate({ config: options.config })
-
-  spinner.stop()
-  console.log(`Updated chain(s) "${keys.join(", ")}"`)
-
   if (!options.skipCodegen) {
-    generate({
+    console.log(`Updating descriptors`)
+    await generate({
       config: options.config,
     })
   }
+
+  spinner.stop()
+  console.log(`Updated chain(s) "${keys.join(", ")}"`)
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `client`: optional arguments logic in `apis` and `query` [#600](https://github.com/polkadot-api/polkadot-api/pull/600)
 - `cli`: Yarn berry immutable installation from a clean install [#598](https://github.com/polkadot-api/polkadot-api/pull/598)
+- `cli`: runs codegen two times when called.
 
 ## 0.12.0 - 2024-07-25
 


### PR DESCRIPTION
🙈 I didn't realise `papi update` was already calling the codegen after updating the metadata.
