### PR TITLE
fix: target `es2022` and lib `es2023` on builds

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Update dependencies
+- Target ES2022 when bundling
 
 ## 0.9.4 - 2024-10-03
 

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Add missing `RuntimeToken` export type
+- Target ES2022 when bundling
 
 ## 1.4.0 - 2024-10-03
 

--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Update dependencies
+- Target ES2022 when bundling
 
 ## 0.12.2 - 2024-10-03
 

--- a/packages/descriptors/package.json
+++ b/packages/descriptors/package.json
@@ -24,7 +24,7 @@
     "dist"
   ],
   "scripts": {
-    "build-core": "tsc --noEmit && tsup-node src/index.ts --clean --sourcemap --platform neutral --target=es2020 --format esm,cjs --dts && tsup-node src/index.ts --clean --sourcemap --platform neutral --target=es2020 --format cjs --dts --minify --out-dir dist/min",
+    "build-core": "tsc --noEmit && tsup-node src/index.ts --clean --sourcemap --platform neutral --target=es2022 --format esm,cjs --dts && tsup-node src/index.ts --clean --sourcemap --platform neutral --target=es2020 --format cjs --dts --minify --out-dir dist/min",
     "build": "pnpm build-core",
     "test": "echo 'no tests'",
     "lint": "prettier --check \"src/**/*.{js,jsx,ts,tsx,json,md}\"",

--- a/packages/docgen/CHANGELOG.md
+++ b/packages/docgen/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Update dependencies
+- Target ES2022 when bundling
 
 ## 0.0.3 - 2024-10-03
 

--- a/packages/json-rpc/json-rpc-provider-proxy/CHANGELOG.md
+++ b/packages/json-rpc/json-rpc-provider-proxy/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Avoid using `Map.values().forEach()`
+- Target ES2022 when bundling
 
 ## 0.2.2 - 2024-10-03
 

--- a/packages/json-rpc/json-rpc-provider-proxy/CHANGELOG.md
+++ b/packages/json-rpc/json-rpc-provider-proxy/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Avoid using `Map.values().forEach()`
+
 ## 0.2.2 - 2024-10-03
 
 ### Fixed

--- a/packages/json-rpc/json-rpc-provider-proxy/src/get-proxy.ts
+++ b/packages/json-rpc/json-rpc-provider-proxy/src/get-proxy.ts
@@ -123,7 +123,7 @@ export const getProxy: ReconnectableJsonRpcConnection = (
           )
         })
         activeChainHeads.clear()
