### PR TITLE
feat(ink): decode v5 events

### DIFF
--- a/examples/ink/package.json
+++ b/examples/ink/package.json
@@ -11,6 +11,9 @@
   "dependencies": {
     "@polkadot-api/descriptors": "file:.papi/descriptors",
     "@polkadot-api/ink-contracts": "workspace:*",
-    "polkadot-api": "workspace:*"
+    "@polkadot-labs/hdkd": "^0.0.8",
+    "@polkadot-labs/hdkd-helpers": "^0.0.8",
+    "polkadot-api": "workspace:*",
+    "rxjs": "7.8.1"
   }
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Expose `topics` on transaction events.
+
 ### Fixed
 
 - Support chains with `u64` block numbers

--- a/packages/client/src/tx/submit-fns.ts
+++ b/packages/client/src/tx/submit-fns.ts
@@ -139,7 +139,7 @@ const getTxSuccessFromSystemEvents = (
 ): Omit<TxEventsPayload, "block"> => {
   const events = systemEvents
     .filter((x) => x.phase.type === "ApplyExtrinsic" && x.phase.value === txIdx)
-    .map((x) => x.event)
+    .map((x) => ({ ...x.event, topics: x.topics }))
 
   const lastEvent = events[events.length - 1]
   if (

--- a/packages/client/src/tx/types.ts
+++ b/packages/client/src/tx/types.ts
@@ -38,6 +38,9 @@ export type TxInBestBlocksFound = {
   found: true
 } & TxEventsPayload
 
+export type EventWithTopics = SystemEvent["event"] & {
+  topics: SystemEvent["topics"]
+}
 export type TxEventsPayload = {
   /**
    * Verify if extrinsic was successful, i.e. check if `System.ExtrinsicSuccess`
@@ -48,7 +51,7 @@ export type TxEventsPayload = {
    * Array of all events emitted by the tx. Ordered as they are emitted
    * on-chain.
    */
-  events: Array<SystemEvent["event"]>
+  events: Array<EventWithTopics>
   /**
    * Block information where the tx is found. `hash` of the block, `number` of
    * the block, `index` of the tx in the block.

--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.12.5 - 2024-10-12
 
 ### Fixed

--- a/packages/ink-contracts/CHANGELOG.md
+++ b/packages/ink-contracts/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - ink-client: Add support for nested storage roots.
 
+### Changed
+
+- Dynamic builder and client accept event topics for event decoding.
+
 ## 0.1.0 - 2024-10-12
 
 Initial release

--- a/packages/ink-contracts/src/ink-client.ts
+++ b/packages/ink-contracts/src/ink-client.ts
@@ -1,12 +1,13 @@
-import { Binary } from "@polkadot-api/substrate-bindings"
+import { Binary, FixedSizeBinary } from "@polkadot-api/substrate-bindings"
 import { getInkDynamicBuilder, InkDynamicBuilder } from "./dynamic-builders"
-import { getInkLookup } from "./get-lookup"
+import { getInkLookup, InkMetadataLookup } from "./get-lookup"
 import {
   Event,
   InkCallableDescriptor,
   InkDescriptors,
   InkStorageDescriptor,
 } from "./ink-descriptors"
+import { EventSpecV5 } from "./metadata-types"
 
 export type InkCallableInterface<T extends InkCallableDescriptor> = <
   L extends string & keyof T,
@@ -52,10 +53,10 @@ export type GenericEvent =
     }
   | { type: string; value: unknown }
 export interface InkEventInterface<E> {
-  decode: (value: { data: Binary }) => E
+  decode: (value: { data: Binary }, signatureTopic?: string) => E
   filter: (
     address: string,
-    events?: Array<GenericEvent | { event: GenericEvent }>,
+    events?: Array<{ event: GenericEvent; topics: FixedSizeBinary<number>[] }>,
   ) => E[]
 }
 
@@ -90,7 +91,10 @@ export const getInkClient = <
     constructor: buildCallable(builder.buildConstructor),
     message: buildCallable(builder.buildMessage),
     storage: buildStorage(builder.buildStorage),
-    event: buildEvent(builder.buildEvent),
+    event:
+      Number(lookup.metadata.version) === 4
+        ? buildEventV4(builder.buildEvents)
+        : buildEventV5(lookup, builder.buildEvent),
   }
 }
 
@@ -124,33 +128,92 @@ const buildStorage =
     }
   }
 
-const buildEvent = <E extends Event>(
-  decoder: InkDynamicBuilder["buildEvent"],
+const buildEventV4 = <E extends Event>(
+  eventsDecoder: InkDynamicBuilder["buildEvents"],
 ): InkEventInterface<E> => {
-  const decode: InkEventInterface<E>["decode"] = (value) =>
-    decoder().dec(value.data.asBytes()) as E
+  const decode: InkEventInterface<E>["decode"] = (value) => {
+    return eventsDecoder().dec(value.data.asBytes()) as E
+  }
+  const filter: InkEventInterface<E>["filter"] = (address, events = []) => {
+    const contractEvents = events
+      .map((v) => v.event)
+      .filter(
+        (v: any) =>
+          v.type === "Contracts" &&
+          v.value.type === "ContractEmitted" &&
+          v.value.value.contract === address,
+      )
+    return contractEvents.map((v: any) => {
+      try {
+        return decode(v.value.value)
+      } catch (ex) {
+        console.error(
+          `Contract ${address} emitted an incompatible event`,
+          v.value.value,
+        )
+        throw ex
+      }
+    })
+  }
+  return { decode, filter }
+}
+
+const buildEventV5 = <E extends Event>(
+  lookup: InkMetadataLookup,
+  eventDecoder: InkDynamicBuilder["buildEvent"],
+): InkEventInterface<E> => {
+  const metadataEventTopics = new Set(
+    lookup.metadata.spec.events
+      .map((evt) => (evt as EventSpecV5).signature_topic)
+      .filter((v) => v != null),
+  )
+  const hasAnonymousEvents = lookup.metadata.spec.events.some(
+    (evt) => (evt as EventSpecV5).signature_topic == null,
+  )
+
+  const decode: InkEventInterface<E>["decode"] = (value, signatureTopic) => {
+    if (signatureTopic != null) {
+      if (!metadataEventTopics.has(signatureTopic)) {
+        throw new Error(`Event with signature topic ${value} not found`)
+      }
+      return eventDecoder(signatureTopic)!.dec(value.data.asBytes()) as E
+    }
+    if (!hasAnonymousEvents) {
+      throw new Error("Event signature topic required")
+    }
+    return eventDecoder(undefined)!.dec(value.data.asBytes()) as E
+  }
+  const filter: InkEventInterface<E>["filter"] = (address, events = []) => {
+    const contractEvents = events.filter(
+      (v) =>
+        v.event.type === "Contracts" &&
+        (v.event.value as any).type === "ContractEmitted" &&
+        (v.event.value as any).value.contract === address,
+    )
+
+    return contractEvents
+      .map((v) => {
+        const eventTopics = v.topics.map((evt) => evt.asHex())
+        const suitableTopic = eventTopics.find((topic) =>
+          metadataEventTopics.has(topic),
+        )
+        try {
+          return decode((v.event.value as any).value, suitableTopic)
+        } catch (ex) {
+          console.error(`Contract ${address} emitted an incompatible event`, {
+            event: (v.event.value as any).value.data.asHex(),
+            eventTopics,
+            metadataEventTopics: [...metadataEventTopics],
+            hasAnonymousEvents,
+          })
+          return null
+        }
+      })
+      .filter((v) => v !== null)
+  }
 
   return {
     decode,
-    filter: (address, events = []) =>
-      events
-        .map((v) => ("event" in v ? v.event : v))
-        .filter(
-          (v: any) =>
-            v.type === "Contracts" &&
-            v.value.type === "ContractEmitted" &&
-            v.value.value.contract === address,
-        )
-        .map((v: any) => {
-          try {
-            return decode(v.value.value)
-          } catch (ex) {
-            console.error(
-              `Contract ${address} emitted an incompatible event`,
-              v.value.value,
-            )
-            throw ex
-          }
-        }),
+    filter,
   }
 }

--- a/packages/ink-contracts/src/metadata-types.ts
+++ b/packages/ink-contracts/src/metadata-types.ts
@@ -78,12 +78,12 @@ interface EventSpecV4 {
   docs: string[]
 }
 
-interface EventSpecV5 extends EventSpecV4 {
+export interface EventSpecV5 extends EventSpecV4 {
   modulePath: string
-  signatureTopic?: string
+  signature_topic?: string
 }
 
-interface EventParamSpec {
+export interface EventParamSpec {
   label: string
   indexed: number
   type: TypeSpec

--- a/packages/observable-client/CHANGELOG.md
+++ b/packages/observable-client/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Improve logic of `withOptionalHash` for non-static blocks.
+- Add types of topics for SystemEvent
 
 ## 0.5.10 - 2024-10-16
 

--- a/packages/observable-client/src/chainHead/streams/get-runtime-creator.ts
+++ b/packages/observable-client/src/chainHead/streams/get-runtime-creator.ts
@@ -5,6 +5,7 @@ import {
 } from "@polkadot-api/metadata-builders"
 import {
   AccountId,
+  Binary,
   Bytes,
   Codec,
   Decoder,
@@ -42,7 +43,7 @@ export type SystemEvent = {
       value: any
     }
   }
-  topics: Array<any>
+  topics: Array<Binary>
 }
 
 export interface RuntimeContext {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,9 +111,18 @@ importers:
       '@polkadot-api/ink-contracts':
         specifier: workspace:*
         version: link:../../packages/ink-contracts
+      '@polkadot-labs/hdkd':
+        specifier: ^0.0.8
+        version: 0.0.8
+      '@polkadot-labs/hdkd-helpers':
+        specifier: ^0.0.8
+        version: 0.0.8
       polkadot-api:
         specifier: workspace:*
         version: link:../../packages/client
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
       typescript:
         specifier: ^5.0.0
         version: 5.6.2


### PR DESCRIPTION
Previously I assumed that events in ink! are encoded as enums, just like regular events.

However, this changed [on ink! v5](https://use.ink/faq/migrating-from-ink-4-to-5#events-20), where only the payload is encoded. To know which codec to use, now events come with a `signatureTopic` so they can be looked up from the `topics` array on events. This PR adds support for v5 events by decoding them through the signatureTopic.