### PR TITLE
fix(codegen): type collision with compact numbers

### DIFF
--- a/packages/codegen/src/internal-types/generate-typescript.ts
+++ b/packages/codegen/src/internal-types/generate-typescript.ts
@@ -51,6 +51,8 @@ export const nativeNodeCodegen = (
     }
   }
   if (node.type === "union") {
+    if (node.value.length === 1) return next(node.value[0])
+
     const partResults = node.value.map(next)
     return {
       code: partResults.map(({ code }) => `(${code})`).join(" | "),

--- a/packages/codegen/src/types-builder.ts
+++ b/packages/codegen/src/types-builder.ts
@@ -107,7 +107,7 @@ export const getTypesBuilder = (
         return onlyCode(papiPrimitive.code)
       }
 
-      if (!checksum || isPrimitive(node)) {
+      if (!checksum || isPrimitive(node) || node.type === "union") {
         // It's not a lookup type nor an inlined Enum type
         // Return the primitive type or the regular codegen.
         // And if it's a chainPrimitive also return that primitive without creating


### PR DESCRIPTION
For compact numbers, the intermediate type representation is a union, which is not a primitive.

However, for codegen purposes, we can just inline union types instead of assigning an anonymous type to them. I've also removed the brackets of union types when there's only one inner type.