### PR TITLE
feat(codegen): expose `<key>Apis`

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Expose `<key>Apis` type for Runtime APIs.
+
 ## 0.11.13 - 2025-05-05
 
 ### Fixed

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -367,7 +367,7 @@ async function replacePackageJson(descriptorsDir: string, version: bigint) {
   "types": "./dist/index.d.ts",
   "sideEffects": false,
   "peerDependencies": {
-    "polkadot-api": ">=1.9.11"
+    "polkadot-api": ">=1.11.0"
   }
 }
 `,

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Expose `<key>Apis` type for Runtime APIs.
+
 ## 1.10.2 - 2025-05-05
 
 ### Fixed

--- a/packages/client/src/descriptors.ts
+++ b/packages/client/src/descriptors.ts
@@ -100,6 +100,24 @@ type ExtractPlain<T extends DescriptorEntry<PlainDescriptor<any>>> = {
   }
 }
 
+type ExtractRuntime<T extends DescriptorEntry<RuntimeDescriptor<any, any>>> = {
+  [K in keyof T]: {
+    [KK in keyof T[K]]: T[K][KK] extends RuntimeDescriptor<
+      infer Args,
+      infer Value
+    >
+      ? {
+          Args: Args
+          Value: Value
+        }
+      : unknown
+  }
+}
+
+export type ApisFromDef<
+  T extends DescriptorEntry<RuntimeDescriptor<any, any>>,
+> = ExtractRuntime<T>
+
 export type QueryFromPalletsDef<
   T extends PalletsTypedef<any, any, any, any, any>,
 > = ExtractStorage<T["__storage"]>

--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Expose `<key>Apis` type for Runtime APIs.
+
 ## 0.14.0 - 2025-04-24
 
 ### Changed

--- a/packages/codegen/src/generate-descriptors.ts
+++ b/packages/codegen/src/generate-descriptors.ts
@@ -294,6 +294,7 @@ export const generateDescriptors = (
       "Enum",
       "_Enum",
       "GetEnum",
+      "ApisFromDef",
       "QueryFromPalletsDef",
       "TxFromPalletsDef",
       "EventsFromPalletsDef",
@@ -388,6 +389,7 @@ type IDescriptors = {
 const _allDescriptors = { descriptors: descriptorValues, metadataTypes, asset, getMetadata, genesis } as any as IDescriptors;
 export default _allDescriptors;
 
+export type ${prefix}Apis = ApisFromDef<IRuntimeCalls>
 export type ${prefix}Queries = QueryFromPalletsDef<PalletsTypedef>
 export type ${prefix}Calls = TxFromPalletsDef<PalletsTypedef>
 export type ${prefix}Events = EventsFromPalletsDef<PalletsTypedef>


### PR DESCRIPTION
Something missing I encountered while implementing view functions...

This should go under `next`, since it is an addition and changes the required version of `polkadot-api` in the descriptors package.