### PR TITLE
Add optional dappName param to `connectInjectedExtension`

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+
+- **PJS Signer:**
+  - Ability to pass the DApp name to `connectInjectedExtension`.[791](https://github.com/polkadot-api/polkadot-api/pull/791)
+
 ## 1.5.1 - 2024-10-12
 
 ### Fixed

--- a/packages/signers/pjs-signer/CHANGELOG.md
+++ b/packages/signers/pjs-signer/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Ability to pass the DApp name to `connectInjectedExtension`.[791](https://github.com/polkadot-api/polkadot-api/pull/791)
+
 ## 0.4.5 - 2024-10-11
 
 ### Fixed

--- a/packages/signers/pjs-signer/src/injected-extensions.ts
+++ b/packages/signers/pjs-signer/src/injected-extensions.ts
@@ -21,12 +21,13 @@ const supportedAccountTypes = new Set<KeypairType>([
 
 export const connectInjectedExtension = async (
   name: string,
+  dappName?: string,
 ): Promise<InjectedExtension> => {
   let entry = window.injectedWeb3?.[name]
 
   if (!entry) throw new Error(`Unavailable extension: "${name}"`)
 
-  const enabledExtension = await entry.enable()
+  const enabledExtension = await entry.enable(dappName)
   const signPayload = enabledExtension.signer.signPayload.bind(
     enabledExtension.signer,
   )

--- a/packages/signers/pjs-signer/src/types.ts
+++ b/packages/signers/pjs-signer/src/types.ts
@@ -93,7 +93,7 @@ export interface SignerPayloadJSON {
 export type InjectedWeb3 = Record<
   string,
   | {
-      enable: () => Promise<PjsInjectedExtension>
+      enable: (dappName?: string) => Promise<PjsInjectedExtension>
     }
   | undefined
 >


### PR DESCRIPTION
The `injectedWeb3.enable` function expects a Dapp name param, that is then displayed to users.
I kept it optional here so as not to break any existing implementation.. but I'm actually surprised it's been working so far without a name, since it seems to be a required param, see here https://github.com/polkadot-js/extension/blob/master/packages/extension-inject/src/bundle.ts#L42

In any case this should let users see a nice Dapp name in the authorization screen. Note that more than a nice to have, I rely on this Dapp name for testing, e.g in https://github.com/ChainSafe/cypress-polkadot-wallet so that devs can emulate an extension in a e2e environment, and authorize specific dapps, by name, programmatically. 