### PR TITLE
feat(tx): use highest nonce by default

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -10,6 +10,10 @@
   - inkClient: `defaultConstructor` property with the name of the default constructor.
   - inkClient: `defaultMessage` property with the name of the default message.
 
+### Changed
+
+- Transactions will use the highest nonce available instead of the one found in `finalized` or `best` by default.
+
 ## 1.9.13 - 2025-04-16
 
 ### Fixed

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Changed
 
-- Transactions will use the highest nonce available instead of the one found in `finalized` or `best` by default.
+- Transactions will use the highest nonce available instead of the one found in `finalized` or `best` by default [#1008](https://github.com/polkadot-api/polkadot-api/pull/1008).
 
 ## 1.9.13 - 2025-04-16
 

--- a/packages/client/src/tx/create-tx.ts
+++ b/packages/client/src/tx/create-tx.ts
@@ -155,7 +155,7 @@ const getNonce$ = (chainHead: ChainHead$, from: HexString) => {
     map((result) => {
       const winner = result.reduce(
         (acc: bigint | number | null, v) =>
-          v.success ? (v.value > (acc ?? 0) ? v.value : acc) : acc,
+          v.success ? (v.value >= (acc ?? 0) ? v.value : acc) : acc,
         null,
       )
 

--- a/packages/client/src/tx/create-tx.ts
+++ b/packages/client/src/tx/create-tx.ts
@@ -1,11 +1,23 @@
-import { HexString, u16, u32, u64, u8 } from "@polkadot-api/substrate-bindings"
-import { Observable, combineLatest, map, mergeMap, of, take } from "rxjs"
 import { BlockInfo, ChainHead$ } from "@polkadot-api/observable-client"
 import type { PolkadotSigner } from "@polkadot-api/polkadot-signer"
-import { _void } from "@polkadot-api/substrate-bindings"
-import { CustomSignedExtensionValues } from "./types"
+import { HexString, u16, u32, u64, u8 } from "@polkadot-api/substrate-bindings"
 import { fromHex, toHex } from "@polkadot-api/utils"
+import {
+  Observable,
+  catchError,
+  combineLatest,
+  distinctUntilChanged,
+  filter,
+  map,
+  mergeMap,
+  of,
+  scan,
+  startWith,
+  switchMap,
+  take,
+} from "rxjs"
 import { getSignExtensionsCreator } from "./signed-extensions"
+import { CustomSignedExtensionValues } from "./types"
 
 type HintedSignedExtensions = Partial<{
   tip: bigint
@@ -22,7 +34,11 @@ const lenToDecoder = {
   8: u64.dec,
 }
 
-const getNonce$ = (call$: ChainHead$["call$"], from: HexString, at: string) =>
+const getNonceAtBlock$ = (
+  call$: ChainHead$["call$"],
+  from: HexString,
+  at: string,
+) =>
   call$(at, NONCE_RUNTIME_CALL, from).pipe(
     map((result) => {
       const bytes = fromHex(result)
@@ -51,7 +67,7 @@ export const createTx: (
   combineLatest([
     hinted.nonce
       ? of(hinted.nonce)
-      : getNonce$(chainHead.call$, toHex(signer.publicKey), atBlock.hash),
+      : getNonce$(chainHead, toHex(signer.publicKey)),
     chainHead.getRuntimeContext$(atBlock.hash),
     chainHead.genesis$,
   ]).pipe(
@@ -90,3 +106,64 @@ export const createTx: (
       )
     }),
   )
+
+const getNonce$ = (chainHead: ChainHead$, from: HexString) => {
+  const followHead$ = (head: string) =>
+    chainHead.newBlocks$.pipe(
+      scan((acc, block) => (block.parent === acc ? block.hash : acc), head),
+      startWith(head),
+      distinctUntilChanged(),
+    )
+  const followNonce$ = (head: string) =>
+    followHead$(head).pipe(
+      switchMap((hash) => getNonceAtBlock$(chainHead.call$, from, hash)),
+    )
+  const getHeadsNonce$ = (heads: string[]) =>
+    combineLatest(
+      heads.map((head) =>
+        followNonce$(head).pipe(
+          map((value) => ({
+            success: true as const,
+            value,
+          })),
+          catchError((err) =>
+            of({
+              success: false as const,
+              value: err,
+            }),
+          ),
+        ),
+      ),
+    ).pipe(take(1))
+
+  return chainHead.pinnedBlocks$.pipe(
+    filter((v) => !v.recovering && v.blocks.size > 0),
+    take(1),
+    map(({ blocks, best }) => {
+      // Grab only the heads: those blocks above the best that don't have children and are not getting pruned
+      const bestBlock = blocks.get(best)!
+      return [...blocks.values()]
+        .filter(
+          (v) =>
+            !v.unpinnable &&
+            v.children.size === 0 &&
+            v.number >= bestBlock.number,
+        )
+        .map((v) => v.hash)
+    }),
+    switchMap(getHeadsNonce$),
+    map((result) => {
+      const winner = result.reduce(
+        (acc: bigint | number | null, v) =>
+          v.success ? (v.value > (acc ?? 0) ? v.value : acc) : acc,
+        null,
+      )
+
+      if (winner == null) {
+        // We must have at least one error
+        throw result[0].value
+      }
+      return winner
+    }),
+  )
+}

--- a/packages/client/src/tx/create-tx.ts
+++ b/packages/client/src/tx/create-tx.ts
@@ -116,6 +116,7 @@ const getNonce$ = (chainHead: ChainHead$, from: HexString) => {
     )
   const followNonce$ = (head: string) =>
     followHead$(head).pipe(
+      take(2),
       switchMap((hash) => getNonceAtBlock$(chainHead.call$, from, hash)),
     )
   const getHeadsNonce$ = (heads: string[]) =>


### PR DESCRIPTION
Currently, the nonce is picked based on where the transaction is being created: If it's created against the finalized block, then it takes the nonce from that block, and if it's against the best block then it's done against that one.

Although papi provides a way manually handling the `nonce`, a recurring issue new users have with the library is running into "stale" transactions because they created a second transaction without waiting for the first one to become finalized.

This changes the default behaviour so that it always looks at the nonce of the latest blocks, regardless of where the transaction is being created.

It won't cover all cases, so consumers are still encouraged to manage the nonce value themselves if they want to create multiple transactions at once (at least until this is solved by moving the nonce logic to the signer), but it should decrease the likeliness of stale transactions happening.

### Implementation note

To pick which blocks to use, I look at the "heads" (i.e. blocks with no children) that have a height of the best block or higher, and request the nonce for all of them.

For each of these heads, if a new block comes in, then the old nonce request is discarded and a new starts up. Whenever all heads have resolved at least one nonce value, then it picks the highest nonce and uses that to create the transaction, regardless if there are still nonce operations ongoing (and in fact, cancels those operations).

All these cases should be extremely unlikely to happen, but might help get a better approximation. The most common case should be just 1 head (best block) and to receive the nonce before a new block is added.