### PR TITLE
fix: fixed correct ESM export for React Native.

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -7,6 +7,10 @@
 - `polkadot-api/smoldot/node-worker` to create a smoldot worker in NodeJS.
 - `polkadot-api/smoldot/from-node-worker` to create a client from a node smoldot worker.
 
+### Fixed
+
+- Fixed correct ESM export for React Native.
+
 ## 0.12.1 - 2024-07-30
 
 ### Fixed

--- a/packages/client/chains/ksmcc3/package.json
+++ b/packages/client/chains/ksmcc3/package.json
@@ -3,6 +3,7 @@
   "types": "../../dist/reexports/chains_ksmcc3.d.ts",
   "module": "../../dist/esm/reexports/chains_ksmcc3.mjs",
   "import": "../../dist/esm/reexports/chains_ksmcc3.mjs",
+  "browser": "../../dist/esm/reexports/chains_ksmcc3.mjs",
   "require": "../../dist/reexports/chains_ksmcc3.js",
   "default": "../../dist/reexports/chains_ksmcc3.js"
 }

--- a/packages/client/chains/ksmcc3_asset_hub/package.json
+++ b/packages/client/chains/ksmcc3_asset_hub/package.json
@@ -3,6 +3,7 @@
   "types": "../../dist/reexports/chains_ksmcc3_asset_hub.d.ts",
   "module": "../../dist/esm/reexports/chains_ksmcc3_asset_hub.mjs",
   "import": "../../dist/esm/reexports/chains_ksmcc3_asset_hub.mjs",
+  "browser": "../../dist/esm/reexports/chains_ksmcc3_asset_hub.mjs",
   "require": "../../dist/reexports/chains_ksmcc3_asset_hub.js",
   "default": "../../dist/reexports/chains_ksmcc3_asset_hub.js"
 }

--- a/packages/client/chains/ksmcc3_bridge_hub/package.json
+++ b/packages/client/chains/ksmcc3_bridge_hub/package.json
@@ -3,6 +3,7 @@
   "types": "../../dist/reexports/chains_ksmcc3_bridge_hub.d.ts",
   "module": "../../dist/esm/reexports/chains_ksmcc3_bridge_hub.mjs",
   "import": "../../dist/esm/reexports/chains_ksmcc3_bridge_hub.mjs",
+  "browser": "../../dist/esm/reexports/chains_ksmcc3_bridge_hub.mjs",
   "require": "../../dist/reexports/chains_ksmcc3_bridge_hub.js",
   "default": "../../dist/reexports/chains_ksmcc3_bridge_hub.js"
 }

--- a/packages/client/chains/package.json
+++ b/packages/client/chains/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/reexports/chains.d.ts",
   "module": "../dist/esm/reexports/chains.mjs",
   "import": "../dist/esm/reexports/chains.mjs",
+  "browser": "../dist/esm/reexports/chains.mjs",
   "require": "../dist/reexports/chains.js",
   "default": "../dist/reexports/chains.js"
 }

--- a/packages/client/chains/paseo/package.json
+++ b/packages/client/chains/paseo/package.json
@@ -3,6 +3,7 @@
   "types": "../../dist/reexports/chains_paseo.d.ts",
   "module": "../../dist/esm/reexports/chains_paseo.mjs",
   "import": "../../dist/esm/reexports/chains_paseo.mjs",
+  "browser": "../../dist/esm/reexports/chains_paseo.mjs",
   "require": "../../dist/reexports/chains_paseo.js",
   "default": "../../dist/reexports/chains_paseo.js"
 }

--- a/packages/client/chains/paseo_asset_hub/package.json
+++ b/packages/client/chains/paseo_asset_hub/package.json
@@ -3,6 +3,7 @@
   "types": "../../dist/reexports/chains_paseo_asset_hub.d.ts",
   "module": "../../dist/esm/reexports/chains_paseo_asset_hub.mjs",
   "import": "../../dist/esm/reexports/chains_paseo_asset_hub.mjs",
+  "browser": "../../dist/esm/reexports/chains_paseo_asset_hub.mjs",
   "require": "../../dist/reexports/chains_paseo_asset_hub.js",
   "default": "../../dist/reexports/chains_paseo_asset_hub.js"
 }

