### PR TITLE
fix(client): take `genesisHash` from RPC

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Use `genesisHash` from RPC instead of using an operation if possible
+
 ## 1.9.9 - 2025-04-01
 
 ### Fixed


### PR DESCRIPTION
Some local networks start with a corrupted state, which gets fixed in the first block.
Nevertheless, with `InstantSeal`, the block only gets produced after the first transaction, which can't be created with the corrupted state.
