### PR TITLE
fix(ws-provider): `follow` enhancer

### DIFF
--- a/packages/json-rpc/ws-provider/CHANGELOG.md
+++ b/packages/json-rpc/ws-provider/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Added an internal `followEnhancer` to address issues with certain RPC providers where misconfigured middlewares incorrectly trigger errors on `chainHead_v1_follow` requests, even though the client hasn't reached the 2-subscription limit.
+
 ## 0.3.4 - 2024-10-31
 
 ### Added

--- a/packages/json-rpc/ws-provider/src/follow-enhancer.ts
+++ b/packages/json-rpc/ws-provider/src/follow-enhancer.ts
@@ -1,0 +1,86 @@
+import { JsonRpcProvider } from "@polkadot-api/json-rpc-provider"
+import { WsJsonRpcProvider } from "./types"
+
+const methods: Record<string, "follow" | "unfollow"> = {}
+;["v1", "unstable"].forEach((version) => {
+  methods[`chainHead_${version}_follow`] = "follow"
+  methods[`chainHead_${version}_unfollow`] = "unfollow"
+})
+
+export const followEnhancer: (input: WsJsonRpcProvider) => WsJsonRpcProvider = (
+  base,
+) => {
+  const { getStatus } = base
+  const prematureStops = new Set<string>()
+  const preOpId = new Set<string>()
+  const onGoing = new Set<string>()
+
+  const clear = () => {
+    prematureStops.clear()
+    preOpId.clear()
+    onGoing.clear()
+  }
+  const enhancedSwitch: typeof base.switch = (...args) => {
+    clear()
+    base.switch(...args)
+  }
+
+  const result: JsonRpcProvider = (onMsg) => {
+    const { send, disconnect } = base((fromProvider) => {
+      const parsed = JSON.parse(fromProvider)
+      // it's a response
+      if ("id" in parsed) {
+        const { id, result } = parsed
+        if (preOpId.has(id)) {
+          preOpId.delete(id)
+          if (prematureStops.has(result)) {
+            prematureStops.delete(result)
+            return
+          }
+
+          onGoing.add(result)
+          const currentSize = onGoing.size + preOpId.size
+          if (currentSize > 2)
+            console.warn(
+              `Too many chainHead follow subscriptions (${currentSize})`,
+            )
+          else if (parsed.error) {
+            console.warn(`chainHead follow failed on the ${currentSize} sub`)
+            Promise.resolve().then(() => enhancedSwitch())
+            return
+          }
+        }
+      } else {
+        // it's a notifiaction
+        const { subscription, result } = (parsed as any).params
+        if (result?.event === "stop") {
+          if (onGoing.has(subscription)) onGoing.delete(subscription)
+          else prematureStops.add(subscription)
+        }
+      }
+      onMsg(fromProvider)
+    })
+
+    return {
+      send(toProvider) {
+        const parsed = JSON.parse(toProvider)
+        const method = methods[parsed.method]
+        if (method === "follow") {
+          preOpId.add(parsed.id)
+        } else if (method === "unfollow") {
+          onGoing.delete(parsed.params[0])
+        }
+        send(toProvider)
+      },
+      disconnect() {
+        clear()
+        disconnect()
+      },
+    }
+  }
+
+  return Object.assign(result, {
+    getStatus,
+    switch: enhancedSwitch,
+  })
+}

