### PR TITLE
fix(ink): filter events by contract address in ink!v6

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Ensure mortality always encode to valid values.
+- ink!: Filter events by contract address for ink!v6
 
 ## 1.12.0 - 2025-05-21
 

--- a/packages/ink-contracts/CHANGELOG.md
+++ b/packages/ink-contracts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Filter events by contract address for ink!v6
+
 ## 0.3.2 - 2025-05-20
 
 ### Fixed


### PR DESCRIPTION
On ink! v6, contracts are deployed to pallet-revive, where addresses are in the ethereum format.

This means that they are not converted by default to SS58 strings, so when filtering events we need to convert them to hex to filter them.