### PR TITLE
Fix JSON-RPC providers

### DIFF
--- a/packages/json-rpc/json-rpc-provider-proxy/CHANGELOG.md
+++ b/packages/json-rpc/json-rpc-provider-proxy/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Properly handle errored requests.
+
 ## 0.2.3 - 2024-10-05
 
 ### Fixed

--- a/packages/json-rpc/json-rpc-provider-proxy/src/get-proxy.ts
+++ b/packages/json-rpc/json-rpc-provider-proxy/src/get-proxy.ts
@@ -46,12 +46,13 @@ export const getProxy: ReconnectableJsonRpcConnection = (
       const parsed = JSON.parse(msg)
       if ("id" in parsed) {
         if (
+          "result" in parsed &&
           state.onGoingRequests.get(parsed.id)?.type ===
-          OngoingMsgType.ChainHeadFollow
+            OngoingMsgType.ChainHeadFollow
         )
           state.activeChainHeads.add(parsed.result)
         state.onGoingRequests.delete(parsed.id)
-      } else {
+      } else if ("params" in parsed) {
         const { subscription, result } = parsed.params
         if (result?.event === "stop")
           state.activeChainHeads.delete(subscription)

--- a/packages/json-rpc/ws-provider/CHANGELOG.md
+++ b/packages/json-rpc/ws-provider/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- `followEnhancer` should resend the errored chainHead_v1_follow request.
+
 ## 0.3.5 - 2024-11-15
 
 ### Fixed


### PR DESCRIPTION
#853 didn't quite have the effect that we expected. This PR amends that.

In order to make sure that it now has the effect that we wanted, I did test it against a custom WS proxy built with bun:

```ts
let nConnections = 0
let responseIdx = 0
const responses = [
  '{"jsonrpc":"2.0","result":{"methods":["account_nextIndex","archive_unstable_body","archive_unstable_call","archive_unstable_finalizedHeight","archive_unstable_genesisHash","archive_unstable_hashByHeight","archive_unstable_header","archive_unstable_storage","author_hasKey","author_hasSessionKeys","author_insertKey","author_pendingExtrinsics","author_removeExtrinsic","author_rotateKeys","author_submitAndWatchExtrinsic","author_submitExtrinsic","author_unwatchExtrinsic","chainHead_v1_body","chainHead_v1_call","chainHead_v1_continue","chainHead_v1_follow","chainHead_v1_header","chainHead_v1_stopOperation","chainHead_v1_storage","chainHead_v1_unfollow","chainHead_v1_unpin","chain_getBlock","chain_getBlockHash","chain_getFinalisedHead","chain_getFinalizedHead","chain_getHead","chain_getHeader","chain_getRuntimeVersion","chain_subscribeAllHeads","chain_subscribeFinalisedHeads","chain_subscribeFinalizedHeads","chain_subscribeNewHead","chain_subscribeNewHeads","chain_subscribeRuntimeVersion","chain_unsubscribeAllHeads","chain_unsubscribeFinalisedHeads","chain_unsubscribeFinalizedHeads","chain_unsubscribeNewHead","chain_unsubscribeNewHeads","chain_unsubscribeRuntimeVersion","childstate_getKeys","childstate_getKeysPaged","childstate_getKeysPagedAt","childstate_getStorage","childstate_getStorageEntries","childstate_getStorageHash","childstate_getStorageSize","dev_getBlockStats","eth_accounts","eth_blockNumber","eth_call","eth_chainId","eth_coinbase","eth_estimateGas","eth_feeHistory","eth_gasPrice","eth_getBalance","eth_getBlockByHash","eth_getBlockByNumber","eth_getBlockReceipts","eth_getBlockTransactionCountByHash","eth_getBlockTransactionCountByNumber","eth_getCode","eth_getFilterChanges","eth_getFilterLogs","eth_getLogs","eth_getStorageAt","eth_getTransactionByBlockHashAndIndex","eth_getTransactionByBlockNumberAndIndex","eth_getTransactionByHash","eth_getTransactionCount","eth_getTransactionReceipt","eth_getUncleByBlockHashAndIndex","eth_getUncleByBlockNumberAndIndex","eth_getUncleCountByBlockHash","eth_getUncleCountByBlockNumber","eth_getWork","eth_hashrate","eth_maxPriorityFeePerGas","eth_mining","eth_newBlockFilter","eth_newFilter","eth_newPendingTransactionFilter","eth_protocolVersion","eth_sendRawTransaction","eth_sendTransaction","eth_submitHashrate","eth_submitWork","eth_subscribe","eth_syncing","eth_uninstallFilter","eth_unsubscribe","net_listening","net_peerCount","net_version","offchain_localStorageGet","offchain_localStorageSet","payment_queryFeeDetails","payment_queryInfo","rpc_methods","state_call","state_callAt","state_getChildReadProof","state_getKeys","state_getKeysPaged","state_getKeysPagedAt","state_getMetadata","state_getPairs","state_getReadProof","state_getRuntimeVersion","state_getStorage","state_getStorageAt","state_getStorageHash","state_getStorageHashAt","state_getStorageSize","state_getStorageSizeAt","state_queryStorage","state_queryStorageAt","state_subscribeRuntimeVersion","state_subscribeStorage","state_traceBlock","state_unsubscribeRuntimeVersion","state_unsubscribeStorage","subscribe_newHead","system_accountNextIndex","system_addLogFilter","system_addReservedPeer","system_chain","system_chainType","system_dryRun","system_dryRunAt","system_health","system_localListenAddresses","system_localPeerId","system_name","system_nodeRoles","system_peers","system_properties","system_removeReservedPeer","system_reservedPeers","system_resetLogFilter","system_syncState","system_unstable_networkState","system_version","transactionWatch_v1_submitAndWatch","transactionWatch_v1_unwatch","transaction_v1_broadcast","transaction_v1_stop","unsubscribe_newHead","web3_clientVersion","web3_sha3"]},"id":0}',
  '{"jsonrpc": "2.0", "error": {"code": -32800, "message": "Too many subscriptions"}, "id": 1}',
]

let listener: (msg: any) => void = () => {}
const socket = new WebSocket("wss://polkadot-asset-hub-rpc.polkadot.io")
socket.addEventListener("message", (event) => {
  listener(event.data)
})

Bun.serve({
  port: 1714,
  fetch(req, server) {
    if (server.upgrade(req)) return
    return new Response("Upgrade failed", { status: 500 })
  },
  websocket: {
    message(ws, message) {
      if (nConnections < 3) ws.send(responses[responseIdx++])
      else socket.send(message)
    },
    open(ws) {
      nConnections++
      console.log("new connection", nConnections)
      responseIdx = nConnections === 1 ? 0 : 1
      if (nConnections > 2) {
        listener = (x) => {
          ws.send(x)
        }
      }
    },
    close() {},
    drain() {},
  },
})
```

which emulates the issue that some RPC providers suffer from.