--- a/packages/json-rpc/ws-provider/src/ws-provider.ts
+++ b/packages/json-rpc/ws-provider/src/ws-provider.ts
@@ -54,122 +54,131 @@ export const getInternalWsProvider = (
     let switchTo: [string] | [string, string | string[]] | null = null
     let disconnect: (withHalt?: boolean) => void = noop
 
-    const result = getSyncProvider(async () => {
-      const [uri, protocols] = switchTo || endpoints[idx++ % endpoints.length]
-      switchTo = null
-      const socket = new WebsocketClass(uri, protocols)
-      const forceSocketClose = () => {
-        try {
-          socket.addEventListener("error", noop, { once: true })
-          socket.close()
-        } catch {}
-      }
-      onStatusChanged(
-        (status = {
-          type: WsEvent.CONNECTING,
-          uri,
-          protocols,
-        }),
-      )
-
-      await new Promise<void>((resolve, reject) => {
-        const onOpen = () => {
-          initialCleanup()
-          resolve()
+    let outerCleanup: () => void = noop
+    const result = followEnhancer(
+      getSyncProvider(async () => {
+        const [uri, protocols] = switchTo || endpoints[idx++ % endpoints.length]
+        switchTo = null
+        const socket = new WebsocketClass(uri, protocols)
+        const forceSocketClose = () => {
+          try {
+            socket.addEventListener("error", noop, { once: true })
+            socket.close()
+          } catch {}
         }
+        onStatusChanged(
+          (status = {
+            type: WsEvent.CONNECTING,
+            uri,
+            protocols,
+          }),
+        )
 
-        const onError = (e: Event | null) => {
-          initialCleanup()
-          if (e == null) forceSocketClose()
-          console.error(
-            `Unable to connect to ${uri}${
-              protocols ? ", protocols: " + protocols : ""
-            }`,
-          )
-          onStatusChanged(
-            (status = {
-              type: e ? WsEvent.ERROR : WsEvent.CLOSE,
-              event: e,
-            }),
-          )
-          setTimeout(reject, e ? 300 : 0, e)
-        }
+        await new Promise<void>((resolve, reject) => {
+          const onOpen = () => {
+            initialCleanup()
+            resolve()
+          }
 
-        const timeoutToken =
-          timeout !== Infinity
-            ? setTimeout(() => {
-                initialCleanup()
-                forceSocketClose()
-                onStatusChanged((status = timeoutError))
-                reject(timeoutError.event)
-              }, timeout)
-            : undefined
-
-        const initialCleanup = () => {
-          clearTimeout(timeoutToken)
-          socket.removeEventListener("error", onError)
-          socket.removeEventListener("open", onOpen)
-        }
-        socket.addEventListener("open", onOpen)
-        socket.addEventListener("error", onError)
-        disconnect = () => {
-          onError(null)
-        }
-      })
-
-      onStatusChanged(
-        (status = {
-          type: WsEvent.CONNECTED,
-          uri,
-          protocols,
-        }),
-      )
-
-      return (onMessage, onHalt) => {
-        const _onMessage = (e: MessageEvent) => {
-          if (typeof e.data === "string") onMessage(e.data)
-        }
-        const innerHalt =
-          (reason: WsEvent.CLOSE | WsEvent.ERROR) => (e: any) => {
-            console.warn(`WS halt (${reason})`)
+          const onError = (e: Event | null) => {
+            initialCleanup()
+            if (e == null) forceSocketClose()
+            console.error(
+              `Unable to connect to ${uri}${
+                protocols ? ", protocols: " + protocols : ""
+              }`,
+            )
             onStatusChanged(
               (status = {
-                type: reason,
+                type: e ? WsEvent.ERROR : WsEvent.CLOSE,
                 event: e,
               }),
             )
-            onHalt()
+            setTimeout(reject, e ? 300 : 0, e)
           }
-        const onError = innerHalt(WsEvent.ERROR)
-        const onClose = innerHalt(WsEvent.CLOSE)
 
-        socket.addEventListener("message", _onMessage)
-        socket.addEventListener("error", onError)
-        socket.addEventListener("close", onClose)
-        disconnect = (withHalt) => {
-          disconnect = noop
-          socket.removeEventListener("message", _onMessage)
-          socket.removeEventListener("error", onError)
-          socket.removeEventListener("close", onClose)
-          forceSocketClose()
-          if (withHalt) onClose({})
+          const timeoutToken =
+            timeout !== Infinity
+              ? setTimeout(() => {
+                  initialCleanup()
+                  forceSocketClose()
+                  onStatusChanged((status = timeoutError))
+                  reject(timeoutError.event)
+                }, timeout)
+              : undefined
+
+          const initialCleanup = () => {
+            clearTimeout(timeoutToken)
+            socket.removeEventListener("error", onError)
+            socket.removeEventListener("open", onOpen)
+          }
+          socket.addEventListener("open", onOpen)
+          socket.addEventListener("error", onError)
+          disconnect = () => {
+            onError(null)
+          }
+        })
+
+        onStatusChanged(
+          (status = {
+            type: WsEvent.CONNECTED,
+            uri,
+            protocols,
+          }),
+        )
+
+        return (onMessage, onHalt) => {
+          const _onMessage = (e: MessageEvent) => {
+            if (typeof e.data === "string") onMessage(e.data)
+          }
+          const innerHalt =
+            (reason: WsEvent.CLOSE | WsEvent.ERROR) => (e: any) => {
+              console.warn(`WS halt (${reason})`)
+              onStatusChanged(
+                (status = {
+                  type: reason,
+                  event: e,
+                }),
+              )
+              onHalt()
+            }
+          const onError = innerHalt(WsEvent.ERROR)
+          const onClose = innerHalt(WsEvent.CLOSE)
+
+          socket.addEventListener("message", _onMessage)
+          socket.addEventListener("error", onError)
+          socket.addEventListener("close", onClose)
+          disconnect = (withHalt) => {
+            outerCleanup()
+            disconnect = noop
+            socket.removeEventListener("message", _onMessage)
+            socket.removeEventListener("error", onError)
+            socket.removeEventListener("close", onClose)
+            forceSocketClose()
+            if (withHalt) onClose({})
+          }
+
+          return {
+            send: (msg) => {
+              socket.send(msg)
+            },
+            disconnect,
+          }
         }
+      }),
+      () => {
+        switchFn()
+      },
+    )
+    outerCleanup = result.cleanup
+    delete (result as any).cleanup
 
-        return {
-          send: (msg) => {
-            socket.send(msg)
-          },
-          disconnect,
-        }
-      }
-    }) as WsJsonRpcProvider
-
-    result.getStatus = () => status
-    result.switch = (...args) => {
+    const switchFn: WsJsonRpcProvider["switch"] = (...args) => {
       if (status.type === WsEvent.CLOSE) return
       if (args.length) switchTo = args as any
       if (status.type !== WsEvent.ERROR) disconnect(true)
     }
-    return followEnhancer(result)
+
+    return Object.assign(result, { switch: switchFn, getStatus: () => status })
   }
 }

--- a/packages/json-rpc/ws-provider/src/ws-provider.ts
+++ b/packages/json-rpc/ws-provider/src/ws-provider.ts
@@ -6,6 +6,7 @@ import {
   WsEvent,
   WsProviderConfig,
 } from "./types"
+import { followEnhancer } from "./follow-enhancer"
 
 const timeoutError: StatusChange = {
   type: WsEvent.ERROR,
@@ -169,6 +170,6 @@ export const getInternalWsProvider = (
       if (args.length) switchTo = args as any
       if (status.type !== WsEvent.ERROR) disconnect(true)
     }
-    return result
+    return followEnhancer(result)
   }
 }


### PR DESCRIPTION
Added an internal `followEnhancer` to address issues with certain RPC providers where misconfigured middlewares incorrectly trigger errors on `chainHead_v1_follow` requests, even though the client hasn't reached the 2-subscription limit.

What the enhancer does is to trigger a `switch` on the `WsJsonRpcProvider` when this situation occurs. The reason why this is effective is because the issue with these RPC providers is that they perform a round-robin on the underlying stateful WS connections with the PolkadotSDK nodes. Therefore, disconnecting and reconnecting can help at hitting a different PolkadotSDK node in which the limit has not yet being reached. It's worth pointing out that this is just an attempt on alleviating an upstream problem that must be addressed by these RPC providers.

The enhancer also detects wether the consumer is opening more chainHead follow subscriptions than what's allowed, and if it does, then it logs a console warning. 