### PR TITLE
test(storage): basic tests

### DIFF
--- a/integration-tests/chopsticks/package.json
+++ b/integration-tests/chopsticks/package.json
@@ -4,8 +4,9 @@
   "version": "0.0.0",
   "description": "",
   "main": "index.js",
+  "type": "module",
   "scripts": {
-    "build-external": "papi",
+    "build-external": "papi && tsc --noEmit",
     "build": "pnpm build-external",
     "lint": "prettier --check \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json,md}\"",

--- a/integration-tests/chopsticks/setupTests.ts
+++ b/integration-tests/chopsticks/setupTests.ts
@@ -1,0 +1,6 @@
+import { startChopsticks, stopChopsticks } from "./src/chopsticks"
+
+export default async function setupTests() {
+  await startChopsticks()
+  return () => stopChopsticks()
+}

--- a/integration-tests/chopsticks/src/chopsticks.ts
+++ b/integration-tests/chopsticks/src/chopsticks.ts
@@ -1,21 +1,19 @@
 import { spawn } from "child_process"
 import { createWriteStream } from "fs"
-import { createClient, PolkadotClient, UnsafeApi } from "polkadot-api"
+import { createClient } from "polkadot-api"
 import { getWsProvider } from "polkadot-api/ws-provider/node"
-import { afterAll, beforeAll } from "vitest"
 
 const ENDPOINT = "wss://rpc.ibp.network/paseo"
 const PORT = 8132
 
 let cleanup = () => {}
-let client: PolkadotClient = null as any
-let api: UnsafeApi<unknown> = null as any
 
 export const ALICE = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
 
 export const getChopsticksProvider = () =>
   getWsProvider(`ws://localhost:${PORT}`)
-const setup = async () => {
+
+export const startChopsticks = async () => {
   const logStream = createWriteStream("./chopsticks.log")
   const logStreamErr = createWriteStream("./chopsticks_err.log")
   const chopsticksProcess = spawn("pnpm", [
@@ -26,13 +24,14 @@ const setup = async () => {
   chopsticksProcess.stdout.pipe(logStream)
   chopsticksProcess.stderr.pipe(logStreamErr)
 
-  client = createClient(getChopsticksProvider())
-  api = client.getUnsafeApi()
+  const client = createClient(getChopsticksProvider())
 
-  console.log(
-    "Connecting to chopsticks… It might take a few retries until the chain is up",
-  )
-  await api.runtimeToken
+  console.log("Connecting to chopsticks… (takes ~3 seconds)")
+  await client.getUnsafeApi().runtimeToken
+
+  // Create a new block to pre-initialize chopsticks and prevent tests from timing out.
+  console.log("Generating the first block… (takes ~8 seconds)")
+  await client._request("dev_newBlock", [])
 
   cleanup = () => {
     cleanup = () => {}
@@ -43,30 +42,9 @@ const setup = async () => {
   }
 }
 
-beforeAll(setup)
-afterAll(() => cleanup())
+export const stopChopsticks = () => cleanup()
 
 export const restartChopsticks = async () => {
-  cleanup()
-  await setup()
-}
-
-export const newBlock = (count?: number): Promise<string> =>
-  client._request("dev_newBlock", [{ count }])
-
-export const jumpBlocks = async (height: number, count?: number) => {
-  await client._request("dev_newBlock", [
-    {
-      count,
-      unsafeBlockHeight: height,
-    },
-  ])
-
-  // Because the height jump, we have to restart the client
-  // otherwise the block height will be wrong on new tx
-  console.log("Restarting client")
-  client.destroy()
-  client = createClient(getWsProvider(`ws://localhost:${PORT}`))
-  api = client.getUnsafeApi()
-  await api.runtimeToken
+  stopChopsticks()
+  await startChopsticks()
 }

--- a/integration-tests/chopsticks/src/chopsticksUtils.ts
+++ b/integration-tests/chopsticks/src/chopsticksUtils.ts
@@ -1,0 +1,31 @@
+import { createClient, PolkadotClient } from "polkadot-api"
+import { afterAll, beforeAll } from "vitest"
+import { getChopsticksProvider } from "./chopsticks"
+
+let client: PolkadotClient = null as any
+beforeAll(async () => {
+  client = createClient(getChopsticksProvider())
+  await client.getUnsafeApi().runtimeToken
+})
+afterAll(() => {
+  client.destroy()
+  client = null as any
+})
+
+export const newBlock = (count?: number): Promise<string> =>
+  client._request("dev_newBlock", [{ count }])
+
+export const jumpBlocks = async (height: number, count?: number) => {
+  await client._request("dev_newBlock", [
+    {
+      count,
+      unsafeBlockHeight: height,
+    },
+  ])
+
+  // Because the height jump, we have to restart the client
+  // otherwise the block height will be wrong on new tx
+  client.destroy()
+  client = createClient(getChopsticksProvider())
+  await client.getUnsafeApi().runtimeToken
+}

--- a/integration-tests/chopsticks/src/stop-events.spec.ts
+++ b/integration-tests/chopsticks/src/stop-events.spec.ts
@@ -1,9 +1,10 @@
 import { paseo } from "@polkadot-api/descriptors"
 import { createClient } from "polkadot-api"
 import { concatMap, filter, firstValueFrom, shareReplay } from "rxjs"
-import { beforeAll, describe, expect, it, vitest } from "vitest"
+import { describe, expect, it, vitest } from "vitest"
 import "./chopsticks"
-import { ALICE, getChopsticksProvider, newBlock } from "./chopsticks"
+import { ALICE, getChopsticksProvider } from "./chopsticks"
+import { newBlock } from "./chopsticksUtils"
 import {
   combineInterceptors,
   createStopInterceptor,
@@ -14,11 +15,6 @@ import {
 import { wait } from "./utils"
 
 describe("Stop events", () => {
-  beforeAll(async () => {
-    // Create a new block to pre-initialize chopsticks and prevent tests from timing out.
-    await newBlock()
-  })
-
   it("reconnects after a stop event recovery fails", async () => {
     const [provider, getInterceptor] = providerInterceptor(
       getChopsticksProvider(),

--- a/integration-tests/chopsticks/src/storage.spec.ts
+++ b/integration-tests/chopsticks/src/storage.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+import { ALICE, getChopsticksProvider } from "./chopsticks"
+import { createClient } from "polkadot-api"
+import { paseo } from "@polkadot-api/descriptors"
+
+describe("storage", () => {
+  it("subscribes and decodes storage values", async () => {
+    const client = createClient(getChopsticksProvider())
+    const api = client.getTypedApi(paseo)
+
+    const result = await api.query.System.Account.getValue(ALICE)
+    const nonce: number = result.nonce
+    expect(nonce).toBeGreaterThan(1000)
+    client.destroy()
+  })
+
+  it("entries decodes storage keys", async () => {
+    const client = createClient(getChopsticksProvider())
+    const api = client.getTypedApi(paseo)
+
+    const entries = await api.query.Referenda.ReferendumInfoFor.getEntries()
+    expect(entries.length).toBeGreaterThan(0)
+    entries.forEach(({ keyArgs }) => expect(keyArgs[0]).toBeTypeOf("number"))
+
+    client.destroy()
+  })
+
+  it("returns the raw key if the hasher is opaque", async () => {
+    const client = createClient(getChopsticksProvider())
+    const api = client.getTypedApi(paseo)
+
+    const entries =
+      await api.query.CoretimeAssignmentProvider.CoreDescriptors.getEntries()
+    expect(entries.length).toBeGreaterThan(0)
+    const hex: string = entries[0].keyArgs[0]
+    expect(hex.startsWith("0x"), "Not a hex string").toBe(true)
+    entries.forEach(({ keyArgs }) => expect(keyArgs[0]).toBeTypeOf("string"))
+
+    client.destroy()
+  })
+})

--- a/integration-tests/chopsticks/vitest.config.ts
+++ b/integration-tests/chopsticks/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config"
+import tsconfigPaths from "vite-tsconfig-paths"
+
+export default defineConfig({
+  test: {
+    include: ["**/*.spec.ts"],
+    disableConsoleIntercept: true,
+    globalSetup: ["./setupTests.ts"],
+  },
+  plugins: [tsconfigPaths()],
+})


### PR DESCRIPTION
It covers just the happy path + opaque keys.

Also reworked the setup of the test so that chopsticks spawns just once when you're running in watch mode. Makes it so much faster to work on tests when you don't have to wait 10 seconds on every test change!

I'd like to have the capacity of creating forks, but chopsticks doesn't have that... It might be possible to do spawning multiple chopsticks instances and with a clever JSON-RPC middleware that switches between them, but that… sounds like I'm probably overthinking.