### PR TITLE
feat(tx-utils): add new `tx-utils` library

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,6 +68,7 @@ jobs:
             smoldot,
             substrate-bindings,
             substrate-client,
+            tx-utils,
             utils,
             view-builder,
           ]

--- a/examples/bun/package.json
+++ b/examples/bun/package.json
@@ -23,6 +23,8 @@
     "@ledgerhq/hw-transport-node-hid": "^6.29.4",
     "@polkadot-api/descriptors": "file:.papi/descriptors",
     "@polkadot-api/ledger-signer": "workspace:*",
-    "polkadot-api": "workspace:*"
+    "@polkadot-api/tx-utils": "workspace:*",
+    "polkadot-api": "workspace:*",
+    "rxjs": "^7.8.1"
   }
 }

--- a/examples/bun/src/tx-utils.ts
+++ b/examples/bun/src/tx-utils.ts
@@ -1,0 +1,53 @@
+import { Binary, createClient } from "polkadot-api"
+import { getSmProvider } from "polkadot-api/sm-provider"
+import { start } from "polkadot-api/smoldot"
+import { chainSpec } from "polkadot-api/chains/polkadot"
+import { defer, map, mergeMap, take, withLatestFrom } from "rxjs"
+import { wnd } from "@polkadot-api/descriptors"
+import { getExtrinsicDecoder } from "@polkadot-api/tx-utils"
+
+export const JSONprint = (e: unknown) =>
+  JSON.stringify(
+    e,
+    (_, v) =>
+      typeof v === "bigint"
+        ? v.toString()
+        : v instanceof Binary
+          ? v.asHex()
+          : v,
+    2,
+  )
+
+const smoldot = start()
+
+const client = createClient(getSmProvider(smoldot.addChain({ chainSpec })))
+const api = client.getTypedApi(wnd)
+
+const extrinsicDecoder$ = defer(() =>
+  api.apis.Metadata.metadata_at_version(15),
+).pipe(map((metadata) => getExtrinsicDecoder(metadata!.asBytes())))
+
+client.finalizedBlock$
+  .pipe(
+    take(10),
+    mergeMap((blockInfo) =>
+      client
+        .watchBlockBody(blockInfo.hash)
+        .pipe(map((txs) => ({ txs, blockInfo }))),
+    ),
+    withLatestFrom(extrinsicDecoder$),
+    map(([{ txs, blockInfo }, extrinsicDecoder]) => ({
+      blockInfo,
+      txs: txs.map(extrinsicDecoder).filter((x) => x.signed),
+    })),
+  )
+  .subscribe({
+    next(x) {
+      console.log(JSONprint(x))
+    },
+    error: console.error,
+    complete() {
+      client.destroy()
+      smoldot.terminate()
+    },
+  })

--- a/packages/tx-utils/CHANGELOG.md
+++ b/packages/tx-utils/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+### Changed
+
+Initial release

--- a/packages/tx-utils/README.md
+++ b/packages/tx-utils/README.md
@@ -1,0 +1,1 @@
+# @polkadot-api/tx-utils

--- a/packages/tx-utils/package.json
+++ b/packages/tx-utils/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@polkadot-api/tx-utils",
+  "version": "0.0.1",
+  "author": "Josep M Sobrepere (https://github.com/josepot)",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/polkadot-api/polkadot-api.git"
+  },
+  "license": "MIT",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "node": {
+        "production": {
+          "import": "./dist/esm/index.mjs",
+          "require": "./dist/min/index.js",
+          "default": "./dist/index.js"
+        },
+        "import": "./dist/esm/index.mjs",
+        "require": "./dist/index.js",
+        "default": "./dist/index.js"
+      },
+      "module": "./dist/esm/index.mjs",
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/esm/index.mjs",
+  "browser": "./dist/esm/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build-core": "tsc --noEmit && rollup -c ../../rollup.config.js",
+    "build": "pnpm build-core",
+    "test": "vitest",
+    "lint": "prettier --check README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
+    "format": "prettier --write README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
+    "prepack": "pnpm run build"
+  },
+  "dependencies": {
+    "@polkadot-api/substrate-bindings": "workspace:*",
+    "@polkadot-api/utils": "workspace:*",
+    "@polkadot-api/metadata-builders": "workspace:*"
+  }
+}

--- a/packages/tx-utils/package.json
+++ b/packages/tx-utils/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "build-core": "tsc --noEmit && rollup -c ../../rollup.config.js",
     "build": "pnpm build-core",
-    "test": "vitest",
+    "test": "echo 'no tests'",
     "lint": "prettier --check README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
     "format": "prettier --write README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
     "prepack": "pnpm run build"