--- a/packages/client/chains/polkadot/package.json
+++ b/packages/client/chains/polkadot/package.json
@@ -3,6 +3,7 @@
   "types": "../../dist/reexports/chains_polkadot.d.ts",
   "module": "../../dist/esm/reexports/chains_polkadot.mjs",
   "import": "../../dist/esm/reexports/chains_polkadot.mjs",
+  "browser": "../../dist/esm/reexports/chains_polkadot.mjs",
   "require": "../../dist/reexports/chains_polkadot.js",
   "default": "../../dist/reexports/chains_polkadot.js"
 }

--- a/packages/client/chains/polkadot_asset_hub/package.json
+++ b/packages/client/chains/polkadot_asset_hub/package.json
@@ -3,6 +3,7 @@
   "types": "../../dist/reexports/chains_polkadot_asset_hub.d.ts",
   "module": "../../dist/esm/reexports/chains_polkadot_asset_hub.mjs",
   "import": "../../dist/esm/reexports/chains_polkadot_asset_hub.mjs",
+  "browser": "../../dist/esm/reexports/chains_polkadot_asset_hub.mjs",
   "require": "../../dist/reexports/chains_polkadot_asset_hub.js",
   "default": "../../dist/reexports/chains_polkadot_asset_hub.js"
 }

--- a/packages/client/chains/polkadot_bridge_hub/package.json
+++ b/packages/client/chains/polkadot_bridge_hub/package.json
@@ -3,6 +3,7 @@
   "types": "../../dist/reexports/chains_polkadot_bridge_hub.d.ts",
   "module": "../../dist/esm/reexports/chains_polkadot_bridge_hub.mjs",
   "import": "../../dist/esm/reexports/chains_polkadot_bridge_hub.mjs",
+  "browser": "../../dist/esm/reexports/chains_polkadot_bridge_hub.mjs",
   "require": "../../dist/reexports/chains_polkadot_bridge_hub.js",
   "default": "../../dist/reexports/chains_polkadot_bridge_hub.js"
 }

--- a/packages/client/chains/polkadot_collectives/package.json
+++ b/packages/client/chains/polkadot_collectives/package.json
@@ -3,6 +3,7 @@
   "types": "../../dist/reexports/chains_polkadot_collectives.d.ts",
   "module": "../../dist/esm/reexports/chains_polkadot_collectives.mjs",
   "import": "../../dist/esm/reexports/chains_polkadot_collectives.mjs",
+  "browser": "../../dist/esm/reexports/chains_polkadot_collectives.mjs",
   "require": "../../dist/reexports/chains_polkadot_collectives.js",
   "default": "../../dist/reexports/chains_polkadot_collectives.js"
 }

--- a/packages/client/chains/polkadot_people/package.json
+++ b/packages/client/chains/polkadot_people/package.json
@@ -3,6 +3,7 @@
   "types": "../../dist/reexports/chains_polkadot_people.d.ts",
   "module": "../../dist/esm/reexports/chains_polkadot_people.mjs",
   "import": "../../dist/esm/reexports/chains_polkadot_people.mjs",
+  "browser": "../../dist/esm/reexports/chains_polkadot_people.mjs",
   "require": "../../dist/reexports/chains_polkadot_people.js",
   "default": "../../dist/reexports/chains_polkadot_people.js"
 }

--- a/packages/client/chains/rococo_v2_2/package.json
+++ b/packages/client/chains/rococo_v2_2/package.json
@@ -3,6 +3,7 @@
   "types": "../../dist/reexports/chains_rococo_v2_2.d.ts",
   "module": "../../dist/esm/reexports/chains_rococo_v2_2.mjs",
   "import": "../../dist/esm/reexports/chains_rococo_v2_2.mjs",
+  "browser": "../../dist/esm/reexports/chains_rococo_v2_2.mjs",
   "require": "../../dist/reexports/chains_rococo_v2_2.js",
   "default": "../../dist/reexports/chains_rococo_v2_2.js"
 }

