### PR TITLE
feat(polkadot-sdk-compat): add `fixDescendantValues` enhancer

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `polkadot-sdk-compat`: Add `fixChainSpec` enhancer which addresses [the following issue](https://github.com/paritytech/polkadot-sdk/issues/5539) on the PolkadotSDK node.
+- `polkadot-sdk-compat`: Add `fixDescendantValues` enhancer which addresses [the following issue](https://github.com/paritytech/polkadot-sdk/issues/5589) on the PolkadotSDK node.
 
 ## 1.2.1 - 2024-09-10
 

--- a/packages/json-rpc/polkadot-sdk-compat/CHANGELOG.md
+++ b/packages/json-rpc/polkadot-sdk-compat/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add `fixChainSpec` enhancer which addresses [the following issue](https://github.com/paritytech/polkadot-sdk/issues/5539) on the PolkadotSDK node.
+- Add `fixDescendantValues` enhancer which addresses [the following issue](https://github.com/paritytech/polkadot-sdk/issues/5589) on the PolkadotSDK node.
 
 ## 2.1.0 - 2024-09-04
 

--- a/packages/json-rpc/polkadot-sdk-compat/src/index.ts
+++ b/packages/json-rpc/polkadot-sdk-compat/src/index.ts
@@ -6,6 +6,7 @@ import {
   fixUnorderedEvents,
   fixUnorderedBlocks,
   fixChainSpec,
+  fixDescendantValues,
 } from "./parsed-enhancers"
 
 const withPolkadotSdkCompat = parsed(
@@ -15,6 +16,7 @@ const withPolkadotSdkCompat = parsed(
   patchChainHeadEvents,
   fixUnorderedBlocks,
   fixChainSpec,
+  fixDescendantValues,
 )
 
 export * from "./parsed"
@@ -25,4 +27,5 @@ export {
   unpinHash,
   patchChainHeadEvents,
   fixUnorderedBlocks,
+  fixDescendantValues,
 }

--- a/packages/json-rpc/polkadot-sdk-compat/src/parsed-enhancers/fix-descendant-values.ts
+++ b/packages/json-rpc/polkadot-sdk-compat/src/parsed-enhancers/fix-descendant-values.ts
@@ -1,0 +1,299 @@
+import { chainHead } from "@/methods"
+import type { ParsedJsonRpcEnhancer } from "@/parsed"
+import { getRequest, jsonObj, operationNotification } from "@/utils"
+
+const operationPrefix = "__INNER_OP_DesV"
+let nextOperationId = 0
+export const fixDescendantValues: ParsedJsonRpcEnhancer = (base) => (onMsg) => {
+  const [provider, request] = getRequest(base)
+  const getDescendantValues = getDescendantValuesFromOldRpc(request)
+
+  // the `id` of the json-rpc request that should respond with the `operationId`
+  // if it has started, the value is the callback-function that is waiting for the `operationId`
+  const preOpId = new Map<string, (operationId: string) => void>()
+
+  // chainHeadSubscription - operationId => operationState
+  const onGoing: Map<
+    string,
+    Map<
+      string,
+      {
+        isOutterDone: boolean
+        isInnerDone: boolean
+        cancel: () => void
+      }
+    >
+  > = new Map()
+
+  const { send: originalSend, disconnect } = provider((msg: any) => {
+    // it's a response
+    if ("id" in msg) {
+      const opIdCb = preOpId.get(msg.id)
+      if (opIdCb) {
+        preOpId.delete(msg.id)
+        if (msg.result.result === "started") opIdCb(msg.result.operationId)
+      }
+    } else if (msg.params) {
+      // it's a notifiaction
+      const { subscription, result } = (msg as any).params
+      const { operationId } = result || {}
+      const operations = onGoing.get(subscription)
+
+      if (operations && result.event === "stop") {
+        operations.forEach((x) => {
+          x.cancel()
+        })
+        onGoing.delete(subscription)
+      }
+
+      const operation = operations?.get(operationId)
+      if (operation) {
+        switch (result.event) {
+          case "operationInaccessible":
+          case "operationError":
+            operation.cancel()
+            break
+          case "operationStorageDone": {
+            if (operation.isInnerDone) {
+              operations!.delete(operationId)
+            } else {
+              operation.isOutterDone = true
+              return
+            }
+          }
+        }
+      }
+    }
+    onMsg(msg)
+  })
+
+  const getStartDescendantValues =
+    (subscription: string, blockHash: string, keys: string[]) =>
+    (operationId: string) => {
+      let _cancel = () => {}
+      if (!onGoing.has(subscription)) {
+        onGoing.set(subscription, new Map())
+      }
+      const operationsMap = onGoing.get(subscription)!
+      const state = {
+        isOutterDone: false,
+        isInnerDone: false,
+        cancel: () => {
+          _cancel()
+        },
+      }
+      operationsMap.set(operationId, state)
+
+      let nFinished = 0
+      const stoppers = keys.map((key) =>
+        getDescendantValues(
+          key,
+          blockHash,
+          (values) => {
+            onMsg(
+              operationNotification(
+                subscription,
+                "operationStorageItems",
+                operationId,
+                { items: values.map(([key, value]) => ({ key, value })) },
+              ),
+            )
+          },
+          (error) => {
+            _cancel()
+            if (!state.isOutterDone) {
+              // stop the outer
+              originalSend(
+                jsonObj({
+                  method: "chainHead_v1_stopOperation",
+                  params: [operationId],
+                }),
+              )
+            }
+            // send error
+            onMsg(
+              operationNotification(
+                subscription,
+                "operationError",
+                operationId,
+                {
+                  error:
+                    typeof error === "string" ? error : JSON.stringify(error),
+                },
+              ),
+            )
+          },
+          () => {
+            if (++nFinished === keys.length) {
+              if (state.isOutterDone) {
+                // done
+                _cancel()
+                onMsg(
+                  operationNotification(
+                    subscription,
+                    "operationStorageDone",
+                    operationId,
+                  ),
+                )
+              } else state.isInnerDone = true
+            }
+          },
+        ),
+      )
+      _cancel = () => {
+        operationsMap.delete(operationId)
+        stoppers.forEach((cb) => cb())
+      }
+    }
+
+  const send = (msg: any) => {
+    switch (msg.method) {
+      case chainHead.storage: {
+        const [followSub, blockHash, items] = msg.params as [
+          string,
+          string,
+          any[],
+        ]
+        const descendantsValuesKeys: string[] = []
+        const actualItems = items.filter((x) => {
+          const isDescendantsValues = x.type === "descendantsValues"
+          if (isDescendantsValues) descendantsValuesKeys.push(x.key)
+          return !isDescendantsValues
+        })
+
+        const startGetDescendantValues = getStartDescendantValues(
+          followSub,
+          blockHash,
+          descendantsValuesKeys,
+        )
+        if (!actualItems.length) {
+          const operationId = operationPrefix + nextOperationId++
+          onMsg(
+            jsonObj({
+              id: msg.id,
+              result: { result: "started", operationId },
+            }),
+          )
+          startGetDescendantValues(operationId)
+          onGoing.get(followSub)!.get(operationId)!.isOutterDone = true
+          return
+        } else if (descendantsValuesKeys.length) {
+          preOpId.set(msg.id, startGetDescendantValues)
+        }
+        msg.params[2] = actualItems
+        break
+      }
+      case chainHead.stopOperation: {
+        const [followSubscription, operationId] = msg.params as [string, string]
+        const data = onGoing.get(followSubscription)?.get(operationId)
+        if (data) {
+          data.cancel()
+          if (data.isOutterDone) return
+        }
+        break
+      }
+      case chainHead.unfollow: {
+        const [followSubscription] = msg.params as [string]
+        onGoing.get(followSubscription)?.forEach((x) => x.cancel())
+        onGoing.delete(followSubscription)
+        break
+      }
+    }
+    originalSend(msg)
+  }
+
+  return {
+    send,
+    disconnect,
+  }
+}
+
+/**
+ * A higher-order function that returns a process to fetch descendant values
+ * from the storage of block using an older RPC method.
+ *
+ * This function takes a `request` function as an argument, which is used to
+ * make RPC calls. The returned function accepts a storage key (`rootKey`) and a
+ * block hash (`at`) as inputs, as well as three callbacks:
+ * 1. `onValues`: triggered when new values are retrieved.
+ * 2. `onError`: triggered in case of an error during the operation.
+ * 3. `onDone`: triggered when all values have been successfully fetched.
+ *
+ * The operation works by paginating through storage keys using
+ * `state_getKeysPaged`
+ * and fetching the corresponding values using `state_queryStorageAt`.
+ * It runs in the background and supports stopping the operation early by
+ * returning a callback function that, when invoked, cancels further processing.
+ *
+ * The flow of execution:
+ * - The function continuously fetches storage keys in batches.
+ * - For each batch, it fetches the descendant values at the specified block
+ * hash.
+ * - If an error occurs or the user cancels the operation, it stops fetching.
+ * - The `onDone` callback is triggered when all the keys have been processed
+ * and all ongoing value retrieval operations are completed.
+ */
+const getDescendantValuesFromOldRpc =
+  (
+    request: <T>(
+      method: string,
+      args: Array<any>,
+      onSuccess: (value: T) => void,
+      onError: (e: any) => void,
+    ) => void,
+  ) =>
+  (
+    rootKey: string,
+    at: string,
+    onValues: (input: Array<[string, string]>) => void,
+    onError: (e: any) => void,
+    onDone: () => void,
+  ): (() => void) => {
+    let isRunning = true
+    let areAllKeysDone = false
+    let onGoingValues = 0
+
+    const _onError = (e: any) => {
+      if (isRunning) {
+        isRunning = false
+        onError(e)
+      }
+    }
+
+    const PAGE_SIZE = 1000
+    const pullKeys = (startAtKey?: string) => {
+      request<string[]>(
+        "state_getKeysPaged",
+        [rootKey, PAGE_SIZE, startAtKey || undefined, at],
+        (result) => {
+          if (isRunning) {
+            if (result.length > 0) {
+              onGoingValues++
+              request<[{ block: string; changes: Array<[string, string]> }]>(
+                "state_queryStorageAt",
+                [result, at],
+                ([{ changes }]) => {
+                  if (isRunning) {
+                    onGoingValues--
+                    onValues(changes)
+                    if (areAllKeysDone && !onGoingValues) onDone()
+                  }
+                },
+                _onError,
+              )
+            }
+            if (result.length < PAGE_SIZE) {
+              areAllKeysDone = true
+              if (!onGoingValues) onDone()
+            } else pullKeys(result.at(-1))
+          }
+        },
+        _onError,
+      )
+    }
+    pullKeys()
+
+    return () => {
+      isRunning = false
+    }
+  }

--- a/packages/json-rpc/polkadot-sdk-compat/src/parsed-enhancers/index.ts
+++ b/packages/json-rpc/polkadot-sdk-compat/src/parsed-enhancers/index.ts
@@ -1,4 +1,5 @@
 export { fixChainSpec } from "./chain-spec"
+export { fixDescendantValues } from "./fix-descendant-values"
 export { fixUnorderedBlocks } from "./fix-unordered-blocks"
 export { fixUnorderedEvents } from "./fix-unordered-events"
 export { patchChainHeadEvents } from "./patch-chainhead-events"

--- a/packages/json-rpc/polkadot-sdk-compat/src/utils.ts
+++ b/packages/json-rpc/polkadot-sdk-compat/src/utils.ts
@@ -1,0 +1,71 @@
+import { ParsedJsonRpcProvider } from "./parsed"
+
+export const jsonObj = <T extends {}>(input: T) => ({
+  jsonrpc: "2.0",
+  ...input,
+})
+export const operationNotification = <T extends {}>(
+  subscription: string,
+  event: string,
+  operationId: string,
+  innerResult: T = {} as T,
+) =>
+  jsonObj({
+    method: "chainHead_v1_followEvent",
+    params: {
+      subscription,
+      result: {
+        event,
+        operationId,
+        ...innerResult,
+      },
+    },
+  })
+
+const requestPrefix = "__INNER_RQ_DesV"
+export const getRequest = (base: ParsedJsonRpcProvider) => {
+  let nextId = 0
+  const onGoingRequests = new Map<string, (ok: boolean, x: any) => void>()
+
+  const listener: <T extends { id: string; result: T; error?: any }>(
+    msg: T,
+  ) => boolean = ({ id, error, result }) => {
+    const callback = onGoingRequests.get(id)
+    if (callback) {
+      onGoingRequests.delete(id)
+      if (error) callback(false, error)
+      else callback(true, result)
+    }
+    return !callback
+  }
+
+  let send: <T extends {}>(msg: T) => void = () => {}
+  const provider: ParsedJsonRpcProvider = (onMsg) => {
+    const { send: _send, disconnect } = base((msg) => {
+      if (listener(msg as any)) onMsg(msg)
+    })
+    send = _send
+    return {
+      send,
+      disconnect: () => {
+        onGoingRequests.clear()
+        disconnect()
+      },
+    }
+  }
+
+  const request = <T>(
+    method: string,
+    params: Array<any>,
+    onSuccess: (x: T) => void,
+    onError: (e: any) => void,
+  ): void => {
+    const id = requestPrefix + nextId++
+    onGoingRequests.set(id, (isOk, value) => {
+      ;(isOk ? onSuccess : onError)(value)
+    })
+    send(jsonObj({ id, method, params }))
+  }
+
+  return [provider, request] as const
+}


### PR DESCRIPTION
This PR introduces a new JSON-RPC enhancer to address the performance bottleneck described in [this issue](https://github.com/paritytech/polkadot-sdk/issues/5589) on the PolkadotSDK node.

Without this enhancement, fetching all descendant values of the `NominationPools.PoolMembers` storage entry can take up to 10 minutes. With this enhancer, the same data retrieval process is reduced to under 10 seconds.

Shout out to our friends at Talisman for bringing this issue to our attention!

cc: @0xKheops @alecdwm