--- a/packages/tx-utils/src/decode-extrinsic.ts
+++ b/packages/tx-utils/src/decode-extrinsic.ts
@@ -1,0 +1,70 @@
+import {
+  AccountId,
+  Bin,
+  compactNumber,
+  createDecoder,
+  Decoder,
+  enhanceDecoder,
+  StringRecord,
+  Struct,
+  u8,
+  Variant,
+} from "@polkadot-api/substrate-bindings"
+import { getMetadata } from "./get-metadata"
+import { getDynamicBuilder, getLookupFn } from "@polkadot-api/metadata-builders"
+
+const versionDec = enhanceDecoder(u8[1], (value) => ({
+  version: value & ~(1 << 7),
+  signed: !!(value & (1 << 7)),
+}))
+
+const allBytesDec = Bin(Infinity).dec
+
+const getDefaultAddress = (prefix: number | undefined) =>
+  Variant({
+    Id: AccountId(prefix),
+    Raw: Bin(),
+    Address32: Bin(32),
+    Address20: Bin(20),
+  }).dec
+
+const defaultSignature = Variant({
+  Ed25519: Bin(64),
+  Sr25519: Bin(64),
+  Ecdsa: Bin(65),
+}).dec
+
+export const getExtrinsicDecoder = (metadataRaw: Uint8Array) => {
+  const metadata = getMetadata(metadataRaw)
+  const lookup = getLookupFn(metadata)
+  const dynamicBuilder = getDynamicBuilder(lookup)
+
+  const extra: Decoder<Record<string, any>> = Struct.dec(
+    Object.fromEntries(
+      metadata.extrinsic.signedExtensions.map(
+        (x) =>
+          [x.identifier, dynamicBuilder.buildDefinition(x.type)[1]] as [
+            string,
+            Decoder<any>,
+          ],
+      ),
+    ) as StringRecord<Decoder<any>>,
+  )
+
+  let address: Decoder<any> = getDefaultAddress(dynamicBuilder.ss58Prefix)
+  let signature: Decoder<any> = defaultSignature
+  const { extrinsic } = metadata
+  if ("address" in extrinsic) {
+    address = dynamicBuilder.buildDefinition(extrinsic.address)[1]
+    signature = dynamicBuilder.buildDefinition(extrinsic.signature)[1]
+  }
+
+  const body = Struct.dec({ address, signature, extra, callData: allBytesDec })
+
+  return createDecoder((data) => {
+    const len = compactNumber.dec(data)
+    const { signed, version } = versionDec(data)
+    if (!signed) return { len, signed, version, callData: allBytesDec(data) }
+    return { len, signed, version, ...body(data) }
+  })
+}

--- a/packages/tx-utils/src/from-pjs-to-tx-data.ts
+++ b/packages/tx-utils/src/from-pjs-to-tx-data.ts
@@ -1,0 +1,53 @@
+import { createDecoder, u16, u8 } from "@polkadot-api/substrate-bindings"
+import { Mortality, SignerPayloadJSON, TxData } from "./types"
+import { fromHex } from "@polkadot-api/utils"
+
+const MAX_U32 = 4_294_967_295
+const fromPjsHexStringToNumber = (input: string): number | bigint => {
+  const result = BigInt(input)
+  return result > MAX_U32 ? result : Number(result)
+}
+
+const mortalDec = createDecoder((value) => {
+  const enc = u16.dec(value)
+  const period = 2 << enc % (1 << 4)
+  const factor = Math.max(period >> 12, 1)
+  const phase = (enc >> 4) * factor
+  return { type: "mortal" as const, period, phase }
+})
+
+const mortalityDec = createDecoder((value) => {
+  const firstByte = u8.dec(value)
+  if (firstByte === 0) return { type: "inmortal" as const }
+  const secondByte = u8.dec(value)
+  return mortalDec(Uint8Array.from([firstByte, secondByte]))
+})
+
+export const fromPjsToTxData = ({
+  genesisHash,
+  ...input
+}: SignerPayloadJSON): TxData => {
+  const eraDecoded = mortalityDec(input.era)
+  const mortality: Mortality =
+    eraDecoded.type === "inmortal"
+      ? { mortal: false, genesisHash: input.era }
+      : {
+          mortal: true,
+          blockHash: input.blockHash,
+          phase: eraDecoded.phase,
+          period: eraDecoded.period,
+        }
+
+  return {
+    callData: fromHex(input.method),
+    genesisHash,
+    mortality,
+    tip: BigInt(fromPjsHexStringToNumber(input.tip)),
+    nonce: fromPjsHexStringToNumber(input.nonce) as number,
+    metadataHash:
+      input.mode === 1 && input.metadataHash
+        ? fromHex(input.metadataHash)
+        : null,
+    asset: undefined, // TODO: figure out a way to convert the messy `assetId` on the PJS payload to the canonical one
+  }
+}