--- a/packages/client/chains/rococo_v2_2_asset_hub/package.json
+++ b/packages/client/chains/rococo_v2_2_asset_hub/package.json
@@ -3,6 +3,7 @@
   "types": "../../dist/reexports/chains_rococo_v2_2_asset_hub.d.ts",
   "module": "../../dist/esm/reexports/chains_rococo_v2_2_asset_hub.mjs",
   "import": "../../dist/esm/reexports/chains_rococo_v2_2_asset_hub.mjs",
+  "browser": "../../dist/esm/reexports/chains_rococo_v2_2_asset_hub.mjs",
   "require": "../../dist/reexports/chains_rococo_v2_2_asset_hub.js",
   "default": "../../dist/reexports/chains_rococo_v2_2_asset_hub.js"
 }

--- a/packages/client/chains/rococo_v2_2_bridge_hub/package.json
+++ b/packages/client/chains/rococo_v2_2_bridge_hub/package.json
@@ -3,6 +3,7 @@
   "types": "../../dist/reexports/chains_rococo_v2_2_bridge_hub.d.ts",
   "module": "../../dist/esm/reexports/chains_rococo_v2_2_bridge_hub.mjs",
   "import": "../../dist/esm/reexports/chains_rococo_v2_2_bridge_hub.mjs",
+  "browser": "../../dist/esm/reexports/chains_rococo_v2_2_bridge_hub.mjs",
   "require": "../../dist/reexports/chains_rococo_v2_2_bridge_hub.js",
   "default": "../../dist/reexports/chains_rococo_v2_2_bridge_hub.js"
 }

--- a/packages/client/chains/westend2/package.json
+++ b/packages/client/chains/westend2/package.json
@@ -3,6 +3,7 @@
   "types": "../../dist/reexports/chains_westend2.d.ts",
   "module": "../../dist/esm/reexports/chains_westend2.mjs",
   "import": "../../dist/esm/reexports/chains_westend2.mjs",
+  "browser": "../../dist/esm/reexports/chains_westend2.mjs",
   "require": "../../dist/reexports/chains_westend2.js",
   "default": "../../dist/reexports/chains_westend2.js"
 }

--- a/packages/client/chains/westend2_asset_hub/package.json
+++ b/packages/client/chains/westend2_asset_hub/package.json
@@ -3,6 +3,7 @@
   "types": "../../dist/reexports/chains_westend2_asset_hub.d.ts",
   "module": "../../dist/esm/reexports/chains_westend2_asset_hub.mjs",
   "import": "../../dist/esm/reexports/chains_westend2_asset_hub.mjs",
+  "browser": "../../dist/esm/reexports/chains_westend2_asset_hub.mjs",
   "require": "../../dist/reexports/chains_westend2_asset_hub.js",
   "default": "../../dist/reexports/chains_westend2_asset_hub.js"
 }

--- a/packages/client/chains/westend2_bridge_hub/package.json
+++ b/packages/client/chains/westend2_bridge_hub/package.json
@@ -3,6 +3,7 @@
   "types": "../../dist/reexports/chains_westend2_bridge_hub.d.ts",
   "module": "../../dist/esm/reexports/chains_westend2_bridge_hub.mjs",
   "import": "../../dist/esm/reexports/chains_westend2_bridge_hub.mjs",
+  "browser": "../../dist/esm/reexports/chains_westend2_bridge_hub.mjs",
   "require": "../../dist/reexports/chains_westend2_bridge_hub.js",
   "default": "../../dist/reexports/chains_westend2_bridge_hub.js"
 }

--- a/packages/client/chains/westend2_collectives/package.json
+++ b/packages/client/chains/westend2_collectives/package.json
@@ -3,6 +3,7 @@
   "types": "../../dist/reexports/chains_westend2_collectives.d.ts",
   "module": "../../dist/esm/reexports/chains_westend2_collectives.mjs",
   "import": "../../dist/esm/reexports/chains_westend2_collectives.mjs",
+  "browser": "../../dist/esm/reexports/chains_westend2_collectives.mjs",
   "require": "../../dist/reexports/chains_westend2_collectives.js",
   "default": "../../dist/reexports/chains_westend2_collectives.js"
 }

--- a/packages/client/logs-provider/package.json
+++ b/packages/client/logs-provider/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/reexports/logs-provider.d.ts",
   "module": "../dist/esm/reexports/logs-provider.mjs",
   "import": "../dist/esm/reexports/logs-provider.mjs",
