### PR TITLE
fix(checksum): infinite loop with self-referencing individual nodes

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix crash when generating code for some chains.
+
 ## 0.10.2 - 2025-01-23
 
 ### Fixed

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix crash when generating code for some chains.
+
 ## 1.8.3 - 2025-01-23
 
 ### Fixed

--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix crash when generating code for some chains.
+
 ## 0.12.12 - 2024-12-18
 
 ### Fixed

--- a/packages/docgen/CHANGELOG.md
+++ b/packages/docgen/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.1.8 - 2025-01-23
 
 ### Fixed

--- a/packages/ink-contracts/CHANGELOG.md
+++ b/packages/ink-contracts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.2.4 - 2024-12-18
 
 ### Fixed

--- a/packages/merkleize-metadata/CHANGELOG.md
+++ b/packages/merkleize-metadata/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 1.1.12 - 2024-12-18
 
 ### Fixed

--- a/packages/metadata-builders/CHANGELOG.md
+++ b/packages/metadata-builders/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- checksumBuilder: fix infinite loop with self-referencing individual nodes.
+
 ## 0.10.0 - 2024-12-18
 
 ### Changed

--- a/packages/metadata-builders/src/lookup-graph.ts
+++ b/packages/metadata-builders/src/lookup-graph.ts
@@ -158,7 +158,7 @@ export function getStronglyConnectedComponents(graph: LookupGraph) {
         component.add(poppedNode)
       } while (poppedNode !== v)
 
-      if (component.size > 1) result.push(component)
+      result.push(component)
     }
   }
 

--- a/packages/metadata-compatibility/CHANGELOG.md
+++ b/packages/metadata-compatibility/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.1.14 - 2024-12-18
 
 ### Fixed

--- a/packages/observable-client/CHANGELOG.md
+++ b/packages/observable-client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.7.1 - 2025-01-23
 
 ### Fixed

--- a/packages/react-builder/CHANGELOG.md
+++ b/packages/react-builder/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.2.3 - 2024-12-18
 
 ### Fixed

--- a/packages/signers/ledger-signer/CHANGELOG.md
+++ b/packages/signers/ledger-signer/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.1.9 - 2024-12-18
 
 ### Fixed

--- a/packages/signers/meta-signers/CHANGELOG.md
+++ b/packages/signers/meta-signers/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.1.2 - 2024-12-18
 
 ### Fixed

--- a/packages/signers/pjs-signer/CHANGELOG.md
+++ b/packages/signers/pjs-signer/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.6.3 - 2024-12-18
 
 ### Fixed

--- a/packages/signers/signer/CHANGELOG.md
+++ b/packages/signers/signer/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.1.13 - 2024-12-18
 
 ### Fixed

--- a/packages/signers/signers-common/CHANGELOG.md
+++ b/packages/signers/signers-common/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.1.4 - 2024-12-18
 
 ### Fixed

--- a/packages/tx-utils/CHANGELOG.md
+++ b/packages/tx-utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.0.8 - 2024-12-18
 
 ### Fixed

--- a/packages/view-builder/CHANGELOG.md
+++ b/packages/view-builder/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.4.1 - 2024-12-18
 
 ### Fixed


### PR DESCRIPTION
Fixes #923 

This was caused on an assumption we made that we couldn't have self-referencing nodes. We were counting for circularities with multiple groups, but discarded nodes that would reference themselves.

The chain that has this case they have an extrinsic `LiquidityPools.schedule_limit_order_update` that takes as a parameter the same `LiquidityPools` extrinsic enum. So this node would be treated as a non-circular one and thus the max call stack error.

This PR checks for the strongly connected components of size 1 to actually be self-referencing before discarding them.