### PR TITLE
Fix race condition on emitted socket 'error' events

### DIFF
--- a/packages/json-rpc/ws-provider/src/ws-provider.ts
+++ b/packages/json-rpc/ws-provider/src/ws-provider.ts
@@ -82,7 +82,6 @@ export const getInternalWsProvider = (
         }
 
         const timeoutToken = setTimeout(() => {
-          cleanup()
           onStatusChanged((status = timeoutError))
           reject(timeoutError.event)
         }, 3_500)


### PR DESCRIPTION
The cleanup function in the socket connect timeout logic removes the socket listeners before the promise is rejected.
If an event is emitted in this time interval an unhandled and uncatcheable error occurs.

To reproduce:
```typescript
import {  getWsProvider } from 'polkadot-api/ws-provider/node'

getWsProvider("https://www.randomkittengenerator.com/")(console.log)
```

Log:
```shell
Unable to connect to https://www.randomkittengenerator.com/
Unable to connect to https://www.randomkittengenerator.com/
Unable to connect to https://www.randomkittengenerator.com/
Unable to connect to https://www.randomkittengenerator.com/
Unable to connect to https://www.randomkittengenerator.com/
Unable to connect to https://www.randomkittengenerator.com/
Unable to connect to https://www.randomkittengenerator.com/
Unable to connect to https://www.randomkittengenerator.com/
Unable to connect to https://www.randomkittengenerator.com/
Unable to connect to https://www.randomkittengenerator.com/
Unable to connect to https://www.randomkittengenerator.com/
node:events:496
      throw er; // Unhandled 'error' event
      ^

Error: Unexpected server response: 200
    at ClientRequest.<anonymous> (/home/marc/Development/ocelloids-server/node_modules/ws/lib/websocket.js:913:7)
    at ClientRequest.emit (node:events:518:28)
    at HTTPParser.parserOnIncomingClient [as onIncoming] (node:_http_client:693:27)
    at HTTPParser.parserOnHeadersComplete (node:_http_common:119:17)
    at TLSSocket.socketOnData (node:_http_client:535:22)
    at TLSSocket.emit (node:events:518:28)
    at addChunk (node:internal/streams/readable:559:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:510:3)
    at Readable.push (node:internal/streams/readable:390:5)
    at TLSWrap.onStreamRead (node:internal/stream_base_commons:190:23)
Emitted 'error' event on WS instance at:
    at emitErrorAndClose (/home/marc/Development/ocelloids-server/node_modules/ws/lib/websocket.js:1041:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)

Node.js v20.11.0
```

Of course, the number of attempts would vary :)