### PR TITLE
fix(codegen): storage docs generation

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.9.21 - 2024-11-22
 
 ### Fixed

--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.12.10 - 2024-11-22
+
+### Fixed
+
+- Fix storage docs generation
+
 ## 0.12.9 - 2024-11-22
 
 ### Fixed

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot-api/codegen",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "author": "Josep M Sobrepere (https://github.com/josepot)",
   "repository": {
     "type": "git",

--- a/packages/codegen/src/generate-docs-descriptors.ts
+++ b/packages/codegen/src/generate-docs-descriptors.ts
@@ -301,7 +301,7 @@ async function buildStorage(
                 return [
                   "Events",
                   {
-                    type: `StorageDescriptor<[], any, ${!modifier}>`,
+                    type: `StorageDescriptor<[], any, ${!modifier}, "never">`,
                     docs: [
                       ...docs,
                       "",
@@ -426,7 +426,7 @@ function getIndexFileDocs({ chainName }: { chainName: string }): string {
  * Storage queries reference
  * 
  * Each item described here is a
- *\`StorageDescriptor<[Args, ReturnType, Optional>\`  
+ *\`StorageDescriptor<Args, ReturnType, Optional, Opaque>\`  
  * For example, \`System.Account\` is of type
  * \`\`\`ts
  * Account: StorageDescriptor<[Key: SS58String], {
@@ -440,7 +440,7 @@ function getIndexFileDocs({ chainName }: { chainName: string }): string {
  *     nonce: number;
  *     providers: number;
  *     sufficients: number;
- * }, false>
+ * }, false, "never">
  * \`\`\`
  * and can be queried via
  * \`\`\`ts

--- a/packages/docgen/CHANGELOG.md
+++ b/packages/docgen/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.1.5 - 2024-11-22
+
+### Fixed
+
+- Fix storage docs generation
+
 ## 0.1.4 - 2024-11-22
 
 ### Fixed

--- a/packages/docgen/package.json
+++ b/packages/docgen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot-api/docgen",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "author": "Yuri Volkov (https://github.com/mutantcornholio)",
   "license": "MIT",
   "sideEffects": true,


### PR DESCRIPTION
This PR releases `codegen` and `docgen` packages. This should not yield to multiple versions of `codegen` installed in anyone's set-up since `docgen` is only used in very specific contexts and `codegen` is not meant to be installed standalone.