### PR TITLE
fix(sm-provider): prevent infinite loop

### DIFF
--- a/packages/json-rpc/sm-provider/CHANGELOG.md
+++ b/packages/json-rpc/sm-provider/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Prevent the smoldot provider from entering in an infinite loop when either smoldot or the chain crashes.
+
 ## 0.1.5 - 2024-10-06
 
 - Update dependencies


### PR DESCRIPTION
Fixes #620. Also, this has made it very obvious that we should provide a different overload, so that the consumer can pass a factory function, so that they have the opportunity to create a non-dead chain.