### PR TITLE
fix(metadata-builders): decode to `null` for void entries

### DIFF
--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -366,7 +366,7 @@ async function replacePackageJson(descriptorsDir: string, version: bigint) {
   "types": "./dist/index.d.ts",
   "sideEffects": false,
   "peerDependencies": {
-    "polkadot-api": ">=1.11.0"
+    "polkadot-api": ">=1.11.2"
   }
 }
 `,

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Storage entry values decode to `null` if the entry is void.
+
 ## 1.11.1 - 2025-05-18
 
 ### Fixed

--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Storage entry values decode to `null` if the entry is void.
+
 ## 0.15.0 - 2025-05-15
 
 ### Added

--- a/packages/codegen/src/generate-descriptors.ts
+++ b/packages/codegen/src/generate-descriptors.ts
@@ -87,7 +87,10 @@ export const generateDescriptors = (
               name,
             )
             const checksum = checksumBuilder.buildStorage(pallet.name, name)!
-            const type = `StorageDescriptor<${key}, ${val}, ${!modifier}, ${opaque}>`
+            // if val is `void` it decodes to `undefined`, making it impossible
+            // to differentiate from a non-existant key
+            // therefore, if the key exists => null, if it doesn't => undefined
+            const type = `StorageDescriptor<${key}, ${val === "undefined" ? "null" : val}, ${!modifier}, ${opaque}>`
             return [
               name,
               {

--- a/packages/codegen/src/generate-docs-descriptors.ts
+++ b/packages/codegen/src/generate-docs-descriptors.ts
@@ -362,10 +362,13 @@ async function buildStorage(
                 pallet.name,
                 name,
               )
+              // if val is `void` it decodes to `undefined`, making it impossible
+              // to differentiate from a non-existant key
+              // therefore, if the key exists => null, if it doesn't => undefined
               return [
                 name,
                 {
-                  type: `StorageDescriptor<${args}, ${payload}, ${!modifier}, ${opaque}>`,
+                  type: `StorageDescriptor<${args}, ${payload === "undefined" ? "null" : payload}, ${!modifier}, ${opaque}>`,
                   docs,
                 },
               ]

--- a/packages/metadata-builders/CHANGELOG.md
+++ b/packages/metadata-builders/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Storage entry values decode to `null` if the entry is void.
+
 ## 0.12.0 - 2025-05-15
 
 ### Added


### PR DESCRIPTION
At the moment, these entries decode to `undefined`. This makes it impossible to differentiate from a non-existing entry when using `getValue`.