### PR TITLE
fix(codegen): descriptors entry points when transaction and events have the same checksum

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Descriptors entry points when transaction and events have the same checksum.
 - Update provider dependencies
 
 ## 0.7.1 - 2024-07-30

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- Descriptors entry points when transaction and events have the same checksum.
 - Fixed correct ESM export for React Native.
 
 ## 0.12.1 - 2024-07-30

--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Descriptors entry points when transaction and events have the same checksum.
+
 ## 0.7.2 - 2024-07-25
 
 ### Fixed

--- a/packages/metadata-builders/CHANGELOG.md
+++ b/packages/metadata-builders/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Checksum collision between transaction calls and events.
+
 ## 0.4.1 - 2024-07-25
 
 ### Fixed

--- a/packages/metadata-builders/src/checksum-builder.ts
+++ b/packages/metadata-builders/src/checksum-builder.ts
@@ -440,6 +440,11 @@ export const getChecksumBuilder = (getLookupEntryDef: MetadataLookup) => {
     )
   }
 
+  const variantShapeId = {
+    errors: 1n,
+    events: 2n,
+    calls: 3n,
+  }
   const buildVariant =
     (variantType: "errors" | "events" | "calls") =>
     (pallet: string, name: string): bigint | null => {
@@ -452,9 +457,11 @@ export const getChecksumBuilder = (getLookupEntryDef: MetadataLookup) => {
 
         if (enumLookup.type !== "enum") throw null
         const entry = enumLookup.value[name]
-        return entry.type === "lookupEntry"
-          ? buildDefinition(entry.value.id)
-          : buildComposite(entry)
+        const valueChecksum =
+          entry.type === "lookupEntry"
+            ? buildDefinition(entry.value.id)
+            : buildComposite(entry)
+        return getChecksum([variantShapeId[variantType], valueChecksum])
       } catch (_) {
         return null
       }

--- a/packages/metadata-builders/tests/__snapshots__/checksum-builder.spec.ts.snap
+++ b/packages/metadata-builders/tests/__snapshots__/checksum-builder.spec.ts.snap
@@ -1,5 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`getChecksumBuilder snapshots > batched call 1`] = `"f1hqd3rvmlrub"`;
+exports[`getChecksumBuilder snapshots > batched call 1`] = `"1blpvugq0msvs"`;
 
-exports[`getChecksumBuilder snapshots > felloship referenda submit 1`] = `"2c5jbfdqmbppc"`;
+exports[`getChecksumBuilder snapshots > felloship referenda submit 1`] = `"k5hf68er6u36"`;

--- a/packages/metadata-compatibility/CHANGELOG.md
+++ b/packages/metadata-compatibility/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.1.1 - 2024-07-25
 
 ### Fixed

--- a/packages/observable-client/CHANGELOG.md
+++ b/packages/observable-client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.5.0 - 2024-07-25
 
 ### Added

--- a/packages/signers/pjs-signer/CHANGELOG.md
+++ b/packages/signers/pjs-signer/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.3.2 - 2024-07-25
 
 ### Fixed

--- a/packages/view-builder/CHANGELOG.md
+++ b/packages/view-builder/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.3.1 - 2024-07-25
 
 ### Fixed


### PR DESCRIPTION
Found and raised by @ggwpez, on some cases there are events that have the same checksum as calls.

For example, the polkadot people chain has checksum `666bl2fqjkejo` for `AmbassadorReferenda.refund_decision_deposit` call, but also for the event `AmbassadorReferenda.ConfirmStarted`. This is because `refund_decision_deposit` only takes `{ index: u32 }` and `ConfirmStarted`'s payload is also `{ index: u32 }`.

Our codegen + compatibility assumes every interaction with the same checksum could be merged into the same descriptor entry point, but that was not the case, since transactions have them through `args` (i.e. they are values being sent) and events have them through `values` (i.e. they are being received). So in runtime the compatibility check failed because the entry points were incompatible.

This solves it by making each of the `buildCall`, `buildEvent` and `buildError` have distinct checksums even if the underlying data is the same.