### PR TITLE
feat(ws-provider): new APIs and improvements

### DIFF
--- a/examples/bun/src/switch-rpcs.ts
+++ b/examples/bun/src/switch-rpcs.ts
@@ -1,0 +1,35 @@
+import { CompatibilityLevel, createClient } from "polkadot-api"
+import { getWsProvider } from "polkadot-api/ws-provider/web"
+import { wnd } from "@polkadot-api/descriptors"
+
+const wsProvider = getWsProvider(
+  [
+    "wss://polkadot-rpc.publicnode.com",
+    "wss://polkadot-public-rpc.blockops.network/ws",
+    "wss://rpc.ibp.network/polkadot",
+    "wss://rpc-polkadot.luckyfriday.io",
+    "wss://polkadot.api.onfinality.io/public-ws",
+  ],
+  (x) => {
+    console.log(x)
+  },
+)
+const client = createClient(wsProvider)
+const testApi = client.getTypedApi(wnd)
+
+client.finalizedBlock$.subscribe(console.log, console.error)
+testApi.query.System.Account.watchValue(
+  "5GvW9jJnq5J7KYAtYfdi88zXxVT3Z6dHHr6cgBgMpkVhPVrp",
+).subscribe(console.log, console.error)
+
+console.log("sync switch")
+wsProvider.switch()
+
+const switchWs = async () => {
+  await new Promise((res) => setTimeout(res, 12_000))
+  console.log("switching")
+  wsProvider.switch()
+  switchWs()
+}
+
+switchWs()

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,16 +6,26 @@
 
 - Add UMD export
 - Add `getUnsafeApi`
-- New overload which allows to pass a list of endpoints. So, that if one fails the client
-  will automatically rotate over them.
-- APIs for introspecting the connection status of the protocol layer.
+
+- **WS Provider:**
+  - Introduced support for multiple endpoints. The client now rotates between provided endpoints in case of connection issues.
+  - Added two options for introspection on protocol status:
+    - Pass a `statusChange` callback when creating the client to receive updates on the connection status.
+    - Call the `getStatus` function on the `WsJsonRpcProvider` to retrieve the current status of the protocol layer.
+
+### Changed
+
+- **WS Provider:**
+  - The client can now proactively trigger a switch to a different endpoint, giving users more control over which endpoint to use.
 
 ### Fixed
 
 - If a connections doesn't open in a timely manner, then the client will try to reconnect with the next endpoint.
-
 - `pjs-signer`: Fix incorrect PJS injected account type
 - `chains`: Update `lightSyncState`
+
+- **WS Provider:**
+  - Automatic timeout handling: the client will now timeout if the connection to the RPC doesn't open in a timely manner and will attempt to reconnect with the next available RPC endpoint.
 
 ## 1.3.3 - 2024-09-24
 

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,8 +6,13 @@
 
 - Add UMD export
 - Add `getUnsafeApi`
+- New overload which allows to pass a list of endpoints. So, that if one fails the client
+  will automatically rotate over them.
+- APIs for introspecting the connection status of the protocol layer.
 
 ### Fixed
+
+- If a connections doesn't open in a timely manner, then the client will try to reconnect with the next endpoint.
 
 - `pjs-signer`: Fix incorrect PJS injected account type
 - `chains`: Update `lightSyncState`

--- a/packages/json-rpc/ws-provider/CHANGELOG.md
+++ b/packages/json-rpc/ws-provider/CHANGELOG.md
@@ -2,9 +2,20 @@
 
 ## Unreleased
 
+### Added
+
+- Introduced support for multiple endpoints. The client now rotates between provided endpoints in case of connection issues.
+- Added two options for introspection on protocol status:
+  - Pass a `statusChange` callback when creating the client to receive updates on the connection status.
+  - Call the `getStatus` function on the `WsJsonRpcProvider` to retrieve the current status of the protocol layer.
+
+### Changed
+
+- The client can now proactively trigger a switch to a different endpoint, giving users more control over which endpoint to use.
+
 ### Fixed
 
-- patch dependencies
+- Automatic timeout handling: the client will now timeout if the connection to the RPC doesn't open in a timely manner and will attempt to reconnect with the next available RPC endpoint.
 
 ## 0.2.2 - 2024-09-20
 

