### PR TITLE
feat(ink): add metadata to callable interface

### DIFF
--- a/packages/codegen/src/ink-types.ts
+++ b/packages/codegen/src/ink-types.ts
@@ -183,11 +183,21 @@ export function generateInkTypes(lookup: InkMetadataLookup) {
     return result
   }
 
+  const inlineField = (label: string, type: string): StructField => ({
+    label,
+    value: {
+      type: "inline",
+      value: type,
+    },
+    docs: [],
+  })
   const createCallableDescriptor = (
     callables: Array<{
       label: string
       docs: string[]
       types: ReturnType<typeof buildCallable>
+      mutates?: boolean
+      payable: boolean
       default?: boolean
     }>,
   ) =>
@@ -209,18 +219,9 @@ export function generateInkTypes(lookup: InkMetadataLookup) {
                 value: callable.types.value,
                 docs: [],
               },
-              ...(callable.default
-                ? [
-                    {
-                      label: "default",
-                      value: {
-                        type: "inline",
-                        value: "true",
-                      },
-                      docs: [],
-                    } satisfies StructField,
-                  ]
-                : []),
+              ...(callable.default ? [inlineField("default", "true")] : []),
+              ...(callable.payable ? [inlineField("payable", "true")] : []),
+              ...(callable.mutates ? [inlineField("mutates", "true")] : []),
             ],
           },
           docs: callable.docs,

--- a/packages/codegen/src/ink-types.ts
+++ b/packages/codegen/src/ink-types.ts
@@ -3,6 +3,7 @@ import {
   MessageParamSpec,
   TypeSpec,
 } from "@polkadot-api/ink-contracts"
