### PR TITLE
fix(client): keyArgs for storage entries with concat hashes

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- keyArgs for storage entries with concat hashes.
+
 ## 1.9.3 - 2025-02-28
 
 ### Fixed

--- a/packages/client/src/descriptors.ts
+++ b/packages/client/src/descriptors.ts
@@ -63,9 +63,10 @@ type UnwrapFixedSizeArray<T extends Array<any>> = T extends [] | [any, ...any[]]
 type RemapKeys<Key extends Array<any>, Opaque> = {
   [K in keyof Key]: K extends Opaque ? OpaqueKeyHash : Key[K]
 }
-type ApplyOpaque<Key extends Array<any>, Opaque> = Opaque extends never
-  ? Key
-  : RemapKeys<UnwrapFixedSizeArray<Key>, Opaque>
+type ApplyOpaque<Key extends Array<any>, Opaque> = RemapKeys<
+  UnwrapFixedSizeArray<Key>,
+  Opaque
+>
 
 type ExtractStorage<
   T extends DescriptorEntry<StorageDescriptor<any, any, any, any>>,


### PR DESCRIPTION
Fixes #955 

This was introduced in #947, which was fixing the case when querying a storage entry with an opaque hash. As it was previously, the key types were wrong because they were showing the decoded version.

It seems TS does weird stuff when comparing with `extends never`: If the type being compared is never, in this case it would result in `never`, regardless of the type declared in the "true" branch. The only way I could get it to work is by adding a unique type (`Opaque extends never` becomes `Opaque | "a literal that won't be used" extends "a literal that won't be used"`).

But in this case it shouldn't really matter, it looks like we can just map the types directly. If `Opaque` is never, then it won't match against any of the keys and the original tuple will be left intact. I think this solution is better because it doesn't need a workaround.

getEntries with concat hash:
<img width="619" alt="Screenshot 2025-03-01 at 20 24 43" src="https://github.com/user-attachments/assets/6182b9ac-de76-491c-88a8-6d80b100ce7b" />

getEntries with opaque hash:
<img width="619" alt="Screenshot 2025-03-01 at 20 25 46" src="https://github.com/user-attachments/assets/39d2a575-496e-463e-a6b9-ba1945da383b" />


