### PR TITLE
fix(json-rpc): potential dead loop from restarting on halt

### DIFF
--- a/packages/json-rpc/sm-provider/src/sm-provider.ts
+++ b/packages/json-rpc/sm-provider/src/sm-provider.ts
@@ -1,6 +1,12 @@
-import type { Chain } from "smoldot"
 import type { JsonRpcProvider } from "@polkadot-api/json-rpc-provider"
 import { getSyncProvider } from "@polkadot-api/json-rpc-provider-proxy"
+import {
+  type Chain,
+  AddChainError,
+  AlreadyDestroyedError,
+  CrashError,
+  JsonRpcDisabledError,
+} from "smoldot"
 
 let pending: Promise<Chain> | null
 
@@ -22,8 +28,17 @@ export const getSmProvider = (chain: Chain | Promise<Chain>): JsonRpcProvider =>
           let message = ""
           try {
             message = await resolvedChain.nextJsonRpcResponse()
-          } catch (e) {
-            if (listening) onError()
+          } catch (error) {
+            if (listening)
+              onError({
+                recoverable: !(
+                  error instanceof AddChainError ||
+                  error instanceof AlreadyDestroyedError ||
+                  error instanceof CrashError ||
+                  error instanceof JsonRpcDisabledError
+                ),
+              })
+
             return
           }
           if (!listening) break

--- a/packages/json-rpc/ws-provider/src/ws-provider.ts
+++ b/packages/json-rpc/ws-provider/src/ws-provider.ts
@@ -31,9 +31,11 @@ export const getInternalWsProvider =
           if (typeof e.data === "string") onMessage(e.data)
         }
 
+        const _onHalt = () => onHalt()
+
         socket.addEventListener("message", _onMessage)
-        socket.addEventListener("error", onHalt)
-        socket.addEventListener("close", onHalt)
+        socket.addEventListener("error", _onHalt)
+        socket.addEventListener("close", _onHalt)
 
         return {
           send: (msg) => {
@@ -41,8 +43,8 @@ export const getInternalWsProvider =
           },
           disconnect: () => {
             socket.removeEventListener("message", _onMessage)
-            socket.removeEventListener("error", onHalt)
-            socket.removeEventListener("close", onHalt)
+            socket.removeEventListener("error", _onHalt)
+            socket.removeEventListener("close", _onHalt)
             socket.close()
           },
         }


### PR DESCRIPTION
Okay, so this will definitely fix #620. The problem was due to restarting a connection that threw an unrecoverable error, for example `CrashError`, this will guarantee to throw again, which is then caught by the halt logic, which then call the start function again -> infinite loop.

This PR attempt to fix that by preventing connection restart when those unrecoverable errors are caught.

I'm sure there are more nuances to this, please feels free to modify or provide more guidances as needed 💪.