### PR TITLE
fix(client): ensure that `_request` is ready

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Avoid unnecessary warnings when invoking `_request`
+
 ## 1.10.1 - 2025-05-04
 
 ### Fixed


### PR DESCRIPTION
I had a call with the ParaSpell team to further discuss and understand #1017 and during that call we realized that it's better to prevent calling the `_request` method from the top-level client synchronously after having created the client.