+  "browser": "../dist/esm/reexports/logs-provider.mjs",
   "require": "../dist/reexports/logs-provider.js",
   "default": "../dist/reexports/logs-provider.js"
 }

--- a/packages/client/pjs-signer/package.json
+++ b/packages/client/pjs-signer/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/reexports/pjs-signer.d.ts",
   "module": "../dist/esm/reexports/pjs-signer.mjs",
   "import": "../dist/esm/reexports/pjs-signer.mjs",
+  "browser": "../dist/esm/reexports/pjs-signer.mjs",
   "require": "../dist/reexports/pjs-signer.js",
   "default": "../dist/reexports/pjs-signer.js"
 }

--- a/packages/client/polkadot-sdk-compat/package.json
+++ b/packages/client/polkadot-sdk-compat/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/reexports/polkadot-sdk-compat.d.ts",
   "module": "../dist/esm/reexports/polkadot-sdk-compat.mjs",
   "import": "../dist/esm/reexports/polkadot-sdk-compat.mjs",
+  "browser": "../dist/esm/reexports/polkadot-sdk-compat.mjs",
   "require": "../dist/reexports/polkadot-sdk-compat.js",
   "default": "../dist/reexports/polkadot-sdk-compat.js"
 }

--- a/packages/client/signer/package.json
+++ b/packages/client/signer/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/reexports/signer.d.ts",
   "module": "../dist/esm/reexports/signer.mjs",
   "import": "../dist/esm/reexports/signer.mjs",
+  "browser": "../dist/esm/reexports/signer.mjs",
   "require": "../dist/reexports/signer.js",
   "default": "../dist/reexports/signer.js"
 }

--- a/packages/client/sm-provider/package.json
+++ b/packages/client/sm-provider/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/reexports/sm-provider.d.ts",
   "module": "../dist/esm/reexports/sm-provider.mjs",
   "import": "../dist/esm/reexports/sm-provider.mjs",
+  "browser": "../dist/esm/reexports/sm-provider.mjs",
   "require": "../dist/reexports/sm-provider.js",
   "default": "../dist/reexports/sm-provider.js"
 }

--- a/packages/client/smoldot/from-node-worker/package.json
+++ b/packages/client/smoldot/from-node-worker/package.json
@@ -3,6 +3,7 @@
   "types": "../../dist/reexports/smoldot_from-node-worker.d.ts",
   "module": "../../dist/esm/reexports/smoldot_from-node-worker.mjs",
   "import": "../../dist/esm/reexports/smoldot_from-node-worker.mjs",
+  "browser": "../../dist/esm/reexports/smoldot_from-node-worker.mjs",
   "require": "../../dist/reexports/smoldot_from-node-worker.js",
   "default": "../../dist/reexports/smoldot_from-node-worker.js"
 }

--- a/packages/client/smoldot/from-worker/package.json
+++ b/packages/client/smoldot/from-worker/package.json
@@ -3,6 +3,7 @@
   "types": "../../dist/reexports/smoldot_from-worker.d.ts",
   "module": "../../dist/esm/reexports/smoldot_from-worker.mjs",
   "import": "../../dist/esm/reexports/smoldot_from-worker.mjs",
+  "browser": "../../dist/esm/reexports/smoldot_from-worker.mjs",
   "require": "../../dist/reexports/smoldot_from-worker.js",
   "default": "../../dist/reexports/smoldot_from-worker.js"
 }

--- a/packages/client/smoldot/node-worker/package.json
+++ b/packages/client/smoldot/node-worker/package.json
@@ -3,6 +3,7 @@
   "types": "../../dist/reexports/smoldot_node-worker.d.ts",
   "module": "../../dist/esm/reexports/smoldot_node-worker.mjs",
   "import": "../../dist/esm/reexports/smoldot_node-worker.mjs",
+  "browser": "../../dist/esm/reexports/smoldot_node-worker.mjs",
   "require": "../../dist/reexports/smoldot_node-worker.js",
   "default": "../../dist/reexports/smoldot_node-worker.js"
 }

