### PR TITLE
fix(client): ensure mortality always encode to valid values

### DIFF
--- a/integration-tests/zombie-tests/src/main.spec.ts
+++ b/integration-tests/zombie-tests/src/main.spec.ts
@@ -307,6 +307,42 @@ describe("E2E", async () => {
     )
   })
 
+  it("different mortality values", async () => {
+    const alice = accounts["alice"]["sr25519"]
+    const bob = accounts["bob"]["sr25519"]
+    const aliceAddress = accountIdDec(alice.publicKey)
+    const bobAddress = accountIdDec(bob.publicKey)
+    const initialNonce =
+      await api.apis.AccountNonceApi.account_nonce(aliceAddress)
+
+    const tx = api.tx.Balances.transfer_allow_death({
+      dest: MultiAddress.Id(bobAddress),
+      value: ED,
+    })
+    let i = 0
+    const submitAndWait = (
+      mortality: { mortal: false } | { mortal: true; period: number },
+    ) =>
+      lastValueFrom(
+        tx.signSubmitAndWatch(alice, { mortality, nonce: initialNonce + i++ }),
+      )
+
+    await Promise.all([
+      submitAndWait({ mortal: false }),
+      submitAndWait({ mortal: true, period: 8 }),
+      submitAndWait({ mortal: true, period: 25 }),
+      submitAndWait({
+        mortal: true,
+        period: api.constants.System.BlockHashCount(token),
+      }),
+    ])
+
+    const currentNonce =
+      await api.apis.AccountNonceApi.account_nonce(aliceAddress)
+
+    expect(currentNonce).toEqual(initialNonce + 4)
+  })
+
   it("keeps on validating transactions after they have been broadcasted", async () => {
     const alice = accounts["alice"]["sr25519"]
     const bob = accounts["bob"]["sr25519"]

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Ensure mortality always encode to valid values.
+
 ## 1.12.0 - 2025-05-21
 
 ### Added

--- a/packages/client/src/tx/signed-extensions/mortal-enc.ts
+++ b/packages/client/src/tx/signed-extensions/mortal-enc.ts
@@ -9,12 +9,24 @@ function trailingZeroes(n: number) {
   return i
 }
 
+function nextPower(n: number) {
+  if ((n & (n - 1)) === 0) return n
+  let count = 0
+  while (n > 0) {
+    n >>= 1
+    count++
+  }
+  return 1 << count
+}
+
 export const mortal = enhanceEncoder(
   Bytes(2)[0],
-  (value: { period: number; phase: number }) => {
-    const factor = Math.max(value.period >> 12, 1)
-    const left = Math.min(Math.max(trailingZeroes(value.period) - 1, 1), 15)
-    const right = (value.phase / factor) << 4
+  (value: { period: number; startAtBlock: number }) => {
+    const period = Math.min(Math.max(nextPower(value.period), 4), 1 << 16)
+    const phase = value.startAtBlock % period
+    const factor = Math.max(period >> 12, 1)
+    const left = Math.min(Math.max(trailingZeroes(period) - 1, 1), 15)
+    const right = (phase / factor) << 4
     return u16[0](left | right)
   },
 )

--- a/packages/client/src/tx/signed-extensions/mortal-enc.ts
+++ b/packages/client/src/tx/signed-extensions/mortal-enc.ts
@@ -9,15 +9,7 @@ function trailingZeroes(n: number) {
   return i
 }
 
-function nextPower(n: number) {
-  if ((n & (n - 1)) === 0) return n
-  let count = 0
-  while (n > 0) {
-    n >>= 1
-    count++
-  }
-  return 1 << count
-}
+const nextPower = (n: number) => 1 << Math.ceil(Math.log2(n))
 
 export const mortal = enhanceEncoder(
   Bytes(2)[0],

--- a/packages/client/src/tx/signed-extensions/sign-extensions.ts
+++ b/packages/client/src/tx/signed-extensions/sign-extensions.ts
@@ -90,7 +90,7 @@ export const getSignExtensionsCreator = (
               ? both(
                   mortal({
                     period: mortality.period,
-                    phase: mortality.startAtBlock.height % mortality.period,
+                    startAtBlock: mortality.startAtBlock.height,
                   }),
                   fromHex(mortality.startAtBlock.hash),
                 )


### PR DESCRIPTION
This follows the same impl as in https://github.com/paritytech/polkadot-sdk/blob/ff5c67c8a3d60ccb3f0af114a07db8f4bec485a0/substrate/primitives/runtime/src/generic/era.rs#L65-L72