### PR TITLE
fix(client): not throw on unknown signed-extensions

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Avoid throwing when creating a transaction that has an unknown signed-extension.
+
 ## 1.4.1 - 2024-10-05
 
 ### Fixed


### PR DESCRIPTION
We should also create an API that allows providing custom sign-extension values while creating the transaction. That PR will come later. However, it doesn't make sense not to allow the signer to deal with custom sign-extensions that the signer may want to deal on their own. So, we shouldn't throw and just provide the signer with the signed-extension data that we know how to deal with.