--- a/packages/client/smoldot/package.json
+++ b/packages/client/smoldot/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/reexports/smoldot.d.ts",
   "module": "../dist/esm/reexports/smoldot.mjs",
   "import": "../dist/esm/reexports/smoldot.mjs",
+  "browser": "../dist/esm/reexports/smoldot.mjs",
   "require": "../dist/reexports/smoldot.js",
   "default": "../dist/reexports/smoldot.js"
 }

--- a/packages/client/smoldot/worker/package.json
+++ b/packages/client/smoldot/worker/package.json
@@ -3,6 +3,7 @@
   "types": "../../dist/reexports/smoldot_worker.d.ts",
   "module": "../../dist/esm/reexports/smoldot_worker.mjs",
   "import": "../../dist/esm/reexports/smoldot_worker.mjs",
+  "browser": "../../dist/esm/reexports/smoldot_worker.mjs",
   "require": "../../dist/reexports/smoldot_worker.js",
   "default": "../../dist/reexports/smoldot_worker.js"
 }

--- a/packages/client/src/reexports/polkadot-sdk-compat.ts
+++ b/packages/client/src/reexports/polkadot-sdk-compat.ts
@@ -1,1 +1,2 @@
 export * from "@polkadot-api/polkadot-sdk-compat"
+export { default } from "@polkadot-api/polkadot-sdk-compat"

--- a/packages/client/src/reexports/polkadot-sdk-compat.ts
+++ b/packages/client/src/reexports/polkadot-sdk-compat.ts
@@ -1,2 +1,1 @@
 export * from "@polkadot-api/polkadot-sdk-compat"
-export { default } from "@polkadot-api/polkadot-sdk-compat"

--- a/packages/client/sync-packages.mjs
+++ b/packages/client/sync-packages.mjs
@@ -67,6 +67,7 @@ for (const [packageName, source] of reexports) {
         types: `${toRoot}/dist/reexports/${fileName}.d.ts`,
         module: `${toRoot}/dist/esm/reexports/${fileName}.mjs`,
         import: `${toRoot}/dist/esm/reexports/${fileName}.mjs`,
+        browser: `${toRoot}/dist/esm/reexports/${fileName}.mjs`,
         require: `${toRoot}/dist/reexports/${fileName}.js`,
         default: `${toRoot}/dist/reexports/${fileName}.js`,
       },

--- a/packages/client/utils/package.json
+++ b/packages/client/utils/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/reexports/utils.d.ts",
   "module": "../dist/esm/reexports/utils.mjs",
   "import": "../dist/esm/reexports/utils.mjs",
+  "browser": "../dist/esm/reexports/utils.mjs",
   "require": "../dist/reexports/utils.js",
   "default": "../dist/reexports/utils.js"
 }

--- a/packages/client/ws-provider/node/package.json
+++ b/packages/client/ws-provider/node/package.json
@@ -3,6 +3,7 @@
   "types": "../../dist/reexports/ws-provider_node.d.ts",
   "module": "../../dist/esm/reexports/ws-provider_node.mjs",
   "import": "../../dist/esm/reexports/ws-provider_node.mjs",
+  "browser": "../../dist/esm/reexports/ws-provider_node.mjs",
   "require": "../../dist/reexports/ws-provider_node.js",
   "default": "../../dist/reexports/ws-provider_node.js"
 }

--- a/packages/client/ws-provider/web/package.json
+++ b/packages/client/ws-provider/web/package.json
@@ -3,6 +3,7 @@
   "types": "../../dist/reexports/ws-provider_web.d.ts",
   "module": "../../dist/esm/reexports/ws-provider_web.mjs",
   "import": "../../dist/esm/reexports/ws-provider_web.mjs",
+  "browser": "../../dist/esm/reexports/ws-provider_web.mjs",
   "require": "../../dist/reexports/ws-provider_web.js",
   "default": "../../dist/reexports/ws-provider_web.js"
 }

--- a/packages/json-rpc/ws-provider/CHANGELOG.md
+++ b/packages/json-rpc/ws-provider/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed correct ESM export for React Native.
+
 ## 0.1.1 - 2024-07-18
 
 ### Fixed

--- a/packages/json-rpc/ws-provider/node/package.json
+++ b/packages/json-rpc/ws-provider/node/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/node/node.d.ts",
   "module": "../dist/node/esm/node.mjs",
   "import": "../dist/node/esm/node.mjs",
