### PR TITLE
fix(cli): pin ES target version for descriptors

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Pin ES target version for descriptors.
+
 ## 0.11.11 - 2025-04-24
 
 ### Fixed

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -28,7 +28,7 @@ import path, { join, posix, win32 } from "path"
 import process from "process"
 import { readPackage } from "read-pkg"
 import tsc from "tsc-prog"
-import tsup, { build } from "tsup"
+import tsup from "tsup"
 import { updatePackage } from "write-package"
 import { detectPackageManager } from "../packageManager"
 import { CommonOptions } from "./commonOptions"
@@ -291,6 +291,7 @@ async function compileCodegen(packageDir: string) {
   }
 
   await tsup.build({
+    target: "es2022",
     format: ["cjs", "esm"],
     entry: [path.join(srcDir, "index.ts").replaceAll(win32.sep, posix.sep)],
     loader: {
@@ -375,7 +376,7 @@ async function readWhitelist(filename: string): Promise<string[] | null> {
 
   const tmpDir = await mkdtemp(join(tmpdir(), "papi-"))
   try {
-    await build({
+    await tsup.build({
       format: "esm",
       entry: {
         index: filename,

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixed
+
+- **CLI:**
+  - Pin ES target version for descriptors.
+
 ## 1.10.0 - 2025-04-24
 
 ### Added


### PR DESCRIPTION
Instead of relying in the local `tsconfig.json` of the user (or the tsup default if it doesn't exist), pin the target to the same one we use for all the other libraries.

Closes #1014