### PR TITLE
change(pjs-signer): improve `getInjectedExtensions` signature

### DIFF
--- a/packages/signers/pjs-signer/CHANGELOG.md
+++ b/packages/signers/pjs-signer/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- `getInjectedExtensions` no longer returns `null` and it returns an empty `Array` instead
+
 ### Fixed
 
 - Update dependencies

--- a/packages/signers/pjs-signer/src/injected-extensions.ts
+++ b/packages/signers/pjs-signer/src/injected-extensions.ts
@@ -76,7 +76,7 @@ export const connectInjectedExtension = async (
   }
 }
 
-export const getInjectedExtensions = (): null | Array<string> => {
+export const getInjectedExtensions = (): Array<string> => {
   const { injectedWeb3 } = window
-  return injectedWeb3 ? Object.keys(injectedWeb3) : null
+  return injectedWeb3 ? Object.keys(injectedWeb3) : []
 }


### PR DESCRIPTION
As @hannahredler rightfully pointed out: it really doesn't make sense to return `null`.