### PR TITLE
fix(client): propagate provided `asset` to the signer

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Propagate the provided `asset` to the signer.
+
 - **CLI:**
   - Pin ES target version for descriptors.
 

--- a/packages/client/src/tx/create-tx.ts
+++ b/packages/client/src/tx/create-tx.ts
@@ -96,6 +96,7 @@ export const createTx: (
             }
           : { mortal: false },
         customSignedExtensions,
+        asset: hinted.asset,
       })
 
       return signer.signTx(


### PR DESCRIPTION
Fixes #1018 