### PR TITLE
Getting around startup memory spike

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Reduced startup memory usage due to esbuild issue [#711](https://github.com/polkadot-api/polkadot-api/pull/711)
+
 ## 0.8.2 - 2024-09-10
 
 ### Fixed

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -7,6 +7,10 @@
 - `polkadot-sdk-compat`: Add `fixChainSpec` enhancer which addresses [the following issue](https://github.com/paritytech/polkadot-sdk/issues/5539) on the PolkadotSDK node.
 - `polkadot-sdk-compat`: Add `fixDescendantValues` enhancer which addresses [the following issue](https://github.com/paritytech/polkadot-sdk/issues/5589) on the PolkadotSDK node.
 
+### Fixed
+
+- codegen: reduced startup memory usage due to esbuild issue [#711](https://github.com/polkadot-api/polkadot-api/pull/711)
+
 ## 1.2.1 - 2024-09-10
 
 ### Fixed

--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Reduced startup memory usage due to esbuild issue [#711](https://github.com/polkadot-api/polkadot-api/pull/711)
+
 ## 0.11.0 - 2024-09-10
 
 ### Fixed


### PR DESCRIPTION
Esbuild doesn't want to fix https://github.com/evanw/esbuild/issues/3894, and we're hitting memory limits again, after upgrading papi to latest version.
This allows us to bypass binary loader and get back to normal memory usage during application startup.

I've created a small repro which fails with OOM on current papi version, but works fine with my changes. 
[papi-repro.tar.gz](https://github.com/user-attachments/files/16981888/papi-repro.tar.gz)

Fixes #654 