### PR TITLE
fix(pjs-signer): incorrect PJS injected account type

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- `pjs-signer`: Fix incorrect PJS injected account type
 - Update dependencies
 
 ## 1.3.3 - 2024-09-24

--- a/packages/signers/pjs-signer/CHANGELOG.md
+++ b/packages/signers/pjs-signer/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix incorrect PJS injected account type
+
 ### Fixed
 
 - Update dependencies

--- a/packages/signers/pjs-signer/src/types.ts
+++ b/packages/signers/pjs-signer/src/types.ts
@@ -131,8 +131,8 @@ export interface PjsInjectedExtension {
     signRaw: SignRaw
   }
   accounts: {
-    get: () => Promise<InjectedPolkadotAccount[]>
-    subscribe: (cb: (accounts: InjectedPolkadotAccount[]) => void) => () => void
+    get: () => Promise<InjectedAccount[]>
+    subscribe: (cb: (accounts: InjectedAccount[]) => void) => () => void
   }
 }
 


### PR DESCRIPTION
I believe these accounts are just plain `InjectedAccount` until transformed with `toPolkadotInjected`.