+import { anonymizeImports, anonymizeType } from "./anonymize"
 import {
   EnumVariant,
   getInternalTypesBuilder,
@@ -11,7 +12,6 @@ import {
   StructField,
   TypeNode,
 } from "./internal-types"
-import { getReusedNodes } from "./internal-types/reused-nodes"
 import {
   CodegenOutput,
   generateTypescript,
@@ -19,7 +19,7 @@ import {
   nativeNodeCodegen,
   processPapiPrimitives,
 } from "./internal-types/generate-typescript"
-import { anonymizeImports, anonymizeType } from "./anonymize"
+import { getReusedNodes } from "./internal-types/reused-nodes"
 
 export function generateInkTypes(lookup: InkMetadataLookup) {
   const internalBuilder = getInternalTypesBuilder(lookup)
@@ -188,6 +188,7 @@ export function generateInkTypes(lookup: InkMetadataLookup) {
       label: string
       docs: string[]
       types: ReturnType<typeof buildCallable>
+      default?: boolean
     }>,
   ) =>
     generateNodeType({
@@ -208,6 +209,18 @@ export function generateInkTypes(lookup: InkMetadataLookup) {
                 value: callable.types.value,
                 docs: [],
               },
+              ...(callable.default
+                ? [
+                    {
+                      label: "default",
+                      value: {
+                        type: "inline",
+                        value: "true",
+                      },
+                      docs: [],
+                    } satisfies StructField,
+                  ]
+                : []),
             ],
           },
           docs: callable.docs,

--- a/packages/codegen/src/internal-types/generate-typescript.ts
+++ b/packages/codegen/src/internal-types/generate-typescript.ts
@@ -25,7 +25,8 @@ export const nativeNodeCodegen = (
   node: TypeNode,
   next: (node: TypeNode) => CodegenOutput,
 ): CodegenOutput => {
-  if (node.type === "primitive") return onlyCode(node.value)
+  if (node.type === "primitive" || node.type === "inline")
+    return onlyCode(node.value)
   if (node.type === "chainPrimitive")
     throw new Error("Can't generate chain primitive type " + node.value)
   if (

--- a/packages/codegen/src/internal-types/type-representation.ts
+++ b/packages/codegen/src/internal-types/type-representation.ts
@@ -1,6 +1,10 @@
 import { ArrayVar, StructVar, TupleVar } from "@polkadot-api/metadata-builders"
 
-type PrimitiveNode = PrimitiveType | ChainPrimitiveType | FixedSizeBinary
+type PrimitiveNode =
+  | PrimitiveType
+  | ChainPrimitiveType
+  | FixedSizeBinary
+  | InlineType
 export type TypeNode =
   | PrimitiveNode
   | StructType
@@ -11,10 +15,16 @@ export type TypeNode =
   | UnionType
   | OptionType
 export type LookupTypeNode = TypeNode & { id: number }
+export type InlineType = {
+  type: "inline"
+  value: string
+}
 export type MaybeLookupNode = TypeNode | LookupTypeNode
 
 export const isPrimitive = (node: TypeNode): node is PrimitiveNode =>
-  ["chainPrimitive", "primitive", "fixedSizeBinary"].includes(node.type)
+  ["chainPrimitive", "primitive", "fixedSizeBinary", "inline"].includes(
+    node.type,
+  )
 
 export type NativeType =
   | "boolean"

--- a/packages/ink-contracts/src/ink-client.ts
+++ b/packages/ink-contracts/src/ink-client.ts
@@ -18,7 +18,7 @@ export type InkCallableInterface<T extends InkCallableDescriptor> = <
     ? (value?: T[L]["message"]) => Binary
     : (value: T[L]["message"]) => Binary
   decode: (value: { data: Binary }) => T[L]["response"]
-  metadata: {
+  attributes: {
     payable: boolean
     default: boolean
     mutates: boolean
@@ -144,12 +144,12 @@ export const getInkClient = <
 
   return {
     constructor: (label) => ({
-      metadata: getMetadata(findConstructor(label)),
+      attributes: getAttributes(findConstructor(label)),
       ...constructorCodec(label),
     }),
     defaultConstructor,
     message: (label) => ({
-      metadata: getMetadata(findMessage(label)),
+      attributes: getAttributes(findMessage(label)),
       ...messageCodec(label),
     }),
     defaultMessage,
@@ -161,7 +161,7 @@ export const getInkClient = <
   }
 }
 
-const getMetadata = (spec: ConstructorSpec | MessageSpec) => ({
+const getAttributes = (spec: ConstructorSpec | MessageSpec) => ({
   payable: spec.payable,
   default: spec.default,
   mutates: "mutates" in spec ? spec.mutates : true,

--- a/packages/ink-contracts/src/ink-client.ts
+++ b/packages/ink-contracts/src/ink-client.ts
@@ -68,6 +68,24 @@ export interface InkEventInterface<E> {
   ) => E[]
 }
 
+type HasDefault<T> = "default" extends keyof T
+  ? T["default"] extends true
+    ? true
+    : false
+  : false
+type GetDefault<M> = keyof {
+  [K in keyof M as HasDefault<M[K]> extends true ? K : never]: true
+}
+
+// T can be the default message or `never`.
+// Typescript doesn't like doing `extends never` (it works for the "false" case, but for the other it will always give back never)
+// One way of running around it is by checking whether an empty object extends an object with that key.
+type WrapDefault<T extends string> = {} extends {
+  [K in T]: K
+}
+  ? string | undefined
+  : T
+
 export interface InkClient<
   D extends InkDescriptors<
     InkStorageDescriptor,
@@ -77,7 +95,9 @@ export interface InkClient<
   >,
 > {
   constructor: InkCallableInterface<D["__types"]["constructors"]>
+  defaultConstructor: WrapDefault<GetDefault<D["__types"]["constructors"]>>
   message: InkCallableInterface<D["__types"]["messages"]>
+  defaultMessage: WrapDefault<GetDefault<D["__types"]["messages"]>>
   storage: InkStorageInterface<D["__types"]["storage"]>
   event: InkEventInterface<D["__types"]["event"]>
 }

--- a/packages/ink-contracts/src/ink-client.ts
+++ b/packages/ink-contracts/src/ink-client.ts
@@ -7,7 +7,7 @@ import {
   InkDescriptors,
   InkStorageDescriptor,
 } from "./ink-descriptors"
-import { EventSpecV5 } from "./metadata-types"
+import { ConstructorSpec, EventSpecV5, MessageSpec } from "./metadata-types"
 
 export type InkCallableInterface<T extends InkCallableDescriptor> = <
   L extends string & keyof T,
@@ -18,6 +18,11 @@ export type InkCallableInterface<T extends InkCallableDescriptor> = <
     ? (value?: T[L]["message"]) => Binary
     : (value: T[L]["message"]) => Binary
   decode: (value: { data: Binary }) => T[L]["response"]
+  metadata: {
+    payable: boolean
+    default: boolean
+    mutates: boolean
+  }
 }
 
 export type InkStorageInterface<S extends InkStorageDescriptor> =
@@ -90,9 +95,44 @@ export const getInkClient = <
   const lookup = getInkLookup(inkContract.metadata)
   const builder = getInkDynamicBuilder(lookup)
 
+  const constructorCodec = buildCallable(builder.buildConstructor)
+  const messageCodec = buildCallable(builder.buildMessage)
+
+  const findConstructor = (label: string) => {
+    const result = lookup.metadata.spec.constructors.find(
+      (c) => c.label === label,
+    )
+    if (!result) {
+      throw new Error(`Constructor ${label} not found`)
+    }
+    return result
+  }
+  const findMessage = (label: string) => {
+    const result = lookup.metadata.spec.messages.find((c) => c.label === label)
+    if (!result) {
+      throw new Error(`Message ${label} not found`)
+    }
+    return result
+  }
+
+  const defaultConstructor: any = lookup.metadata.spec.constructors.find(
+    (c) => c.default,
+  )?.label
+  const defaultMessage: any = lookup.metadata.spec.messages.find(
+    (c) => c.default,
+  )?.label
+
   return {
-    constructor: buildCallable(builder.buildConstructor),
-    message: buildCallable(builder.buildMessage),
+    constructor: (label) => ({
+      metadata: getMetadata(findConstructor(label)),
+      ...constructorCodec(label),
+    }),
+    defaultConstructor,
+    message: (label) => ({
+      metadata: getMetadata(findMessage(label)),
+      ...messageCodec(label),
+    }),
+    defaultMessage,
     storage: buildStorage(builder.buildStorage),
     event:
       Number(lookup.metadata.version) === 4
@@ -101,19 +141,26 @@ export const getInkClient = <
   }
 }
 
+const getMetadata = (spec: ConstructorSpec | MessageSpec) => ({
+  payable: spec.payable,
+  default: spec.default,
+  mutates: "mutates" in spec ? spec.mutates : true,
+})
+
 const buildCallable =
   <T extends InkCallableDescriptor>(
     builder:
       | InkDynamicBuilder["buildConstructor"]
       | InkDynamicBuilder["buildMessage"],
-  ): InkCallableInterface<T> =>
+  ) =>
   <L extends string & keyof T>(label: L) => {
     const codecs = builder(label)
 
     return {
       encode: (value?: T[L]["message"]) =>
         Binary.fromBytes(codecs.call.enc(value || {})),
-      decode: (response) => codecs.value.dec(response.data.asBytes()),
+      decode: (response: { data: Binary }) =>
+        codecs.value.dec(response.data.asBytes()),
     }
   }
 

--- a/packages/ink-contracts/src/ink-descriptors.ts
+++ b/packages/ink-contracts/src/ink-descriptors.ts
@@ -24,6 +24,8 @@ export type InkCallableDescriptor = Record<
     message: StringRecord<unknown>
     response: StringRecord<unknown>
     default?: boolean
+    payable?: boolean
+    mutates?: boolean
   }
 >
 

--- a/packages/ink-contracts/src/ink-descriptors.ts
+++ b/packages/ink-contracts/src/ink-descriptors.ts
@@ -23,6 +23,7 @@ export type InkCallableDescriptor = Record<
   {
     message: StringRecord<unknown>
     response: StringRecord<unknown>
+    default?: boolean
   }
 >
 

--- a/packages/ink-contracts/src/metadata-types.ts
+++ b/packages/ink-contracts/src/metadata-types.ts
@@ -55,7 +55,7 @@ interface InkSpecV5 {
   lang_error: TypeSpec
 }
 
-interface ConstructorSpec {
+export interface ConstructorSpec {
   label: string
   selector: string
   payable: boolean
@@ -65,7 +65,7 @@ interface ConstructorSpec {
   docs: string[]
 }
 
-interface MessageSpec {
+export interface MessageSpec {
   label: string
   selector: string
   mutates: boolean


### PR DESCRIPTION
Closes #985 

This adds a `.attributes` property into the messages/constructors of the ink client:

```ts
const psp22 = getInkClient(contracts.psp22);
const increaseAllowance = psp22.message("PSP22::increase_allowance");

console.log(increaseAllowance.attributes); /*
{
  payable: false,
  default: false,
  mutates: true,
}
*/
```

And it also adds a couple of properties to get the default constructor and default message:

```ts
console.log(psp22.defaultMessage, psp22.defaultConstructor)
```

I've updated the codegen so that these properties are actually the label of default message/constructors if it has a default one, and `string | undefined` if it doesn't (I think having this type will make it easier to use in cases where the contract is generic, while still directly removing the "undefined" case if you are just working with one specific contract which has the default).