### PR TITLE
fix: finalized$ emits blocks that are not pinned after a stop event recovery

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixed
 
 - chainHead not recovering after RPC error.
+- finalized emits blocks that are not pinned after a stop event recovery.
+- small memory leak after stop event recovery.
 
 ## 1.9.5 - 2025-03-07
 

--- a/packages/observable-client/CHANGELOG.md
+++ b/packages/observable-client/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixed
 
 - chainHead not recovering after RPC error.
+- finalized emits blocks that are not pinned after a stop event recovery.
+- cached streams persisting after stop event recovery.
 
 ## 0.8.2 - 2025-03-07
 

--- a/packages/observable-client/src/chainHead/chainHead.ts
+++ b/packages/observable-client/src/chainHead/chainHead.ts
@@ -178,6 +178,9 @@ export const getChainHead$ = (chainHead: ChainHead) => {
         cache.delete(hash)
       })
     },
+    (block) => {
+      cache.delete(block)
+    },
   )
 
   const getRuntimeContext$ = withRefcount((hash: string) =>
@@ -227,6 +230,7 @@ export const getChainHead$ = (chainHead: ChainHead) => {
   }
 
   const finalized$ = pinnedBlocks$.pipe(
+    filter((x) => !x.recovering),
     distinctUntilChanged((a, b) => a.finalized === b.finalized),
     scan((acc, value) => {
       let current = value.blocks.get(value.finalized)!
@@ -254,6 +258,7 @@ export const getChainHead$ = (chainHead: ChainHead) => {
   )
 
   const bestBlocks$ = pinnedBlocks$.pipe(
+    filter((x) => !x.recovering),
     distinctUntilChanged(
       (prev, current) =>
         prev.finalized === current.finalized && prev.best === current.best,

--- a/packages/observable-client/src/chainHead/streams/pinned-blocks.ts
+++ b/packages/observable-client/src/chainHead/streams/pinned-blocks.ts
@@ -68,6 +68,7 @@ export const getPinnedBlocks$ = (
   call$: (hash: string, method: string, args: string) => Observable<string>,
   blockUsage$: Subject<BlockUsageEvent>,
   onUnpin: (blocks: string[]) => void,
+  deleteFromCache: (block: string) => void,
 ) => {
   const pinnedBlocks$: Observable<PinnedBlocks> = merge(
     blockUsage$,
@@ -161,6 +162,7 @@ export const getPinnedBlocks$ = (
             for (const [hash, block] of acc.blocks) {
               if (block.recovering) {
                 deleteBlock(acc.blocks, hash)
+                deleteFromCache(hash)
               }
             }
             acc.recovering = false


### PR DESCRIPTION
Also fixed a small memory leak after stop event.