### PR TITLE
fix(ink-codegen): keep original storage layout

### DIFF
--- a/packages/ink-contracts/CHANGELOG.md
+++ b/packages/ink-contracts/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-### Changed
+## Unreleased
+
+### Added
+
+- ink-client: Add support for nested storage roots.
 
 ## 0.1.0 - 2024-10-12
 

--- a/packages/ink-contracts/src/get-lookup.ts
+++ b/packages/ink-contracts/src/get-lookup.ts
@@ -127,7 +127,10 @@ function getStorageLayout(metadata: InkMetadata, lookup: V14Lookup) {
       }
 
       // Anyone addressing this node will encounter an empty type
-      return null
+      return addType({
+        tag: "composite",
+        value: [],
+      })
     }
     if ("leaf" in node) {
       return node.leaf.ty


### PR DESCRIPTION
I had an issue on the previous implementation - By reusing lookupEntries we can also reuse the existing codegen to generate the types for ink! storage, but because lookup resolves pointers (composites of just one element) and nested root layouts were being removed, this resulted in an inaccurate representation.

As an example, standard PSP22 has a `data` field in storage with the following layout:
```ts
data: {
  type: "struct",
  value: [{
    name: "total_supply",
    type: "u128"
  }, {
    name: "balances",
    type: "root(Map<AccountId, u128>)"
  }, {
    name: "allowances",
    type: "root(DoubleMap<[AccountId,AccountId], u128>)"
  }]
}
```

The previous implementation would leave `balances` and `allowances` empty, because they are nested storage roots, so `data` would become a struct with a single field `total_supply` => normalised as a pointer on lookup. The resulting codegen would output:

```ts
data: bigint
```

Which is fine, but for a higher level library is annoying because I'd like to undo the nesting, and having a `bigint` instead of the original object makes it impossible. 

With this change, `balances` and `allowances` are kept in the struct, but as `void`s. This ensures the struct is not normalised as a pointer, and codegen outputs:

```ts
data: { totalSupply: bigint }
```