+  "browser": "../dist/node/esm/node.mjs",
   "require": "../dist/node/node.js",
   "default": "../dist/node/node.js",
   "sideEffects": false

--- a/packages/json-rpc/ws-provider/web/package.json
+++ b/packages/json-rpc/ws-provider/web/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/web/web.d.ts",
   "module": "../dist/web/esm/web.mjs",
   "import": "../dist/web/esm/web.mjs",
+  "browser": "../dist/web/esm/web.mjs",
   "require": "../dist/web/web.js",
   "default": "../dist/web/web.js",
   "sideEffects": false

--- a/packages/known-chains/CHANGELOG.md
+++ b/packages/known-chains/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed correct ESM export for React Native.
+
 ## 0.3.0 - 2024-07-25
 
 ### Added

--- a/packages/known-chains/ksmcc3/package.json
+++ b/packages/known-chains/ksmcc3/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/specs/ksmcc3.d.ts",
   "module": "../dist/specs/ksmcc3.mjs",
   "import": "../dist/specs/ksmcc3.mjs",
+  "browser": "../dist/specs/ksmcc3.mjs",
   "require": "../dist/specs/ksmcc3.js",
   "default": "../dist/specs/ksmcc3.js"
 }

--- a/packages/known-chains/ksmcc3_asset_hub/package.json
+++ b/packages/known-chains/ksmcc3_asset_hub/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/specs/ksmcc3_asset_hub.d.ts",
   "module": "../dist/specs/ksmcc3_asset_hub.mjs",
   "import": "../dist/specs/ksmcc3_asset_hub.mjs",
+  "browser": "../dist/specs/ksmcc3_asset_hub.mjs",
   "require": "../dist/specs/ksmcc3_asset_hub.js",
   "default": "../dist/specs/ksmcc3_asset_hub.js"
 }

--- a/packages/known-chains/ksmcc3_bridge_hub/package.json
+++ b/packages/known-chains/ksmcc3_bridge_hub/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/specs/ksmcc3_bridge_hub.d.ts",
   "module": "../dist/specs/ksmcc3_bridge_hub.mjs",
   "import": "../dist/specs/ksmcc3_bridge_hub.mjs",
+  "browser": "../dist/specs/ksmcc3_bridge_hub.mjs",
   "require": "../dist/specs/ksmcc3_bridge_hub.js",
   "default": "../dist/specs/ksmcc3_bridge_hub.js"
 }

--- a/packages/known-chains/paseo/package.json
+++ b/packages/known-chains/paseo/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/specs/paseo.d.ts",
   "module": "../dist/specs/paseo.mjs",
   "import": "../dist/specs/paseo.mjs",
+  "browser": "../dist/specs/paseo.mjs",
   "require": "../dist/specs/paseo.js",
   "default": "../dist/specs/paseo.js"
 }

--- a/packages/known-chains/paseo_asset_hub/package.json
+++ b/packages/known-chains/paseo_asset_hub/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/specs/paseo_asset_hub.d.ts",
   "module": "../dist/specs/paseo_asset_hub.mjs",
   "import": "../dist/specs/paseo_asset_hub.mjs",
+  "browser": "../dist/specs/paseo_asset_hub.mjs",
   "require": "../dist/specs/paseo_asset_hub.js",
   "default": "../dist/specs/paseo_asset_hub.js"
 }

--- a/packages/known-chains/polkadot/package.json
+++ b/packages/known-chains/polkadot/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/specs/polkadot.d.ts",
   "module": "../dist/specs/polkadot.mjs",
   "import": "../dist/specs/polkadot.mjs",
+  "browser": "../dist/specs/polkadot.mjs",
   "require": "../dist/specs/polkadot.js",
   "default": "../dist/specs/polkadot.js"
 }

--- a/packages/known-chains/polkadot_asset_hub/package.json
+++ b/packages/known-chains/polkadot_asset_hub/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/specs/polkadot_asset_hub.d.ts",
   "module": "../dist/specs/polkadot_asset_hub.mjs",
   "import": "../dist/specs/polkadot_asset_hub.mjs",