-        onGoingRequests.values().forEach((x) => {
+        for (const x of onGoingRequests.values()) {
           if (x.type === OngoingMsgType.ChainHeadOperation)
             onMsgFromProvider(
               jsonRpcMsg({
@@ -133,7 +133,7 @@ export const getProxy: ReconnectableJsonRpcConnection = (
               }),
             )
           else send(x.msg)
-        })
+        }
         onGoingRequests.clear()
       }
       state = {

--- a/packages/json-rpc/json-rpc-provider/CHANGELOG.md
+++ b/packages/json-rpc/json-rpc-provider/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Target ES2022 when bundling
+
 ## 0.0.3 - 2024-08-12
 
 ### Fixed

--- a/packages/json-rpc/logs-provider/CHANGELOG.md
+++ b/packages/json-rpc/logs-provider/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Target ES2022 when bundling
+
 ## 0.0.5 - 2024-09-04
 
 ### Added

--- a/packages/json-rpc/polkadot-sdk-compat/CHANGELOG.md
+++ b/packages/json-rpc/polkadot-sdk-compat/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Target ES2022 when bundling
+
 ## 2.2.1 - 2024-09-20
 
 ### Fixed

--- a/packages/json-rpc/sm-provider/CHANGELOG.md
+++ b/packages/json-rpc/sm-provider/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Update dependencies
+- Target ES2022 when bundling
 
 ## 0.1.2 - 2024-10-03
 

--- a/packages/json-rpc/sm-provider/CHANGELOG.md
+++ b/packages/json-rpc/sm-provider/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.1.2 - 2024-10-03
 
 ### Fixed

--- a/packages/json-rpc/ws-provider/CHANGELOG.md
+++ b/packages/json-rpc/ws-provider/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.3.0 - 2024-10-03
 
 ### Added

--- a/packages/json-rpc/ws-provider/CHANGELOG.md
+++ b/packages/json-rpc/ws-provider/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Update dependencies
+- Target ES2022 when bundling
 
 ## 0.3.0 - 2024-10-03
 

--- a/packages/known-chains/CHANGELOG.md
+++ b/packages/known-chains/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Target ES2022 when bundling
+
 ## 0.5.3 - 2024-10-03
 
 ### Fixed

--- a/packages/known-chains/build.sh
+++ b/packages/known-chains/build.sh
@@ -5,4 +5,4 @@ pnpm tsc --noEmit
 
 chains=$(ls -1 ./src/specs/*.ts | sed 's/\.\///g' | tr "\n" " ")
 
-pnpm tsup-node src/index.ts ${chains} --clean --sourcemap --platform neutral --target=es2020 --format esm,cjs --dts
+pnpm tsup-node src/index.ts ${chains} --clean --sourcemap --platform neutral --target=es2022 --format esm,cjs --dts

--- a/packages/merkleize-metadata/CHANGELOG.md
+++ b/packages/merkleize-metadata/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Update dependencies
+- Target ES2022 when bundling
 
 ## 1.1.5 - 2024-10-03
 

--- a/packages/metadata-builders/CHANGELOG.md
+++ b/packages/metadata-builders/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - `Compact<void>` is now resolved as `void` in lookup level
+- Target ES2022 when bundling
 
 ## 0.8.0 - 2024-10-03
 

--- a/packages/metadata-compatibility/CHANGELOG.md
+++ b/packages/metadata-compatibility/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Remove unused `Numeric` primitive.
 
+### Fixed
+
+- Target ES2022 when bundling
+
 ## 0.1.7 - 2024-10-03
 
 ### Fixed

--- a/packages/metadata-fixtures/package.json
+++ b/packages/metadata-fixtures/package.json
@@ -33,7 +33,7 @@
     "dist"
   ],
   "scripts": {
-    "build-core": "tsc --noEmit && tsup-node src/index.ts --clean --sourcemap --platform neutral --target=es2020 --format esm,cjs --dts && tsup-node src/index.ts --clean --sourcemap --platform neutral --target=es2020 --format cjs --dts --minify --out-dir dist/min",
+    "build-core": "tsc --noEmit && tsup-node src/index.ts --clean --sourcemap --platform neutral --target=es2022 --format esm,cjs --dts && tsup-node src/index.ts --clean --sourcemap --platform neutral --target=es2022 --format cjs --dts --minify --out-dir dist/min",
     "build": "pnpm build-core",
     "test": "echo 'no tests'",
     "lint": "prettier --check README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",

--- a/packages/observable-client/CHANGELOG.md
+++ b/packages/observable-client/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Update dependencies
+- Target ES2022 when bundling
 
 ## 0.5.7 - 2024-10-03
 

--- a/packages/signers/ledger-signer/CHANGELOG.md
+++ b/packages/signers/ledger-signer/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Update dependencies
+- Target ES2022 when bundling
 
 ## 0.1.2 - 2024-10-03
 

--- a/packages/signers/pjs-signer/CHANGELOG.md
+++ b/packages/signers/pjs-signer/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix incorrect PJS injected account type
+- Target ES2022 when bundling
 
 ## 0.4.3 - 2024-09-24
 

--- a/packages/signers/polkadot-signer/CHANGELOG.md
+++ b/packages/signers/polkadot-signer/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Target ES2022 when bundling
+
 ## 0.1.5 - 2024-09-24
 
 ### Added

--- a/packages/signers/signer/CHANGELOG.md
+++ b/packages/signers/signer/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Target ES2022 when bundling
+
 ## 0.1.6 - 2024-10-03
 
 ### Fixed

--- a/packages/smoldot/CHANGELOG.md
+++ b/packages/smoldot/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Target ES2022 when bundling
+
 ## 0.3.2 - 2024-08-16
 
 ### Fixed

--- a/packages/substrate-bindings/CHANGELOG.md
+++ b/packages/substrate-bindings/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Target ES2022 when bundling
+
 ## 0.9.0 - 2024-10-03
 
 ### Added

--- a/packages/substrate-client/CHANGELOG.md
+++ b/packages/substrate-client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Target ES2022 when bundling
+
 ## 0.2.1 - 2024-08-12
 
 ### Fixed

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Target ES2022 when bundling
+
 ## 0.1.1 - 2024-07-18
 
 ### Fixed

--- a/packages/view-builder/CHANGELOG.md
+++ b/packages/view-builder/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Update dependencies
+- Target ES2022 when bundling
 
 ## 0.3.7 - 2024-10-03
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "lib": ["DOM", "DOM.Iterable", "ES2023"],
     "importHelpers": true,
     "declaration": false,
     "sourceMap": false,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
+    "target": "ES2022",
     "module": "ESNext",
     "lib": ["DOM", "DOM.Iterable", "ES2023"],
     "importHelpers": true,


### PR DESCRIPTION
Iterators `forEach` is still widely experimental and is not supported on Firefox, Safari, Node LTS and Bun.

https://caniuse.com/mdn-javascript_builtins_iterator_foreach
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/forEach

Closes #770 