--- a/packages/json-rpc/ws-provider/src/ws-provider.ts
+++ b/packages/json-rpc/ws-provider/src/ws-provider.ts
@@ -1,56 +1,185 @@
 import type { JsonRpcProvider } from "@polkadot-api/json-rpc-provider"
 import { getSyncProvider } from "@polkadot-api/json-rpc-provider-proxy"
 
-export const getInternalWsProvider =
-  (WebsocketClass: typeof WebSocket) =>
-  (uri: string, protocols?: string | string[]): JsonRpcProvider =>
-    getSyncProvider(async () => {
+export enum WsEvent {
+  CONNECTING,
+  CONNECTED,
+  ERROR,
+  CLOSE,
+}
+export type WsConnecting = {
+  type: WsEvent.CONNECTING
+  uri: string
+  protocols?: string | string[]
+}
+export type WsConnected = {
+  type: WsEvent.CONNECTED
+  uri: string
+  protocols?: string | string[]
+}
+export type WsError = {
+  type: WsEvent.ERROR
+  event: any
+}
+export type WsClose = {
+  type: WsEvent.CLOSE
+  event: any
+}
+export type StatusChange = WsConnecting | WsConnected | WsError | WsClose
+export type WsJsonRpcProvider = JsonRpcProvider & {
+  switch: (uri?: string, protocol?: string[]) => void
+  getStatus: () => StatusChange
+}
+
+export interface GetWsProviderInput {
+  (
+    uri: string,
+    protocols?: string | string[],
+    onStatusChanged?: (status: StatusChange) => void,
+  ): WsJsonRpcProvider
+  (
+    uri: string,
+    onStatusChanged?: (status: StatusChange) => void,
+  ): WsJsonRpcProvider
+  (
+    endpoints: Array<string | { uri: string; protocol: string[] }>,
+    onStatusChanged?: (status: StatusChange) => void,
+  ): WsJsonRpcProvider
+}
+
+const timeoutError: StatusChange = {
+  type: WsEvent.ERROR,
+  event: { type: "timeout" },
+}
+
+const noop = () => {}
+export const getInternalWsProvider = (
+  WebsocketClass: typeof WebSocket,
+): GetWsProviderInput => {
+  return (...args): WsJsonRpcProvider => {
+    let endpoints: Array<[string, string | string[]] | [string]> = []
+    let onStatusChanged: (status: StatusChange) => void = noop
+
+    if (typeof args[1] === "function") onStatusChanged = args[1]
+    if (Array.isArray(args[0]))
+      endpoints = args[0].map((x) =>
+        typeof x === "string" ? [x] : [x.uri, x.protocol],
+      )
+    else {
+      endpoints = [[args[0]]]
+      if (args[1] && args[1] !== onStatusChanged)
+        endpoints[0][1] = args[1] as any
+      if (args[2]) onStatusChanged = args[2] as any
+    }
+    let idx = 0
+    let status: StatusChange
+    let switchTo: [string] | [string, string | string[]] | null = null
+    let disconnect: (withHalt?: boolean) => void = noop
+
+    const result = getSyncProvider(async () => {
+      const [uri, protocols] = switchTo || endpoints[idx++ % endpoints.length]
+      switchTo = null
       const socket = new WebsocketClass(uri, protocols)
+      onStatusChanged(
+        (status = {
+          type: WsEvent.CONNECTING,
+          uri,
+          protocols,
+        }),
+      )
 
       await new Promise<void>((resolve, reject) => {
         const onOpen = () => {
+          cleanup()
           resolve()
-          socket.removeEventListener("error", onError)
         }
-        socket.addEventListener("open", onOpen, { once: true })
 
-        const onError = (e: Event) => {
+        const onError = (e: Event | null) => {
+          cleanup()
           console.error(
             `Unable to connect to ${uri}${
               protocols ? ", protocols: " + protocols : ""
             }`,
           )
-          reject(e)
+          onStatusChanged(
+            (status = {
+              type: e ? WsEvent.ERROR : WsEvent.CLOSE,
+              event: e,
+            }),
+          )
+          setTimeout(reject, e ? 300 : 0, e)
+        }
+
+        const timeoutToken = setTimeout(() => {
+          cleanup()
+          onStatusChanged((status = timeoutError))
+          reject(timeoutError.event)
+        }, 3_500)
+        const cleanup = () => {
+          clearTimeout(timeoutToken)
+          socket.removeEventListener("error", onError)
           socket.removeEventListener("open", onOpen)
         }
-        socket.addEventListener("error", onError, { once: true })
+        socket.addEventListener("open", onOpen)
+        socket.addEventListener("error", onError)
+        disconnect = () => {
+          onError(null)
+        }
       })
+
+      onStatusChanged(
+        (status = {
+          type: WsEvent.CONNECTED,
+          uri,
+          protocols,
+        }),
+      )
 
       return (onMessage, onHalt) => {
         const _onMessage = (e: MessageEvent) => {
           if (typeof e.data === "string") onMessage(e.data)
         }
-        const innerHalt = (reason: string) => () => {
-          console.warn(`WS halt (${reason})`)
-          onHalt()
-        }
-        const onError = innerHalt("err")
-        const onClose = innerHalt("close")
+        const innerHalt =
+          (reason: WsEvent.CLOSE | WsEvent.ERROR) => (e: any) => {
+            console.warn(`WS halt (${reason})`)
+            onStatusChanged(
+              (status = {
+                type: reason,
+                event: e,
+              }),
+            )
+            onHalt()
+          }
+        const onError = innerHalt(WsEvent.ERROR)
+        const onClose = innerHalt(WsEvent.CLOSE)
 
         socket.addEventListener("message", _onMessage)
         socket.addEventListener("error", onError)
         socket.addEventListener("close", onClose)
+        disconnect = (withHalt) => {
+          disconnect = noop
+          socket.removeEventListener("message", _onMessage)
+          socket.removeEventListener("error", onError)
+          socket.removeEventListener("close", onClose)
+          socket.close()
+          if (withHalt) onClose({})
+        }
 
         return {
           send: (msg) => {
             socket.send(msg)
           },
-          disconnect: () => {
-            socket.removeEventListener("message", _onMessage)
-            socket.removeEventListener("error", onError)
-            socket.removeEventListener("close", onClose)
-            socket.close()
-          },
+          disconnect,
         }
       }
-    })
+    }) as WsJsonRpcProvider
+
+    result.getStatus = () => status
+    result.switch = (...args) => {
+      if (status.type === WsEvent.CLOSE) return
+      if (args.length) switchTo = args as any
+      if (status.type !== WsEvent.ERROR) disconnect(true)
+    }
+    return result
+  }
+}


### PR DESCRIPTION
These changes introduce a number of long-awaited improvements into the ws-provider:
1) It has a new overload which allows the consumer to pass a list of endpoints. The client will rotate over these different endpoints every time that there is a connection issue with one of them.
2) There are 2 different ways of introspecting on the status of the protocol layer:
  - Passing a `statusChange` callback when creating the client
  - Calling the `getStatus` function on the `WsJsonRpcProvider`