+  "browser": "../dist/specs/polkadot_asset_hub.mjs",
   "require": "../dist/specs/polkadot_asset_hub.js",
   "default": "../dist/specs/polkadot_asset_hub.js"
 }

--- a/packages/known-chains/polkadot_bridge_hub/package.json
+++ b/packages/known-chains/polkadot_bridge_hub/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/specs/polkadot_bridge_hub.d.ts",
   "module": "../dist/specs/polkadot_bridge_hub.mjs",
   "import": "../dist/specs/polkadot_bridge_hub.mjs",
+  "browser": "../dist/specs/polkadot_bridge_hub.mjs",
   "require": "../dist/specs/polkadot_bridge_hub.js",
   "default": "../dist/specs/polkadot_bridge_hub.js"
 }

--- a/packages/known-chains/polkadot_collectives/package.json
+++ b/packages/known-chains/polkadot_collectives/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/specs/polkadot_collectives.d.ts",
   "module": "../dist/specs/polkadot_collectives.mjs",
   "import": "../dist/specs/polkadot_collectives.mjs",
+  "browser": "../dist/specs/polkadot_collectives.mjs",
   "require": "../dist/specs/polkadot_collectives.js",
   "default": "../dist/specs/polkadot_collectives.js"
 }

--- a/packages/known-chains/polkadot_people/package.json
+++ b/packages/known-chains/polkadot_people/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/specs/polkadot_people.d.ts",
   "module": "../dist/specs/polkadot_people.mjs",
   "import": "../dist/specs/polkadot_people.mjs",
+  "browser": "../dist/specs/polkadot_people.mjs",
   "require": "../dist/specs/polkadot_people.js",
   "default": "../dist/specs/polkadot_people.js"
 }

--- a/packages/known-chains/rococo_v2_2/package.json
+++ b/packages/known-chains/rococo_v2_2/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/specs/rococo_v2_2.d.ts",
   "module": "../dist/specs/rococo_v2_2.mjs",
   "import": "../dist/specs/rococo_v2_2.mjs",
+  "browser": "../dist/specs/rococo_v2_2.mjs",
   "require": "../dist/specs/rococo_v2_2.js",
   "default": "../dist/specs/rococo_v2_2.js"
 }

--- a/packages/known-chains/rococo_v2_2_asset_hub/package.json
+++ b/packages/known-chains/rococo_v2_2_asset_hub/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/specs/rococo_v2_2_asset_hub.d.ts",
   "module": "../dist/specs/rococo_v2_2_asset_hub.mjs",
   "import": "../dist/specs/rococo_v2_2_asset_hub.mjs",
+  "browser": "../dist/specs/rococo_v2_2_asset_hub.mjs",
   "require": "../dist/specs/rococo_v2_2_asset_hub.js",
   "default": "../dist/specs/rococo_v2_2_asset_hub.js"
 }

--- a/packages/known-chains/rococo_v2_2_bridge_hub/package.json
+++ b/packages/known-chains/rococo_v2_2_bridge_hub/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/specs/rococo_v2_2_bridge_hub.d.ts",
   "module": "../dist/specs/rococo_v2_2_bridge_hub.mjs",
   "import": "../dist/specs/rococo_v2_2_bridge_hub.mjs",
+  "browser": "../dist/specs/rococo_v2_2_bridge_hub.mjs",
   "require": "../dist/specs/rococo_v2_2_bridge_hub.js",
   "default": "../dist/specs/rococo_v2_2_bridge_hub.js"
 }

--- a/packages/known-chains/sync-packages.mjs
+++ b/packages/known-chains/sync-packages.mjs
@@ -36,6 +36,7 @@ for (const filename of specFiles) {
         types: `../dist/specs/${packageName}.d.ts`,
         module: `../dist/specs/${packageName}.mjs`,
         import: `../dist/specs/${packageName}.mjs`,
+        browser: `../dist/specs/${packageName}.mjs`,
         require: `../dist/specs/${packageName}.js`,
         default: `../dist/specs/${packageName}.js`,
       },

--- a/packages/known-chains/westend2/package.json
+++ b/packages/known-chains/westend2/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/specs/westend2.d.ts",
   "module": "../dist/specs/westend2.mjs",
   "import": "../dist/specs/westend2.mjs",
