### PR TITLE
fix(client): solve race-condition on client.destroy

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Avoid race-conditions when destroying the client.
+
 ## 1.10.1 - 2025-05-04
 
 ### Fixed

--- a/packages/observable-client/CHANGELOG.md
+++ b/packages/observable-client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Avoid race-conditions when destroying the client.
+
 ## 0.9.0 - 2025-04-24
 
 ### Added


### PR DESCRIPTION
Thanks to the feedback provided on a reproduction case by our frens on ParaSpell we were able to identify a rather ugly race-condition that happened when destroying the client. If in the moment of destroying the client we have received the response to the follow-request and the initialized event, then we have a concatMap that waits for the header of the finalized-block, and completing the source observable was not causing the unsubscription of the `concatMap` observable... As a result, the `getHeader` was triggering an error and the `retryChainHeadError` was constantly retrying to re-stablish the follow-subscription... The solution is to unsubscribe from the resulting observable, rather than just completing the source observable.