--- a/packages/tx-utils/src/from-pjs-to-tx-data.ts
+++ b/packages/tx-utils/src/from-pjs-to-tx-data.ts
@@ -1,6 +1,17 @@
-import { createDecoder, u16, u8 } from "@polkadot-api/substrate-bindings"
+import {
+  _void,
+  compact,
+  createDecoder,
+  Option,
+  u16,
+  u32,
+  u64,
+  u8,
+  V14,
+  V15,
+} from "@polkadot-api/substrate-bindings"
 import { Mortality, SignerPayloadJSON, TxData } from "./types"
-import { fromHex } from "@polkadot-api/utils"
+import { fromHex, mergeUint8 } from "@polkadot-api/utils"
 
 const MAX_U32 = 4_294_967_295
 const fromPjsHexStringToNumber = (input: string): number | bigint => {
@@ -23,10 +34,118 @@ const mortalityDec = createDecoder((value) => {
   return mortalDec(Uint8Array.from([firstByte, secondByte]))
 })
 
-export const fromPjsToTxData = ({
-  genesisHash,
-  ...input
-}: SignerPayloadJSON): TxData => {
+const optionU32Enc = Option(u32).enc
+
+// TODO: missing named consensus
+const encodePjsOptionNetworkId = (
+  _metadata: V14 | V15,
+  networkId: any,
+): Uint8Array => {
+  const keys = Object.keys(networkId)
+  if (keys.length !== 1) throw "Bad length"
+  const field = networkId[keys[0]]
+  if (keys[0] === "any") return Uint8Array.from([0])
+  if (keys[0] === "byGenesis")
+    return mergeUint8(Uint8Array.from([1, 0]), fromHex(field))
+  if (keys[0] === "byFork")
+    return mergeUint8(
+      Uint8Array.from([1, 1]),
+      u64.enc(field.blockNumber),
+      fromHex(field.blockHash),
+    )
+  throw new Error("Named consensus not implemented yet")
+}
+
+const encodePjsJunction = (metadata: V14 | V15, junction: any): Uint8Array => {
+  const keys = Object.keys(junction)
+  if (keys.length !== 1) throw "Bad length"
+  const field = junction[keys[0]]
+  switch (keys[0]) {
+    case "parachain":
+      return mergeUint8(Uint8Array.from([0]), compact.enc(field))
+    case "accountId32":
+      return mergeUint8(
+        Uint8Array.from([1]),
+        encodePjsOptionNetworkId(metadata, field.network),
+        fromHex(field.id),
+      )
+    case "accountIndex64":
+      return mergeUint8(
+        Uint8Array.from([2]),
+        encodePjsOptionNetworkId(metadata, field.network),
+        compact.enc(field.index),
+      )
+    case "accountKey20":
+      return mergeUint8(
+        Uint8Array.from([3]),
+        encodePjsOptionNetworkId(metadata, field.network),
+        fromHex(field.key),
+      )
+    case "palletInstance":
+      return mergeUint8(Uint8Array.from([4]), u8.enc(field))
+    case "generalIndex":
+      return mergeUint8(Uint8Array.from([5]), compact.enc(field))
+    case "generalKey":
+      // General key is not used to locate assets
+      throw "Unexpected generalKey type"
+    case "onlyChild":
+      return Uint8Array.from([7])
+    case "plurality": // Plurality is not used to locate assets
+      throw "Unexpected plurality type"
+    case "globalConsensus":
+      return mergeUint8(
+        Uint8Array.from([9]),
+        // it is not an option here
+        encodePjsOptionNetworkId(metadata, field).slice(1),
+      )
+    default:
+      throw `Unexpected junction type ${keys[0]}`
+  }
+}
+const fromPjsAssetIdToSigExt = (
+  metadata: V14 | V15,
+  pjsAssetId: any,
+): Uint8Array => {
+  // get rid of easy wins
+  if (typeof pjsAssetId === "string") return fromHex(pjsAssetId)
+  if (typeof pjsAssetId === "number") return optionU32Enc(pjsAssetId)
+
+  const encodedData: Uint8Array[] = []
+  if (!("parents" in pjsAssetId && "interior" in pjsAssetId))
+    throw "Location type not found"
+  encodedData.push(u8.enc(pjsAssetId.parents))
+  const keys = Object.keys(pjsAssetId.interior)
+  if (keys.length !== 1) throw "Enum with more than one entry"
+  const key = keys[0]
+  if (key === "here") {
+    encodedData.push(Uint8Array.from([0]))
+    return mergeUint8(...encodedData)
+  } else if (
+    !(
+      key.startsWith("x") &&
+      key.length === 2 &&
+      Number.isInteger(parseInt(key[1]))
+    )
+  )
+    throw "Not safe"
+  const arrLen = parseInt(key[1])
+  encodedData.push(Uint8Array.from([arrLen]))
+  if (arrLen !== 1) {
+    for (const junction of pjsAssetId.interior[key]) {
+      encodedData.push(encodePjsJunction(metadata, junction))
+    }
+  } else {
+    encodedData.push(encodePjsJunction(metadata, pjsAssetId.interior[key]))
+  }
+
+  // it is an option
+  return mergeUint8(Uint8Array.from([1]), ...encodedData)
+}
+
+export const fromPjsToTxData = (
+  metadata: V14 | V15,
+  { genesisHash, ...input }: SignerPayloadJSON,
+): TxData => {
   const eraDecoded = mortalityDec(input.era)
   const mortality: Mortality =
     eraDecoded.type === "inmortal"
@@ -48,6 +167,9 @@ export const fromPjsToTxData = ({
       input.mode === 1 && input.metadataHash
         ? fromHex(input.metadataHash)
         : null,
-    asset: undefined, // TODO: figure out a way to convert the messy `assetId` on the PJS payload to the canonical one
+    asset:
+      input.assetId != null
+        ? fromPjsAssetIdToSigExt(metadata, input.assetId)
+        : undefined,
   }
 }

--- a/packages/tx-utils/src/get-metadata.ts
+++ b/packages/tx-utils/src/get-metadata.ts
@@ -1,0 +1,48 @@
+import {
+  Option,
+  Bytes,
+  metadata,
+  compact,
+  Tuple,
+  V15,
+  V14,
+} from "@polkadot-api/substrate-bindings"
+import { HexString } from "@polkadot-api/substrate-bindings"
+
+const opaqueBytes = Bytes()
+const optionOpaque = Option(opaqueBytes)
+const opaqueOpaqueBytes = Tuple(compact, opaqueBytes)
+
+const getAnyMetadata = (input: Uint8Array | HexString) => {
+  try {
+    return metadata.dec(input)
+  } catch (_) {}
+
+  // comes from metadata.metadata_at_version
+  try {
+    return metadata.dec(optionOpaque.dec(input)!)
+  } catch (_) {}
+
+  // comes from state.getMetadata
+  try {
+    return metadata.dec(opaqueBytes.dec(input))
+  } catch (_) {}
+
+  // comes from metadata.metadata
+  try {
+    return metadata.dec(opaqueOpaqueBytes.dec(input)[1])
+  } catch (_) {}
+
+  throw null
+}
+
+export const getMetadata = (input: Uint8Array | HexString): V14 | V15 => {
+  try {
+    const { metadata } = getAnyMetadata(input)
+    if (metadata.tag !== "v14" && metadata.tag !== "v15")
+      throw new Error("Wrong metadata version")
+    return metadata.value
+  } catch (e) {
+    throw e || new Error("Unable to decode metadata")
+  }
+}

--- a/packages/tx-utils/src/get-metadata.ts
+++ b/packages/tx-utils/src/get-metadata.ts
@@ -1,44 +1,9 @@
-import {
-  Option,
-  Bytes,
-  metadata,
-  compact,
-  Tuple,
-  V15,
-  V14,
-} from "@polkadot-api/substrate-bindings"
+import { V15, V14, decAnyMetadata } from "@polkadot-api/substrate-bindings"
 import { HexString } from "@polkadot-api/substrate-bindings"
-
-const opaqueBytes = Bytes()
-const optionOpaque = Option(opaqueBytes)
-const opaqueOpaqueBytes = Tuple(compact, opaqueBytes)
-
-const getAnyMetadata = (input: Uint8Array | HexString) => {
-  try {
-    return metadata.dec(input)
-  } catch (_) {}
-
-  // comes from metadata.metadata_at_version
-  try {
-    return metadata.dec(optionOpaque.dec(input)!)
-  } catch (_) {}
-
-  // comes from state.getMetadata
-  try {
-    return metadata.dec(opaqueBytes.dec(input))
-  } catch (_) {}
-
-  // comes from metadata.metadata
-  try {
-    return metadata.dec(opaqueOpaqueBytes.dec(input)[1])
-  } catch (_) {}
-
-  throw null
-}
 
 export const getMetadata = (input: Uint8Array | HexString): V14 | V15 => {
   try {
-    const { metadata } = getAnyMetadata(input)
+    const { metadata } = decAnyMetadata(input)
     if (metadata.tag !== "v14" && metadata.tag !== "v15")
       throw new Error("Wrong metadata version")
     return metadata.value

--- a/packages/tx-utils/src/index.ts
+++ b/packages/tx-utils/src/index.ts
@@ -1,0 +1,2 @@
+export type { SignerPayloadJSON } from "./types"
+export * from "./pjs-tx-helper"

--- a/packages/tx-utils/src/index.ts
+++ b/packages/tx-utils/src/index.ts
@@ -1,2 +1,3 @@
 export type { SignerPayloadJSON } from "./types"
 export * from "./pjs-tx-helper"
+export * from "./decode-extrinsic"

--- a/packages/tx-utils/src/pjs-tx-helper.ts
+++ b/packages/tx-utils/src/pjs-tx-helper.ts
@@ -1,0 +1,66 @@
+import { getDynamicBuilder, getLookupFn } from "@polkadot-api/metadata-builders"
+import {
+  _void,
+  Blake2256,
+  compact,
+  enhanceEncoder,
+  u8,
+} from "@polkadot-api/substrate-bindings"
+import { fromHex, mergeUint8 } from "@polkadot-api/utils"
+import { SignerPayloadJSON } from "./types"
+import { fromPjsToTxData } from "./from-pjs-to-tx-data"
+import { getSignedExtensionParts } from "./signed-extensions"
+import { getMetadata } from "./get-metadata"
+
+const versionEncoder = enhanceEncoder(
+  u8.enc,
+  (value: { signed: boolean; version: number }) =>
+    (+!!value.signed << 7) | value.version,
+)
+
+const signingTypeId: Record<"Ecdsa" | "Ed25519" | "Sr25519", number> = {
+  Ed25519: 0,
+  Sr25519: 1,
+  Ecdsa: 2,
+}
+
+export const getPjsTxHelper = (metadata: Uint8Array | string) => {
+  const lookup = getLookupFn(getMetadata(metadata))
+  const dynamicBuilder = getDynamicBuilder(lookup)
+
+  return (pjsPayload: SignerPayloadJSON) => {
+    const { extra, additionalSigned } = getSignedExtensionParts(
+      lookup,
+      dynamicBuilder,
+      fromPjsToTxData(pjsPayload),
+    )
+    const callData = fromHex(pjsPayload.method)
+
+    return {
+      callData,
+      extra,
+      additionalSigned,
+      createTx: async (
+        publicKey: Uint8Array,
+        signingType: "Ecdsa" | "Ed25519" | "Sr25519",
+        sign: (input: Uint8Array) => Uint8Array | Promise<Uint8Array>,
+        hasher = Blake2256,
+      ) => {
+        const { version } = lookup.metadata.extrinsic
+
+        const toSign = mergeUint8(callData, extra, additionalSigned)
+        const signed = await sign(toSign.length > 256 ? hasher(toSign) : toSign)
+
+        const preResult = mergeUint8(
+          versionEncoder({ signed: true, version }),
+          // converting it to a `MultiAddress` enum, where the index 0 is `Id(AccountId)`
+          new Uint8Array([0, ...publicKey]),
+          new Uint8Array([signingTypeId[signingType], ...signed]),
+          extra,
+          callData,
+        )
+        return mergeUint8(compact.enc(preResult.length), preResult)
+      },
+    }
+  }
+}

--- a/packages/tx-utils/src/pjs-tx-helper.ts
+++ b/packages/tx-utils/src/pjs-tx-helper.ts
@@ -32,7 +32,7 @@ export const getPjsTxHelper = (metadata: Uint8Array | string) => {
     const { extra, additionalSigned } = getSignedExtensionParts(
       lookup,
       dynamicBuilder,
-      fromPjsToTxData(pjsPayload),
+      fromPjsToTxData(lookup.metadata, pjsPayload),
     )
     const callData = fromHex(pjsPayload.method)
 

--- a/packages/tx-utils/src/signed-extensions/chain/CheckGenesis.ts
+++ b/packages/tx-utils/src/signed-extensions/chain/CheckGenesis.ts
@@ -1,0 +1,7 @@
+import { HexString } from "@polkadot-api/substrate-bindings"
+import { fromHex } from "@polkadot-api/utils"
+import type { SignedExtension } from "../internal-types"
+import { empty, signedExtension } from "../utils"
+
+export const CheckGenesis = (genesisHash: HexString): SignedExtension =>
+  signedExtension(empty, fromHex(genesisHash))

--- a/packages/tx-utils/src/signed-extensions/chain/CheckMetadataHash.ts
+++ b/packages/tx-utils/src/signed-extensions/chain/CheckMetadataHash.ts
@@ -1,0 +1,13 @@
+import type { SignedExtension } from "../internal-types"
+import { signedExtension } from "../utils"
+
+const offMode = signedExtension(Uint8Array.from([0]), Uint8Array.from([0]))
+export const CheckMetadataHash = (
+  metadataHash: Uint8Array | undefined | null,
+): SignedExtension =>
+  metadataHash
+    ? signedExtension(
+        Uint8Array.from([1]),
+        Uint8Array.from([1, ...metadataHash]),
+      )
+    : offMode

--- a/packages/tx-utils/src/signed-extensions/chain/CheckNonce.ts
+++ b/packages/tx-utils/src/signed-extensions/chain/CheckNonce.ts
@@ -1,0 +1,6 @@
+import { compact } from "@polkadot-api/substrate-bindings"
+import type { SignedExtension } from "../internal-types"
+import { empty, signedExtension } from "../utils"
+
+export const CheckNonce = (nonce: number | bigint): SignedExtension =>
+  signedExtension(compact.enc(nonce), empty)

--- a/packages/tx-utils/src/signed-extensions/chain/CheckSpecVersion.ts
+++ b/packages/tx-utils/src/signed-extensions/chain/CheckSpecVersion.ts
@@ -1,0 +1,6 @@
+import { MetadataLookup } from "@polkadot-api/metadata-builders"
+import type { SignedExtension } from "../internal-types"
+import { empty, signedExtension, systemVersionProp } from "../utils"
+
+export const CheckSpecVersion = (lookupFn: MetadataLookup): SignedExtension =>
+  signedExtension(empty, systemVersionProp("spec_version", lookupFn))

--- a/packages/tx-utils/src/signed-extensions/chain/CheckTxVersion.ts
+++ b/packages/tx-utils/src/signed-extensions/chain/CheckTxVersion.ts
@@ -1,0 +1,6 @@
+import { MetadataLookup } from "@polkadot-api/metadata-builders"
+import type { SignedExtension } from "../internal-types"
+import { empty, signedExtension, systemVersionProp } from "../utils"
+
+export const CheckTxVersion = (lookupFn: MetadataLookup): SignedExtension =>
+  signedExtension(empty, systemVersionProp("transaction_version", lookupFn))

--- a/packages/tx-utils/src/signed-extensions/chain/index.ts
+++ b/packages/tx-utils/src/signed-extensions/chain/index.ts
@@ -1,0 +1,5 @@
+export * from "./CheckGenesis"
+export * from "./CheckMetadataHash"
+export * from "./CheckNonce"
+export * from "./CheckSpecVersion"
+export * from "./CheckTxVersion"

--- a/packages/tx-utils/src/signed-extensions/get-signed-extension-parts.ts
+++ b/packages/tx-utils/src/signed-extensions/get-signed-extension-parts.ts
@@ -1,0 +1,78 @@
+import {
+  getDynamicBuilder,
+  MetadataLookup,
+} from "@polkadot-api/metadata-builders"
+import { _void } from "@polkadot-api/substrate-bindings"
+import {
+  ChargeAssetTxPayment,
+  ChargeTransactionPayment,
+  CheckMortality,
+} from "./user"
+import {
+  CheckGenesis,
+  CheckMetadataHash,
+  CheckNonce,
+  CheckSpecVersion,
+} from "./chain"
+import { TxData } from "@/types"
+import { SignedExtension } from "./internal-types"
+import { EMPTY_SIGNED_EXTENSION } from "./utils"
+import { mergeUint8 } from "@polkadot-api/utils"
+
+export const getSignedExtensionParts = (
+  lookup: MetadataLookup,
+  dynamicBuilder: ReturnType<typeof getDynamicBuilder>,
+  data: TxData,
+) => {
+  const { tip, mortality, genesisHash, nonce, asset, metadataHash } = data
+  const signedExtensions = lookup.metadata.extrinsic.signedExtensions.map(
+    ({ identifier, type, additionalSigned }): SignedExtension => {
+      switch (identifier) {
+        case "CheckGenesis":
+          return CheckGenesis(genesisHash)
+        case "CheckMetadataHash":
+          return CheckMetadataHash(metadataHash)
+        case "CheckNonce":
+          return CheckNonce(nonce)
+        case "CheckSpecVersion":
+          return CheckSpecVersion(lookup)
+        case "ChargeAssetTxPayment":
+          return ChargeAssetTxPayment(tip, asset)
+        case "ChargeTransactionPayment":
+          return ChargeTransactionPayment(tip)
+        case "CheckMortality":
+          return CheckMortality(mortality)
+      }
+
+      if (
+        dynamicBuilder.buildDefinition(type) === _void &&
+        dynamicBuilder.buildDefinition(additionalSigned) === _void
+      )
+        return EMPTY_SIGNED_EXTENSION
+
+      throw new Error(`Unsupported signed-extension: ${identifier}`)
+    },
+  )
+
+  const signedExtensionsRecord = Object.fromEntries(
+    lookup.metadata.extrinsic.signedExtensions.map(({ identifier }, idx) => [
+      identifier,
+      { identifier, ...signedExtensions[idx] },
+    ]),
+  )
+
+  let extraParts: Uint8Array[] = []
+  let additionalSignedParts: Uint8Array[] = []
+  lookup.metadata.extrinsic.signedExtensions.map(({ identifier }) => {
+    const signedExtension = signedExtensionsRecord[identifier]
+    if (!signedExtension)
+      throw new Error(`Missing ${identifier} signed extension`)
+    extraParts.push(signedExtension.value)
+    additionalSignedParts.push(signedExtension.value)
+  })
+
+  const extra = mergeUint8(...extraParts)
+  const additionalSigned = mergeUint8(...additionalSignedParts)
+
+  return { extra, additionalSigned }
+}

--- a/packages/tx-utils/src/signed-extensions/index.ts
+++ b/packages/tx-utils/src/signed-extensions/index.ts
@@ -1,0 +1,1 @@
+export { getSignedExtensionParts } from "./get-signed-extension-parts"

--- a/packages/tx-utils/src/signed-extensions/internal-types.ts
+++ b/packages/tx-utils/src/signed-extensions/internal-types.ts
@@ -1,0 +1,4 @@
+export type SignedExtension = {
+  value: Uint8Array
+  additionalSigned: Uint8Array
+}

--- a/packages/tx-utils/src/signed-extensions/user/ChargeAssetTxPayment.ts
+++ b/packages/tx-utils/src/signed-extensions/user/ChargeAssetTxPayment.ts
@@ -1,0 +1,25 @@
+import {
+  Bytes,
+  Option,
+  Struct,
+  compact,
+} from "@polkadot-api/substrate-bindings"
+import { empty, signedExtension } from "../utils"
+import { SignedExtension } from "../internal-types"
+
+const encoder = Struct({
+  tip: compact,
+  asset: Option(Bytes(Infinity)),
+}).enc
+
+export const ChargeAssetTxPayment = (
+  tip: number | bigint,
+  asset: Uint8Array | undefined,
+): SignedExtension =>
+  signedExtension(
+    encoder({
+      tip,
+      asset,
+    }),
+    empty,
+  )

--- a/packages/tx-utils/src/signed-extensions/user/ChargeTransactionPayment.ts
+++ b/packages/tx-utils/src/signed-extensions/user/ChargeTransactionPayment.ts
@@ -1,0 +1,7 @@
+import { compact } from "@polkadot-api/substrate-bindings"
+import { empty, signedExtension } from "../utils"
+import { SignedExtension } from "../internal-types"
+
+export const ChargeTransactionPayment = (
+  tip: number | bigint,
+): SignedExtension => signedExtension(compact.enc(tip), empty)

--- a/packages/tx-utils/src/signed-extensions/user/CheckMortality.ts
+++ b/packages/tx-utils/src/signed-extensions/user/CheckMortality.ts
@@ -1,0 +1,39 @@
+import { Bytes, enhanceEncoder, u16 } from "@polkadot-api/substrate-bindings"
+import { fromHex } from "@polkadot-api/utils"
+import { SignedExtension } from "../internal-types"
+import { signedExtension } from "../utils"
+import { Mortality } from "@/types"
+
+function trailingZeroes(n: number) {
+  let i = 0
+  while (!(n & 1)) {
+    i++
+    n >>= 1
+  }
+  return i
+}
+
+const mortal = enhanceEncoder(
+  Bytes(2).enc,
+  (value: { period: number; phase: number }) => {
+    const factor = Math.max(value.period >> 12, 1)
+    const left = Math.min(Math.max(trailingZeroes(value.period) - 1, 1), 15)
+    const right = (value.phase / factor) << 4
+    return u16.enc(left | right)
+  },
+)
+
+const zero = new Uint8Array([0])
+export const CheckMortality = (mortality: Mortality): SignedExtension => {
+  if (!mortality.mortal)
+    return signedExtension(zero, fromHex(mortality.genesisHash))
+
+  const { period, phase, blockHash } = mortality
+  return signedExtension(
+    mortal({
+      period,
+      phase,
+    }),
+    fromHex(blockHash),
+  )
+}

--- a/packages/tx-utils/src/signed-extensions/user/index.ts
+++ b/packages/tx-utils/src/signed-extensions/user/index.ts
@@ -1,0 +1,3 @@
+export * from "./ChargeTransactionPayment"
+export * from "./CheckMortality"
+export * from "./ChargeAssetTxPayment"

--- a/packages/tx-utils/src/signed-extensions/utils.ts
+++ b/packages/tx-utils/src/signed-extensions/utils.ts
@@ -1,0 +1,37 @@
+import {
+  getDynamicBuilder,
+  MetadataLookup,
+} from "@polkadot-api/metadata-builders"
+
+export const empty = new Uint8Array()
+
+export const signedExtension = (
+  value: Uint8Array,
+  additionalSigned: Uint8Array,
+) => ({
+  value,
+  additionalSigned,
+})
+export const systemVersionProp = (
+  propName: string,
+  lookupFn: MetadataLookup,
+) => {
+  const dynamicBuilder = getDynamicBuilder(lookupFn)
+
+  const constant = lookupFn.metadata.pallets
+    .find((x) => x.name === "System")!
+    .constants!.find((s) => s.name === "Version")!
+
+  const systemVersion = lookupFn(constant.type)
+  const systemVersionDec = dynamicBuilder.buildDefinition(constant.type).dec
+
+  if (systemVersion.type !== "struct") throw new Error("not a struct")
+
+  const valueEnc = dynamicBuilder.buildDefinition(
+    systemVersion.value[propName].id,
+  ).enc
+
+  return valueEnc(systemVersionDec(constant.value)[propName])
+}
+
+export const EMPTY_SIGNED_EXTENSION = signedExtension(empty, empty)

--- a/packages/tx-utils/src/types.ts
+++ b/packages/tx-utils/src/types.ts
@@ -1,0 +1,87 @@
+type HexString = `0x${string}`
+export interface SignerPayloadJSON {
+  /**
+   * The ss-58 encoded address.
+   */
+  address: string
+  /**
+   * The id of the asset used to pay fees, in hex.
+   */
+  assetId?: number | object
+  /**
+   * The checkpoint hash of the block, in hex.
+   */
+  blockHash: HexString
+  /**
+   * The checkpoint block number, in hex.
+   */
+  blockNumber: HexString
+  /**
+   * The era for this transaction, in hex.
+   */
+  era: HexString
+  /**
+   * The genesis hash of the chain, in hex.
+   */
+  genesisHash: HexString
+  /**
+   * The metadataHash for the CheckMetadataHash SignedExtension, as hex.
+   */
+  metadataHash?: HexString
+  /**
+   * The encoded method (with arguments) in hex.
+   */
+  method: string
+  /**
+   * The mode for the CheckMetadataHash SignedExtension, in hex.
+   */
+  mode?: number
+  /**
+   * The nonce for this transaction, in hex.
+   */
+  nonce: HexString
+  /**
+   * The current spec version for the runtime.
+   */
+  specVersion: HexString
+  /**
+   * The tip for this transaction, in hex.
+   */
+  tip: HexString
+  /**
+   * The current transaction version for the runtime.
+   */
+  transactionVersion: HexString
+  /**
+   * The applicable signed extensions for this runtime.
+   */
+  signedExtensions: string[]
+  /**
+   * The version of the extrinsic we are dealing with.
+   */
+  version: number
+  /**
+   * Optional flag that enables the use of the `signedTransaction` field in
+   * `singAndSend`, `signAsync`, and `dryRun`.
+   */
+  withSignedTransaction?: boolean
+}
+
+export type Mortality =
+  | { mortal: false; genesisHash: HexString }
+  | {
+      mortal: true
+      period: number
+      phase: number
+      blockHash: HexString
+    }
+
+export type TxData = {
+  callData: Uint8Array
+  asset: Uint8Array | undefined
+  metadataHash: Uint8Array | null
+  tip: bigint
+  mortality: Mortality
+  genesisHash: HexString
+  nonce: number
+}

--- a/packages/tx-utils/tsconfig.json
+++ b/packages/tx-utils/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base",
+  "include": ["src", "tests"],
+  "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["*"]
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -677,6 +677,18 @@ importers:
         specifier: workspace:*
         version: link:../utils
 
+  packages/tx-utils:
+    dependencies:
+      '@polkadot-api/metadata-builders':
+        specifier: workspace:*
+        version: link:../metadata-builders
+      '@polkadot-api/substrate-bindings':
+        specifier: workspace:*
+        version: link:../substrate-bindings
+      '@polkadot-api/utils':
+        specifier: workspace:*
+        version: link:../utils
+
   packages/utils: {}
 
   packages/view-builder:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,9 +71,15 @@ importers:
       '@polkadot-api/ledger-signer':
         specifier: workspace:*
         version: link:../../packages/signers/ledger-signer
+      '@polkadot-api/tx-utils':
+        specifier: workspace:*
+        version: link:../../packages/tx-utils
       polkadot-api:
         specifier: workspace:*
         version: link:../../packages/client
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.1
       typescript:
         specifier: ^5
         version: 5.6.2


### PR DESCRIPTION
This is a new library meant mostly to assist PJS extensions to stop using PJS internally. The frens from Talisman have already started this process and @0xKheops asked for these kinds of helpers.

This is an important topic in our roadmap. I hope that this library can help them in these process.