### PR TITLE
fix: `unknown` type on storage queries that have a composite key with the same type

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Fixed
 
-- Update dependencies
+- `unknown` type on storage queries that have a composite key with the same type.
+- Update dependencies.
 
 ## 1.7.8 - 2024-12-10
 


### PR DESCRIPTION
This effected, for example, `api.query.ChildBounties.ChildBounties`