### PR TITLE
fix(polkadot-sdk-compat): fix unpin-hash enhancer

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - codegen: reduced startup memory usage due to esbuild issue [#711](https://github.com/polkadot-api/polkadot-api/pull/711)
+- `polkadot-sdk-compat`: Fix small bug with the unpin-hash enhancer
 
 ## 1.2.1 - 2024-09-10
 

--- a/packages/json-rpc/polkadot-sdk-compat/CHANGELOG.md
+++ b/packages/json-rpc/polkadot-sdk-compat/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Add `fixChainSpec` enhancer which addresses [the following issue](https://github.com/paritytech/polkadot-sdk/issues/5539) on the PolkadotSDK node.
 - Add `fixDescendantValues` enhancer which addresses [the following issue](https://github.com/paritytech/polkadot-sdk/issues/5589) on the PolkadotSDK node.
 
+### Fixed
+
+- Fix small bug with the unpin-hash enhancer
+
 ## 2.1.0 - 2024-09-04
 
 ### Added

--- a/packages/json-rpc/polkadot-sdk-compat/src/parsed-enhancers/unpin-hash.ts
+++ b/packages/json-rpc/polkadot-sdk-compat/src/parsed-enhancers/unpin-hash.ts
@@ -10,7 +10,7 @@ export const unpinHash: ParsedJsonRpcEnhancer = (base) => (onMsg) => {
       params[1].forEach((hash, idx) => {
         _send({
           ...rest,
-          id: idx === 0 ? id : `${id}-patched-idx`,
+          id: idx === 0 ? id : `${id}-patched-${idx}`,
           method,
           params: [params[0], hash],
         })


### PR DESCRIPTION
This bug was probably harmless, because it only affected the "fire and forget" requests... Nevertheless, it had to be fixed 😬 