### PR TITLE
feat(client): add `fromAccountId32` on `FixedSizeBinary`

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- New `FixedSizeBinary` static method `fromAccountId32`
+
 ## 1.4.1 - 2024-10-05
 
 ### Fixed

--- a/packages/substrate-bindings/CHANGELOG.md
+++ b/packages/substrate-bindings/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- New `FixedSizeBinary` static method `fromAccountId32`
+
 ## 0.9.1 - 2024-10-05
 
 ### Fixed

--- a/packages/substrate-bindings/src/codecs/scale/Binary.ts
+++ b/packages/substrate-bindings/src/codecs/scale/Binary.ts
@@ -9,6 +9,8 @@ import {
 } from "scale-ts"
 import { fromHex, mergeUint8, toHex } from "@polkadot-api/utils"
 import type { HexString } from "./Hex"
+import { SS58String } from "@/utils"
+import { AccountId } from "./AccountId"
 
 const textEncoder = new TextEncoder()
 const textDecoder = new TextDecoder()
@@ -66,6 +68,7 @@ export class Binary {
   }
 }
 
+const [accountIdEncoder] = AccountId()
 export class FixedSizeBinary<_L extends number> extends Binary {
   constructor(data: Uint8Array) {
     super(data)
@@ -75,6 +78,12 @@ export class FixedSizeBinary<_L extends number> extends Binary {
     input: I,
   ) {
     return new this<L>(new Uint8Array(input))
+  }
+
+  static fromAccountId32<L extends number>(
+    input: L extends 32 ? SS58String : never,
+  ) {
+    return new this<L>(accountIdEncoder(input))
   }
 }
 


### PR DESCRIPTION
Unfortunately, some of the XCM metadata definitions point to the type-definition for a generic `[u8; 32]` type, rather than routing it via the `AccountId32` type... Because of that, the typings expect a `FixedSizeBinary<32>`. Since converting an ss58-address into a FixedSizeBinary is something that probably most users won't know how to easily do, I thought about adding this new static method to alleviate the issue.

Before:
```ts
XcmV3Junction.AccountId32({
  network: undefined,
  id: FixedSizeBinary.fromBytes(AccountId().enc(dest)),
})
```

After:
```ts
XcmV3Junction.AccountId32({
  network: undefined,
  id: FixedSizeBinary.fromAccountId32(dest),
})
```