### PR TITLE
fix: account for storage entries with opaque keys

### DIFF
--- a/integration-tests/zombie-tests/src/main.spec.ts
+++ b/integration-tests/zombie-tests/src/main.spec.ts
@@ -24,6 +24,7 @@ import { createClient as createRawClient } from "@polkadot-api/substrate-client"
 import { MultiAddress, roc } from "@polkadot-api/descriptors"
 import { accounts } from "./keyring"
 import { getPolkadotSigner } from "polkadot-api/signer"
+import { fromHex } from "@polkadot-api/utils"
 
 const smoldot = start()
 
@@ -404,5 +405,13 @@ describe("E2E", async () => {
 
       expect(finalNonce).toBe(intialNonce + 2)
     }
+  })
+
+  it("queries opaque storage entries", async () => {
+    const entries =
+      await api.query.CoretimeAssignmentProvider.CoreDescriptors.getEntries()
+    entries
+
+    expect(entries.every((x) => !!fromHex(x.keyArgs[0]))).toBe(true)
   })
 })

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,11 +2,19 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.9.20 - 2024-11-19
+
+### Fixed
 
 - Update dependencies
 
 ## 0.9.19 - 2024-11-18
+
+### Fixed
 
 - Update dependencies
 

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix incompatible error on storage.getEntries with partial compatibility level.
+- Handle storage entries that use opaque hashers.
 
 ## 1.7.6 - 2024-11-19
 

--- a/packages/client/src/descriptors.ts
+++ b/packages/client/src/descriptors.ts
@@ -1,11 +1,13 @@
 import type { DescriptorValues } from "@polkadot-api/codegen"
+import type { OpaqueKeyHash } from "@polkadot-api/substrate-bindings"
 
 export type PlainDescriptor<T> = { _type?: T }
 export type StorageDescriptor<
   Args extends Array<any>,
   T,
   Optional extends true | false,
