### PR TITLE
fix(client): throw when entrypoint is not found

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `codegen`: Remove unused error descriptors
 - `codegen`: Resolve errors with a fine-grained approach in the whitelist
 - `compatibility`: Resolve properly enum types
+- `client`: Throw an error when entrypoint is not found
 
 ## 1.2.0 - 2024-09-04
 

--- a/packages/client/src/constants.ts
+++ b/packages/client/src/constants.ts
@@ -40,7 +40,9 @@ export const createConstantEntry = <D, T>(
     const pallet = ctx.lookup.metadata.pallets.find(
       (p) => p.name === palletName,
     )
-    const constant = pallet?.constants.find((c) => c.name === name)!
+    const constant = pallet?.constants.find((c) => c.name === name)
+    if (constant == null)
+      throw new Error(`Runtime entry Constant(${palletName}.${name}) not found`)
     const result = ctx.dynamicBuilder
       .buildConstant(palletName, name)
       .dec(constant.value)

--- a/packages/client/src/event.ts
+++ b/packages/client/src/event.ts
@@ -81,6 +81,18 @@ export const createEventEntry = <D, T>(
   const shared$ = chainHead.finalized$.pipe(
     withCompatibleRuntime(chainHead, (x) => x.hash),
     map(([block, runtime, ctx]) => {
+      const eventsIdx = ctx.lookup.metadata.pallets.find(
+        (p) => p.name === pallet,
+      )?.events
+      if (
+        eventsIdx == null ||
+        ctx.lookup.metadata.lookup[eventsIdx].def.tag !== "variant" ||
+        ctx.lookup.metadata.lookup[eventsIdx].def.value.find(
+          (ev) => ev.name === name,
+        ) == null
+      )
+        throw new Error(`Runtime entry Event(${pallet}.${name}) not found`)
+
       if (!argsAreCompatible(runtime, ctx, null)) throw compatibilityError()
       return [block, runtime, ctx] as const
     }),

--- a/packages/client/src/runtime-call.ts
+++ b/packages/client/src/runtime-call.ts
@@ -49,8 +49,13 @@ export const createRuntimeCallEntry = (
 
     const result$ = compatibleRuntime$(chainHead, at).pipe(
       mergeMap(([runtime, ctx]) => {
+        let codecs
+        try {
+          codecs = ctx.dynamicBuilder.buildRuntimeCall(api, method)
+        } catch {
+          throw new Error(`Runtime entry RuntimeCall(${callName}) not found`)
+        }
         if (!argsAreCompatible(runtime, ctx, args)) throw compatibilityError()
-        const codecs = ctx.dynamicBuilder.buildRuntimeCall(api, method)
         return chainHead.call$(at, callName, toHex(codecs.args.enc(args))).pipe(
           map(codecs.value.dec),
           map((value) => {

--- a/packages/client/src/tx/tx.ts
+++ b/packages/client/src/tx/tx.ts
@@ -78,9 +78,9 @@ export const createTxEntry = <
     ) => {
       const ctx = getCompatibilityApi(runtime).runtime()
       const { dynamicBuilder, assetId, lookup } = ctx
-      let location, codec
+      let codecs
       try {
-        ;({ location, codec } = dynamicBuilder.buildCall(pallet, name))
+        codecs = dynamicBuilder.buildCall(pallet, name)
       } catch {
         throw new Error(`Runtime entry Tx(${pallet}.${name}) not found`)
       }
@@ -104,6 +104,7 @@ export const createTxEntry = <
         }
       }
 
+      const { location, codec } = codecs
       return {
         callData: Binary.fromBytes(
           mergeUint8(new Uint8Array(location), codec.enc(arg)),

--- a/packages/client/src/tx/tx.ts
+++ b/packages/client/src/tx/tx.ts
@@ -77,10 +77,16 @@ export const createTxEntry = <
       txOptions: Partial<{ asset: any }> = {},
     ) => {
       const ctx = getCompatibilityApi(runtime).runtime()
+      const { dynamicBuilder, assetId, lookup } = ctx
+      let location, codec
+      try {
+        ;({ location, codec } = dynamicBuilder.buildCall(pallet, name))
+      } catch {
+        throw new Error(`Runtime entry Tx(${pallet}.${name}) not found`)
+      }
       if (checkCompatibility && !argsAreCompatible(runtime, ctx, arg))
         throw new Error(`Incompatible runtime entry Tx(${pallet}.${name})`)
 
-      const { dynamicBuilder, assetId, lookup } = ctx
       let returnOptions = txOptions
       if (txOptions.asset) {
         if (
@@ -98,7 +104,6 @@ export const createTxEntry = <
         }
       }
 
-      const { location, codec } = dynamicBuilder.buildCall(pallet, name)
       return {
         callData: Binary.fromBytes(
           mergeUint8(new Uint8Array(location), codec.enc(arg)),


### PR DESCRIPTION
We weren't catching at entrypoint creation if the entrypoints indeed existed at the metadata, and therefore errors from inner libraries were being leaked.
Thanks @SBalaguer for the report! 