### PR TITLE
fix(logs-provider): missing `JsonRpcProvider` re-export

### DIFF
--- a/packages/json-rpc/logs-provider/CHANGELOG.md
+++ b/packages/json-rpc/logs-provider/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix missing `JsonRpcProvider` re-export
+
 ## 0.0.6 - 2024-10-05
 
 ### Fixed

--- a/packages/json-rpc/logs-provider/src/index.ts
+++ b/packages/json-rpc/logs-provider/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./logs-provider"
 export * from "./with-logs-recorder"
+export * from "./public-types"

--- a/packages/json-rpc/logs-provider/src/logs-provider.ts
+++ b/packages/json-rpc/logs-provider/src/logs-provider.ts
@@ -1,4 +1,4 @@
-import { JsonRpcProvider } from "@polkadot-api/json-rpc-provider"
+import type { JsonRpcProvider } from "./public-types"
 import Queue from "./queue"
 import { In, OUT, Out } from "./types"
 

--- a/packages/json-rpc/logs-provider/src/public-types.ts
+++ b/packages/json-rpc/logs-provider/src/public-types.ts
@@ -1,0 +1,1 @@
+export type { JsonRpcProvider } from "@polkadot-api/json-rpc-provider"

--- a/packages/json-rpc/logs-provider/src/with-logs-recorder.ts
+++ b/packages/json-rpc/logs-provider/src/with-logs-recorder.ts
@@ -1,4 +1,4 @@
-import { JsonRpcProvider } from "@polkadot-api/json-rpc-provider"
+import type { JsonRpcProvider } from "./public-types"
 import { IN, OUT } from "./types"
 
 export const withLogsRecorder = (


### PR DESCRIPTION
Fixes missing `JsonRpcProvider` re-export in logs provider