### PR TITLE
fix(client): fee estimation for chains using metadata v14

### DIFF
--- a/examples/bun/src/custom-signed-extensions.ts
+++ b/examples/bun/src/custom-signed-extensions.ts
@@ -31,6 +31,11 @@ const transfer = api.tx.Balances.transfer_allow_death({
   value: 12345n,
 })
 
+const estimatedFees = await transfer.getEstimatedFees(BOB, {
+  customSignedExtensions: { CheckAppId: { value: 0 } },
+})
+console.log({ estimatedFees })
+
 transfer
   .signSubmitAndWatch(papiTestSigner, {
     customSignedExtensions: { CheckAppId: { value: 0 } },

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Add block hash and operation for BlockNotPinned error.
+- Fixed fee estimation for chains using metadata v14
 
 ## 1.8.2 - 2025-01-13
 


### PR DESCRIPTION
The fee estimation relies on the `TransactionPaymentApi_query_info` runtime call, and we didn't have a fallback codec for chains that are still on metadata v14.