+  "browser": "../dist/specs/westend2.mjs",
   "require": "../dist/specs/westend2.js",
   "default": "../dist/specs/westend2.js"
 }

--- a/packages/known-chains/westend2_asset_hub/package.json
+++ b/packages/known-chains/westend2_asset_hub/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/specs/westend2_asset_hub.d.ts",
   "module": "../dist/specs/westend2_asset_hub.mjs",
   "import": "../dist/specs/westend2_asset_hub.mjs",
+  "browser": "../dist/specs/westend2_asset_hub.mjs",
   "require": "../dist/specs/westend2_asset_hub.js",
   "default": "../dist/specs/westend2_asset_hub.js"
 }

--- a/packages/known-chains/westend2_bridge_hub/package.json
+++ b/packages/known-chains/westend2_bridge_hub/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/specs/westend2_bridge_hub.d.ts",
   "module": "../dist/specs/westend2_bridge_hub.mjs",
   "import": "../dist/specs/westend2_bridge_hub.mjs",
+  "browser": "../dist/specs/westend2_bridge_hub.mjs",
   "require": "../dist/specs/westend2_bridge_hub.js",
   "default": "../dist/specs/westend2_bridge_hub.js"
 }

--- a/packages/known-chains/westend2_collectives/package.json
+++ b/packages/known-chains/westend2_collectives/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/specs/westend2_collectives.d.ts",
   "module": "../dist/specs/westend2_collectives.mjs",
   "import": "../dist/specs/westend2_collectives.mjs",
+  "browser": "../dist/specs/westend2_collectives.mjs",
   "require": "../dist/specs/westend2_collectives.js",
   "default": "../dist/specs/westend2_collectives.js"
 }

--- a/packages/smoldot/CHANGELOG.md
+++ b/packages/smoldot/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Added `@polkadot-api/smoldot/node-worker` to create a smoldot worker in NodeJS.
 - Added `@polkadot-api/smoldot/from-node-worker` to create a client from a node smoldot worker.
 
+### Fixed
+
+- Fixed correct ESM build path.
+
 ## 0.2.7 - 2024-07-25
 
 ### Fixed

--- a/packages/smoldot/from-node-worker/package.json
+++ b/packages/smoldot/from-node-worker/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/from-node-worker/from-node-worker.d.ts",
   "module": "../dist/from-node-worker/esm/from-node-worker.mjs",
   "import": "../dist/from-node-worker/esm/from-node-worker.mjs",
+  "browser": "../dist/node-worker/esm/node-worker.mjs",
   "require": "../dist/from-node-worker/from-node-worker.js",
   "default": "../dist/from-node-worker/from-node-worker.js"
 }

--- a/packages/smoldot/from-worker/package.json
+++ b/packages/smoldot/from-worker/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/from-worker/from-worker.d.ts",
   "module": "../dist/from-worker/esm/from-worker.mjs",
   "import": "../dist/from-worker/esm/from-worker.mjs",
+  "browser": "../dist/node-worker/esm/node-worker.mjs",
   "require": "../dist/from-worker/from-worker.js",
   "default": "../dist/from-worker/from-worker.js"
 }

--- a/packages/smoldot/node-worker/package.json
+++ b/packages/smoldot/node-worker/package.json
@@ -3,6 +3,7 @@
   "types": "../dist/node-worker/node-worker.d.ts",
   "module": "../dist/node-worker/esm/node-worker.mjs",
   "import": "../dist/node-worker/esm/node-worker.mjs",
+  "browser": "../dist/node-worker/esm/node-worker.mjs",
   "require": "../dist/node-worker/node-worker.js",
   "default": "../dist/node-worker/node-worker.js"
 }

--- a/packages/smoldot/package.json
+++ b/packages/smoldot/package.json
@@ -66,8 +66,8 @@
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
-  "browser": "./dist/index.mjs",
+  "module": "./dist/esm/index.mjs",
+  "browser": "./dist/esm/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",


### PR DESCRIPTION
React native's metro bundler uses the `browser` key for ESM, we were missing that on the subpaths' package.json, so it was defaulting to a non-existent index.mjs file.

Smoldot's top-level package.json module and browser keys were also pointing at a wrong path.