### PR TITLE
fix(view-builder): solve recursive shapes issue

### DIFF
--- a/packages/view-builder/CHANGELOG.md
+++ b/packages/view-builder/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.3.4 - 2024-09-13
+
+### Fixed
+
+- Fix issue with recursive shapes reported on [#679](https://github.com/polkadot-api/polkadot-api/issues/679)
+
 ## 0.3.4 - 2024-09-04
 
 ### Fixed

--- a/packages/view-builder/package.json
+++ b/packages/view-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot-api/view-builder",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "author": "Josep M Sobrepere (https://github.com/josepot)",
   "repository": {
     "type": "git",

--- a/packages/view-builder/src/view-builder.ts
+++ b/packages/view-builder/src/view-builder.ts
@@ -193,7 +193,8 @@ const _buildShapedDecoder = (
 
 const withPath = addPath(_buildShapedDecoder)
 const buildShapedDecoder = withCache(withPath, selfDecoder, (outter, inner) => {
-  inner.shape = outter.shape
+  inner.shape.codec = outter.shape.codec
+  ;(inner.shape as any).shape = (outter.shape as any).shape
   return outter
 })
 


### PR DESCRIPTION
Fixes #679 . Since this package is not released with the top-level client, we can release its patch in this same PR.