### PR TITLE
Fix premature json rpc enhancer

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - `polkadot-sdk-compat`: Add `fixChainSpec` enhancer which addresses [the following issue](https://github.com/paritytech/polkadot-sdk/issues/5539) on the PolkadotSDK node.
 - `polkadot-sdk-compat`: Add `fixDescendantValues` enhancer which addresses [the following issue](https://github.com/paritytech/polkadot-sdk/issues/5589) on the PolkadotSDK node.
+- `polkadot-sdk-compat`: Add `fixDescendantValues` enhancer which addresses [the following issue](https://github.com/paritytech/polkadot-sdk/issues/5589) on the PolkadotSDK node.
+- `polkadot-sdk-compat`: Add `fixPrematureBlocks` enhancer which addresses [the following issue](https://github.com/paritytech/polkadot-sdk/issues/5761) on the PolkadotSDK node.
 - `client`: Export `CompatibilityToken` type
 
 ### Fixed

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - codegen: reduced startup memory usage due to esbuild issue [#711](https://github.com/polkadot-api/polkadot-api/pull/711)
 - `polkadot-sdk-compat`: Fix small bug with the unpin-hash enhancer
+- `json-rpc-proxy`: Added a property to identify internal "stop" events.
 
 ## 1.2.1 - 2024-09-10
 

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -15,6 +15,7 @@
 - codegen: reduced startup memory usage due to esbuild issue [#711](https://github.com/polkadot-api/polkadot-api/pull/711)
 - `polkadot-sdk-compat`: Fix small bug with the unpin-hash enhancer
 - `json-rpc-proxy`: Added a property to identify internal "stop" events.
+- `ws-provider`: Some logs when there is a transport close/error
 
 ## 1.2.1 - 2024-09-10
 

--- a/packages/json-rpc/json-rpc-provider-proxy/CHANGELOG.md
+++ b/packages/json-rpc/json-rpc-provider-proxy/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Added a property to identify internal "stop" events.
+
 ## 0.2.0 - 2024-07-18
 
 ### Fixed

--- a/packages/json-rpc/json-rpc-provider-proxy/src/subscription-manager/chainHeadFollow.ts
+++ b/packages/json-rpc/json-rpc-provider-proxy/src/subscription-manager/chainHeadFollow.ts
@@ -58,6 +58,7 @@ export const chainHeadFollow = (
             subscription: id,
             result: {
               event: STOP_EVENT,
+              eventType: "internal",
             },
           },
         }),

--- a/packages/json-rpc/polkadot-sdk-compat/CHANGELOG.md
+++ b/packages/json-rpc/polkadot-sdk-compat/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add `fixChainSpec` enhancer which addresses [the following issue](https://github.com/paritytech/polkadot-sdk/issues/5539) on the PolkadotSDK node.
 - Add `fixDescendantValues` enhancer which addresses [the following issue](https://github.com/paritytech/polkadot-sdk/issues/5589) on the PolkadotSDK node.
+- Add `fixPrematureBlocks` enhancer which addresses [the following issue](https://github.com/paritytech/polkadot-sdk/issues/5761) on the PolkadotSDK node.
 
 ### Fixed
 

--- a/packages/json-rpc/polkadot-sdk-compat/src/index.ts
+++ b/packages/json-rpc/polkadot-sdk-compat/src/index.ts
@@ -7,13 +7,17 @@ import {
   fixUnorderedBlocks,
   fixChainSpec,
   fixDescendantValues,
+  fixPrematureBlocks,
 } from "./parsed-enhancers"
+import * as methods from "./methods"
+export { methods }
 
 const withPolkadotSdkCompat = parsed(
   translate,
   fixUnorderedEvents,
   unpinHash,
   patchChainHeadEvents,
+  fixPrematureBlocks,
   fixUnorderedBlocks,
   fixChainSpec,
   fixDescendantValues,
@@ -28,4 +32,5 @@ export {
   patchChainHeadEvents,
   fixUnorderedBlocks,
   fixDescendantValues,
+  fixPrematureBlocks,
 }

--- a/packages/json-rpc/polkadot-sdk-compat/src/parsed-enhancers/fix-premature-blocks.ts
+++ b/packages/json-rpc/polkadot-sdk-compat/src/parsed-enhancers/fix-premature-blocks.ts
@@ -1,0 +1,131 @@
+import { chainHead } from "@/methods"
+import type { ParsedJsonRpcEnhancer } from "@/parsed"
+
+interface InitializedRpc {
+  event: "initialized"
+  finalizedBlockHashes: string[]
+}
+
+interface NewBlockRpc {
+  event: "newBlock"
+  blockHash: string
+  parentBlockHash: string
+}
+
+interface BestBlockChangedRpc {
+  event: "bestBlockChanged"
+  bestBlockHash: string
+}
+
+interface FinalizedRpc {
+  event: "finalized"
+  finalizedBlockHashes: Array<string>
+  prunedBlockHashes: Array<string>
+}
+
+export interface StopRpc {
+  event: "stop"
+}
+
+type FollowEvent =
+  | InitializedRpc
+  | NewBlockRpc
+  | BestBlockChangedRpc
+  | FinalizedRpc
+  | StopRpc
+
+export const fixPrematureBlocks: ParsedJsonRpcEnhancer = (base) => (onMsg) => {
+  const pendingChainHeadSubs = new Set<string>()
+  const pinnedBlocksInSub = new Map<string, Set<string>>()
+  const prematureBlocks = new Map<string, Map<string, Array<{}>>>()
+
+  const { send: originalSend, disconnect } = base((message) => {
+    // it's a response
+    if ("id" in message) {
+      onMsg(message)
+      const { id, result } = message as unknown as {
+        id: string
+        result: string
+      }
+
+      if (pendingChainHeadSubs.has(id)) {
+        pendingChainHeadSubs.delete(id)
+        pinnedBlocksInSub.set(result, new Set())
+        prematureBlocks.set(result, new Map())
+        return
+      }
+    } else {
+      // it's a notification
+      const { subscription } = (message as any).params
+      const pinnedBlocks = pinnedBlocksInSub.get(subscription)
+      const prematureSub = prematureBlocks.get(subscription)!
+      if (pinnedBlocks) {
+        const result = (message as any).params.result as FollowEvent
+        const { event } = result
+        if (event === "initialized") {
+          result.finalizedBlockHashes.forEach((hash) => {
+            pinnedBlocks.add(hash)
+          })
+        }
+
+        if (event === "newBlock") {
+          const { parentBlockHash } = result
+          if (!pinnedBlocks.has(parentBlockHash)) {
+            const list = prematureSub.get(parentBlockHash) ?? []
+            list.push(message)
+            prematureSub.set(parentBlockHash, list)
+            return
+          }
+
+          const hash = result.blockHash
+          pinnedBlocks.add(result.blockHash)
+          onMsg(message)
+
+          const prematureMessages = prematureSub.get(hash)
+          if (prematureMessages) {
+            prematureSub.delete(hash)
+            prematureMessages.forEach((msg) => {
+              pinnedBlocks.add((msg as any).params.result.blockHash)
+              onMsg(msg)
+            })
+          }
+          return
+        }
+
+        if (event === "stop") {
+          pinnedBlocks.delete(subscription)
+          prematureBlocks.delete(subscription)
+        }
+      }
+      onMsg(message)
+    }
+  })
+
+  const send = (msg: any) => {
+    const subId = msg.params[0]
+    switch (msg.method) {
+      case chainHead.follow:
+        pendingChainHeadSubs.add(msg.id)
+        break
+
+      case chainHead.unpin:
+        const [subscription, blocks] = msg.params as [string, string[]]
+        blocks.forEach((block) => {
+          pinnedBlocksInSub.get(subscription)?.delete(block)
+          prematureBlocks.get(subscription)?.delete(block)
+        })
+        break
+
+      case chainHead.unfollow:
+        pinnedBlocksInSub.delete(subId)
+        prematureBlocks.delete(subId)
+        break
+    }
+    originalSend(msg)
+  }
+
+  return {
+    send,
+    disconnect,
+  }
+}

--- a/packages/json-rpc/polkadot-sdk-compat/src/parsed-enhancers/index.ts
+++ b/packages/json-rpc/polkadot-sdk-compat/src/parsed-enhancers/index.ts
@@ -1,4 +1,5 @@
 export { fixChainSpec } from "./chain-spec"
+export { fixPrematureBlocks } from "./fix-premature-blocks"
 export { fixDescendantValues } from "./fix-descendant-values"
 export { fixUnorderedBlocks } from "./fix-unordered-blocks"
 export { fixUnorderedEvents } from "./fix-unordered-events"

--- a/packages/json-rpc/ws-provider/CHANGELOG.md
+++ b/packages/json-rpc/ws-provider/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Some logs when there is a transport close/error
+
 ## 0.2.0 - 2024-08-12
 
 ### Changed

--- a/packages/json-rpc/ws-provider/src/ws-provider.ts
+++ b/packages/json-rpc/ws-provider/src/ws-provider.ts
@@ -30,10 +30,17 @@ export const getInternalWsProvider =
         const _onMessage = (e: MessageEvent) => {
           if (typeof e.data === "string") onMessage(e.data)
         }
+        const innerHalt = (reason: string) => (e: any) => {
+          console.warn(`WS halt (${reason})`)
+          console.log(e)
+          onHalt()
+        }
+        const onError = innerHalt("err")
+        const onClose = innerHalt("close")
 
         socket.addEventListener("message", _onMessage)
-        socket.addEventListener("error", onHalt)
-        socket.addEventListener("close", onHalt)
+        socket.addEventListener("error", onError)
+        socket.addEventListener("close", onClose)
 
         return {
           send: (msg) => {
@@ -41,8 +48,8 @@ export const getInternalWsProvider =
           },
           disconnect: () => {
             socket.removeEventListener("message", _onMessage)
-            socket.removeEventListener("error", onHalt)
-            socket.removeEventListener("close", onHalt)
+            socket.removeEventListener("error", onError)
+            socket.removeEventListener("close", onClose)
             socket.close()
           },
         }


### PR DESCRIPTION
There are 3 commits in this PR. They are all a bit related:
1) add the `fixPrematureBlocks` enhancer which fixes #713 which is a confirmed bug on the [polkadot-sdk node](https://github.com/paritytech/polkadot-sdk/issues/5761). I have been able to test the enhancer when the issue occurs and things keep working perfectly fine.
2) As of today it's not possible to know whether a stop event comes from the outside or it was triggered by the json-rpc-provider-proxy. The second commit adds a property to distinguish the internal from the external stop events.
3) Improve the logs of the ws-provider.