-> = { _type: T; _args: Args; _optional: Optional }
+  Opaque extends string,
+> = { _type: T; _args: Args; _optional: Optional; _Opaque: Opaque }
 
 export type TxDescriptor<Args extends {} | undefined> = {
   ___: Args
@@ -17,7 +19,7 @@ export type RuntimeDescriptor<Args extends Array<any>, T> = [Args, T]
 export type DescriptorEntry<T> = Record<string, Record<string, T>>
 
 export type PalletsTypedef<
-  St extends DescriptorEntry<StorageDescriptor<any, any, any>>,
+  St extends DescriptorEntry<StorageDescriptor<any, any, any, any>>,
   Tx extends DescriptorEntry<TxDescriptor<any>>,
   Ev extends DescriptorEntry<PlainDescriptor<any>>,
   Err extends DescriptorEntry<PlainDescriptor<any>>,
@@ -46,16 +48,20 @@ export type ChainDefinition = {
 }
 
 type ExtractStorage<
-  T extends DescriptorEntry<StorageDescriptor<any, any, any>>,
+  T extends DescriptorEntry<StorageDescriptor<any, any, any, any>>,
 > = {
   [K in keyof T]: {
     [KK in keyof T[K]]: T[K][KK] extends StorageDescriptor<
       infer Key,
       infer Value,
-      infer Optional
+      infer Optional,
+      infer Opaque
     >
       ? {
           KeyArgs: Key
+          KeyArgsOut: {
+            [K in keyof Key]: K extends Opaque ? OpaqueKeyHash : Key[K]
+          }
           Value: Value
           IsOptional: Optional
         }

--- a/packages/client/src/storage.ts
+++ b/packages/client/src/storage.ts
@@ -82,6 +82,7 @@ export type StorageEntryWithKeys<
   D,
   Args extends Array<any>,
   Payload,
+  ArgsOut extends Array<any>,
 > = {
   /**
    * Get `Payload` (Promise-based) for the storage entry with a specific set of
@@ -131,17 +132,18 @@ export type StorageEntryWithKeys<
    */
   getEntries: (
     ...args: WithCallOptions<PossibleParents<Args>>
-  ) => Promise<Array<{ keyArgs: Args; value: NonNullable<Payload> }>>
+  ) => Promise<Array<{ keyArgs: ArgsOut; value: NonNullable<Payload> }>>
 } & (Unsafe extends true ? {} : CompatibilityFunctions<D>)
 
 export type StorageEntry<
   Unsafe,
   D,
   Args extends Array<any>,
+  ArgsOut extends Array<any>,
   Payload,
 > = Args extends []
   ? StorageEntryWithoutKeys<Unsafe, D, Payload>
-  : StorageEntryWithKeys<Unsafe, D, Args, Payload>
+  : StorageEntryWithKeys<Unsafe, D, Args, Payload, ArgsOut>
 
 export type Storage$ = <Type extends StorageItemInput["type"]>(
   hash: string | null,
@@ -163,7 +165,7 @@ export const createStorageEntry = (
     argsAreCompatible,
     valuesAreCompatible,
   }: CompatibilityHelper,
-): StorageEntry<any, any, any, any> => {
+): StorageEntry<any, any, any, any, any> => {
   const isSystemNumber = pallet === "System" && name === "Number"
   const sysNumberMapper$ = chainHead.runtime$.pipe(
     filter(Boolean),

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -34,6 +34,7 @@ export type StorageApi<
       string,
       | {
           KeyArgs: Array<any>
+          KeyArgsOut: Array<any>
           Value: any
           IsOptional: false | true
         }
@@ -44,6 +45,7 @@ export type StorageApi<
   [K in keyof A]: {
     [KK in keyof A[K]]: A[K][KK] extends {
       KeyArgs: Array<any>
+      KeyArgsOut: Array<any>
       Value: any
       IsOptional: false | true
     }
@@ -51,6 +53,7 @@ export type StorageApi<
           Unsafe,
           D,
           A[K][KK]["KeyArgs"],
+          A[K][KK]["KeyArgsOut"],
           A[K][KK]["IsOptional"] extends true
             ? A[K][KK]["Value"] | undefined
             : A[K][KK]["Value"]
@@ -130,7 +133,7 @@ export type AnyApi<Unsafe extends true | false, D> = D extends ChainDefinition
       >
     }
   : {
-      query: UnsafeEntry<StorageEntryWithKeys<true, D, any, any>>
+      query: UnsafeEntry<StorageEntryWithKeys<true, D, any, any, any>>
       tx: UnsafeEntry<UnsafeTxEntry<D, any, string, string, any>>
       txFromCallData: TxFromBinary<Unsafe, any>
       event: UnsafeEntry<EvClient<true, D, any>>

--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Account for storage entries that use opaque hashers.
+
 ## 0.12.8 - 2024-11-15
 
 ### Fixed

--- a/packages/codegen/src/generate-descriptors.ts
+++ b/packages/codegen/src/generate-descriptors.ts
@@ -81,9 +81,12 @@ export const generateDescriptors = (
         pallet.name,
         Object.fromEntries(
           pallet.storage?.items.map(({ name, modifier, docs }) => {
-            const { key, val } = typesBuilder.buildStorage(pallet.name, name)
+            const { key, val, opaque } = typesBuilder.buildStorage(
+              pallet.name,
+              name,
+            )
             const checksum = checksumBuilder.buildStorage(pallet.name, name)!
-            const type = `StorageDescriptor<${key}, ${val}, ${!modifier}>`
+            const type = `StorageDescriptor<${key}, ${val}, ${!modifier}, ${opaque}>`
             return [
               name,
               {

--- a/packages/codegen/src/generate-docs-descriptors.ts
+++ b/packages/codegen/src/generate-docs-descriptors.ts
@@ -311,14 +311,14 @@ async function buildStorage(
                 ]
               }
 
-              const { args, payload } = docsTypesBuilder.buildStorage(
+              const { args, payload, opaque } = docsTypesBuilder.buildStorage(
                 pallet.name,
                 name,
               )
               return [
                 name,
                 {
-                  type: `StorageDescriptor<${args}, ${payload}, ${!modifier}>`,
+                  type: `StorageDescriptor<${args}, ${payload}, ${!modifier}, ${opaque}>`,
                   docs,
                 },
               ]

--- a/packages/codegen/src/types-builder.ts
+++ b/packages/codegen/src/types-builder.ts
@@ -37,6 +37,7 @@ export const defaultDeclarations = (): CodeDeclarations => ({
   takenNames: new Set(),
 })
 
+const NEVER_STR = "never"
 const opaqueHashers = new Set<string>([
   "Blake2128",
   "Blake2256",
@@ -165,7 +166,7 @@ export const getTypesBuilder = (
       return {
         key: "[]",
         val: `${buildTypeDefinition(storageEntry.type.value)}`,
-        opaque: '""',
+        opaque: NEVER_STR,
       }
 
     const hashers = storageEntry.type.value.hashers
@@ -173,7 +174,7 @@ export const getTypesBuilder = (
       hashers
         .map((x, idx) => (opaqueHashers.has(x.tag) ? `"${idx}"` : null))
         .filter(Boolean)
-        .join(" | ") || '""'
+        .join(" | ") || NEVER_STR
 
     const { key, value } = storageEntry.type.value
     const val = buildTypeDefinition(value)
@@ -381,7 +382,7 @@ export const getDocsTypesBuilder = (
 
     if (storageEntry.type.tag === "plain")
       return {
-        opaque: '""',
+        opaque: NEVER_STR,
         args: "[]",
         payload: `${buildTypeDefinition(storageEntry.type.value)}`,
       }
@@ -394,7 +395,7 @@ export const getDocsTypesBuilder = (
       hashers
         .map((x, idx) => (opaqueHashers.has(x.tag) ? `"${idx}"` : null))
         .filter(Boolean)
-        .join(" | ") || '""'
+        .join(" | ") || NEVER_STR
 
     const returnKey =
       hashers.length === 1

--- a/packages/docgen/CHANGELOG.md
+++ b/packages/docgen/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.1.3 - 2024-11-18
 
 ### Fixed

--- a/packages/ink-contracts/CHANGELOG.md
+++ b/packages/ink-contracts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.2.1 - 2024-11-15
 
 ### Fixed

--- a/packages/merkleize-metadata/CHANGELOG.md
+++ b/packages/merkleize-metadata/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 1.1.9 - 2024-10-29
 
 ### Fixed

--- a/packages/metadata-builders/CHANGELOG.md
+++ b/packages/metadata-builders/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.9.1 - 2024-10-29
 
 ### Fixed

--- a/packages/metadata-compatibility/CHANGELOG.md
+++ b/packages/metadata-compatibility/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.1.11 - 2024-10-29
 
 ### Fixed

--- a/packages/observable-client/CHANGELOG.md
+++ b/packages/observable-client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.6.2 - 2024-11-07
 
 ### Fixed

--- a/packages/react-builder/CHANGELOG.md
+++ b/packages/react-builder/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.2.0 - 2024-11-09
 
 ### Changed

--- a/packages/signers/ledger-signer/CHANGELOG.md
+++ b/packages/signers/ledger-signer/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.1.6 - 2024-10-29
 
 ### Fixed

--- a/packages/signers/pjs-signer/CHANGELOG.md
+++ b/packages/signers/pjs-signer/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.6.0 - 2024-11-05
 
 ### Added

--- a/packages/signers/signer/CHANGELOG.md
+++ b/packages/signers/signer/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.1.10 - 2024-10-29
 
 ### Fixed

--- a/packages/signers/signers-common/CHANGELOG.md
+++ b/packages/signers/signers-common/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.1.1 - 2024-10-29
 
 ### Fixed

--- a/packages/substrate-bindings/CHANGELOG.md
+++ b/packages/substrate-bindings/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Handle storage entries that use opaque hashers.
+
 ## 0.9.3 - 2024-10-29
 
 ### Fixed

--- a/packages/substrate-bindings/src/storage.ts
+++ b/packages/substrate-bindings/src/storage.ts
@@ -68,7 +68,7 @@ export const Storage = (pallet: string) => {
       for (let i = 0, cur = 0; i < encoders.length; i++) {
         const [codec, hasher] = encoders[i]
         const hBytes = hashers.get(hasher)
-        if (hBytes == null) throw new Error("Uknown hasher")
+        if (hBytes == null) throw new Error("Unknown hasher")
         if (hBytes < 0) {
           const opaqueBytes = hBytes * -1
           result[i] = toHex(argsKey.slice(cur, cur + opaqueBytes))

--- a/packages/substrate-bindings/tests/storage.spec.ts
+++ b/packages/substrate-bindings/tests/storage.spec.ts
@@ -9,6 +9,12 @@ describe("storage", () => {
     async (hash, pallet, name) => {
       vi.doMock("@/hashes", () => ({
         Twox128: (_: Uint8Array) => hash,
+        Identity: (_: Uint8Array) => hash,
+        Twox64Concat: (_: Uint8Array) => hash,
+        Blake2128Concat: (_: Uint8Array) => hash,
+        Blake2128: (_: Uint8Array) => hash,
+        Blake2256: (_: Uint8Array) => hash,
+        Twox256: (_: Uint8Array) => hash,
       }))
 
       const { Storage } = await import(`@/storage?${Date.now()}`)
@@ -31,6 +37,9 @@ describe("storage", () => {
       Identity: (_: Uint8Array) => hash,
       Twox64Concat: (_: Uint8Array) => hash,
       Blake2128Concat: (_: Uint8Array) => hash,
+      Blake2128: (_: Uint8Array) => hash,
+      Blake2256: (_: Uint8Array) => hash,
+      Twox256: (_: Uint8Array) => hash,
     }))
 
     const { Storage } = await import(`@/storage?${Date.now()}`)

--- a/packages/tx-utils/CHANGELOG.md
+++ b/packages/tx-utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.0.5 - 2024-11-20
 
 ### Fixed

--- a/packages/view-builder/CHANGELOG.md
+++ b/packages/view-builder/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.3.11 - 2024-10-29
 
 ### Fixed


### PR DESCRIPTION
For reference: https://github.com/polkadot-api/papi-console/issues/2