### PR TITLE
chore(codegen): include lazy `getMetadata` in descriptors

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Added
+
+- `getMetadata` in descriptors
+
 ### Fixed
 
 - Update dependencies.

--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Added
+
+- `getMetadata` in descriptors
+
 ## 0.12.13 - 2025-01-24
 
 ### Fixed

--- a/packages/codegen/src/generate-descriptors.ts
+++ b/packages/codegen/src/generate-descriptors.ts
@@ -361,6 +361,9 @@ type IRuntimeCalls = ${customStringifyObject(iRuntimeCalls)};
 type IAsset = PlainDescriptor<${assetType}>
 export type ${prefix}DispatchError = ${dispatchErrorType}
 const asset: IAsset = {} as IAsset
+const getMetadata: () => Promise<Uint8Array> = () => import("./${key}_metadata.ts").then(
+  module => toBinary('default' in module ? module.default : module)
+)
 
 type PalletsTypedef = {
   __storage: IStorage,
@@ -377,8 +380,9 @@ type IDescriptors = {
   } & Promise<any>,
   metadataTypes: Promise<Uint8Array>
   asset: IAsset
+  getMetadata: () => Promise<Uint8Array>
 };
-const _allDescriptors = { descriptors: descriptorValues, metadataTypes, asset } as any as IDescriptors;
+const _allDescriptors = { descriptors: descriptorValues, metadataTypes, asset, getMetadata } as any as IDescriptors;
 export default _allDescriptors;
 
 export type ${prefix}Queries = QueryFromPalletsDef<PalletsTypedef>

--- a/packages/docgen/CHANGELOG.md
+++ b/packages/docgen/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.1.9 - 2025-01-24
 
 ### Fixed


### PR DESCRIPTION
This is needed for the offline apis, but it can also be very useful for debugging and other advanced use-cases. It doesn't increase the bundle-sizes, and -since the file is part of the generated assets- it doesn't bloat the git history either.