### PR TITLE
chore: publish polkadot-api@1.0.2

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.7.6 - 2024-08-26
+
 ### Fixed
 
 - Remove cli warning when generating descriptors.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot-api/cli",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "author": "Victor Oliva (https://github.com/voliva)",
   "license": "MIT",
   "sideEffects": true,

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.0.2 - 2024-08-26
+
 ### Fixed
 
 - Fix unexpected `BlockNotPinnedError` which happened in occassions after signing.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polkadot-api",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "Josep M Sobrepere (https://github.com/josepot)",
   "repository": {
     "type": "git",

--- a/packages/json-rpc/logs-provider/CHANGELOG.md
+++ b/packages/json-rpc/logs-provider/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.0.4 - 2024-08-26
+
 ### Fixed
 
 - Make logs-provider wait the correct ammount of time before processing the next log

--- a/packages/json-rpc/logs-provider/package.json
+++ b/packages/json-rpc/logs-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot-api/logs-provider",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "author": "Josep M Sobrepere (https://github.com/josepot)",
   "repository": {
     "type": "git",

--- a/packages/known-chains/CHANGELOG.md
+++ b/packages/known-chains/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.4.1 - 2024-08-26
+
 ### Fixed
 
 - Fix Paseo AssetHub chainspec

--- a/packages/known-chains/package.json
+++ b/packages/known-chains/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot-api/known-chains",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": "Victor Oliva (https://github.com/voliva)",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I've cherry-picked the fixes into a `release/1.0` branch.

My idea after this is merged and published, is that we can merge it into main to have the fixes there as well.