### PR TITLE
feat(tx): improve DX with unions of TypedApi

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies.
+
 ## 0.8.0 - 2024-08-28
 
 ### Changed

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -147,7 +147,7 @@ async function outputCodegen(
 ) {
   const {
     descriptorsFileContent,
-    descriptorTypesFileContent,
+    descriptorTypesFiles,
     metadataTypes,
     typesFileContent,
     publicTypes,
@@ -199,13 +199,14 @@ ${descriptorsFileContent}`,
     chains.map((chain, i) =>
       fs.writeFile(
         join(outputFolder, `${chain.key}.ts`),
-        descriptorTypesFileContent[i],
+        descriptorTypesFiles[i].content,
       ),
     ),
   )
   await generateIndex(
     outputFolder,
     chains.map((chain) => chain.key),
+    descriptorTypesFiles.map((d) => d.exports),
     publicTypes,
   )
 
@@ -252,11 +253,12 @@ async function compileCodegen(packageDir: string) {
 const generateIndex = async (
   path: string,
   keys: string[],
+  exports: string[][],
   publicTypes: string[],
 ) => {
   const indexTs = [
-    ...keys.flatMap((key) => [
-      `export { default as ${key} } from "./${key}";`,
+    ...keys.flatMap((key, i) => [
+      `export { ${exports[i].join(",")} } from "./${key}";`,
       `export type * from "./${key}";`,
     ]),
     `export {`,

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -7,6 +7,10 @@
 - `pjs-signer`: Remove option byte from `CheckMetadataHash`
 - Avoid unexpected behaviour with `dispatchError` type
 
+### Changed
+
+- codegen: Replace chain call data types for broader `TxCallData` [#687](https://github.com/polkadot-api/polkadot-api/pull/687).
+
 ### Added
 
 - New `Binary` methods for supporting "`opaque`" binary data. [#675](https://github.com/polkadot-api/polkadot-api/pull/675).

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -28,4 +28,5 @@ export type {
   TransactionValidityError,
   TypedApi,
   FixedSizeArray,
+  TxCallData,
 } from "./types"

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -231,3 +231,11 @@ export interface PolkadotClient {
 }
 
 export type FixedSizeArray<L extends number, T> = Array<T> & { length: L }
+
+export type TxCallData = {
+  type: string
+  value: {
+    type: string
+    value: any
+  }
+}

--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Replace chain call data types for broader `TxCallData` [#687](https://github.com/polkadot-api/polkadot-api/pull/687).
+
 ## 0.9.0 - 2024-08-28
 
 ### Changed

--- a/packages/codegen/src/generate-multiple-descriptors.ts
+++ b/packages/codegen/src/generate-multiple-descriptors.ts
@@ -10,7 +10,11 @@ import {
 } from "@polkadot-api/metadata-compatibility"
 import type { V14, V15 } from "@polkadot-api/substrate-bindings"
 import { mapObject } from "@polkadot-api/utils"
-import { DescriptorValues, generateDescriptors } from "./generate-descriptors"
+import {
+  capitalize,
+  DescriptorValues,
+  generateDescriptors,
+} from "./generate-descriptors"
 import { generateTypes } from "./generate-types"
 import { getUsedTypes } from "./get-used-types"
 import knownTypes, { KnownTypes } from "./known-types"
@@ -68,7 +72,7 @@ export const generateMultipleDescriptors = (
         chain.builder,
       ),
       chain.builder,
-      capitalize(chain.key),
+      chain.key,
       paths,
     ),
   )
@@ -82,7 +86,10 @@ export const generateMultipleDescriptors = (
   return {
     descriptorsFileContent,
     metadataTypes: types,
-    descriptorTypesFileContent: chainFiles.map((file) => file.descriptorTypes),
+    descriptorTypesFiles: chainFiles.map((file) => ({
+      content: file.descriptorTypes,
+      exports: file.exports,
+    })),
     typesFileContent: generateTypes(declarations, paths),
     publicTypes: getPublicTypes(declarations.variables),
   }
@@ -185,10 +192,6 @@ function mergeTypes(
     entryPoints: updatedEntryPoints,
     checksumToIdx,
   }
-}
-
-function capitalize(value: string) {
-  return value.slice(0, 1).toUpperCase() + value.slice(1)
 }
 
 function generateDescriptorValuesContent(

--- a/packages/metadata-builders/CHANGELOG.md
+++ b/packages/metadata-builders/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- lookup: Add `call` parameter to lookup with the id of the `outerEnums.call` (also for v14) [#687](https://github.com/polkadot-api/polkadot-api/pull/687).
+
 ## 0.6.0 - 2024-08-28
 
 ### Changed

--- a/packages/metadata-builders/src/lookups.ts
+++ b/packages/metadata-builders/src/lookups.ts
@@ -108,6 +108,7 @@ const _void: VoidVar = { type: "void" }
 export interface MetadataLookup {
   (id: number): LookupEntry
   metadata: V14 | V15
+  call: number | null
 }
 
 export const getLookupFn = (metadata: V14 | V15): MetadataLookup => {
@@ -416,5 +417,16 @@ export const getLookupFn = (metadata: V14 | V15): MetadataLookup => {
     }
   }
 
-  return Object.assign(getLookupEntryDef, { metadata })
+  const getCall = () => {
+    if ("outerEnums" in metadata) {
+      return metadata.outerEnums.call
+    }
+
+    const extrinsic = metadata.lookup[metadata.extrinsic.type]
+    const call = extrinsic.params.find((p) => p.name === "Call")
+
+    return call?.type ?? null
+  }
+
+  return Object.assign(getLookupEntryDef, { metadata, call: getCall() })
 }

--- a/packages/metadata-builders/src/lookups.ts
+++ b/packages/metadata-builders/src/lookups.ts
@@ -422,8 +422,8 @@ export const getLookupFn = (metadata: V14 | V15): MetadataLookup => {
       return metadata.outerEnums.call
     }
 
-    const extrinsic = metadata.lookup[metadata.extrinsic.type]
-    const call = extrinsic.params.find((p) => p.name === "Call")
+    const extrinsic = metadata.lookup[metadata.extrinsic?.type]
+    const call = extrinsic?.params.find((p) => p.name === "Call")
 
     return call?.type ?? null
   }

--- a/packages/metadata-compatibility/CHANGELOG.md
+++ b/packages/metadata-compatibility/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.1.3 - 2024-08-28
 
 ### Fixed

--- a/packages/observable-client/CHANGELOG.md
+++ b/packages/observable-client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.5.2 - 2024-08-28
 
 ### Fixed

--- a/packages/view-builder/CHANGELOG.md
+++ b/packages/view-builder/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.3.3 - 2024-08-28
 
 ### Fixed


### PR DESCRIPTION
When working with multiple chains at once, it's often convenient to have a union of `typedApi`s in order to create utility functions to be reused across all of the chains.

However, TS adds a lot of friction when dealing with cases where types don't have a 1-to-1 overlap. And transactions that take in call data are most affected by that, since a call data of one chain doesn't overlap very well with another of another chain.

This change replaces every callData found in a chain for a generic `TxCallData`, which is just `{ type: string, value: { type: string, value: any } }`, to reduce friction when dealing with unions of TypedApis.

It's not a breaking change since it's a change on the type level which only broadens the type. For those who still want type safety with those, the descriptors package now also export a `{Prefix}CallData` with the original type information for that chain.