3) The user can proactively trigger a `switch` if they want to force the client to move to a different endpoint.
4) The client will automatically timeout if the connection with the RPC doesn't open in a timely manner, and then it will try to reconnect with the next RPC endpoint.

The current interfaces are backwards compatible with the previous one. So, there are no breaking changes. However, some interfaces have changed significantly:
- On the one hand we have the new overload on the `getWsProvider` function that I described above.
- On the other we have the fact that the `getWsProvider` now returns a `WsJsonRpcProvider` interface, which is an extended version of the `JsonRpcProvider` interface. It looks like this:

```ts
export enum WsEvent {
  CONNECTING,
  CONNECTED,
  ERROR,
  CLOSE,
}

export type WsConnecting = {
  type: WsEvent.CONNECTING
  uri: string
  protocols?: string | string[]
}

export type WsConnected = {
  type: WsEvent.CONNECTED
  uri: string
  protocols?: string | string[]
}

export type WsError = {
  type: WsEvent.ERROR
  event: any
}

export type WsClose = {
  type: WsEvent.CLOSE
  event: any
}

export type StatusChange = WsConnecting | WsConnected | WsError | WsClose

export type WsJsonRpcProvider = JsonRpcProvider & {
  switch: (uri?: string, protocol?: string[]) => void
  getStatus: () => StatusChange
}
```

Closes #531 