### PR TITLE
fix(client): properly throw `BlockNotPinnedError`

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Throw \`BlockNotPinned\` when trying to access a non-pinned block.
+
 ## 1.13.0 - 2025-05-30
 
 ### Added

--- a/packages/client/src/re-exports.ts
+++ b/packages/client/src/re-exports.ts
@@ -16,3 +16,4 @@ export {
   getSs58AddressInfo,
 } from "@polkadot-api/substrate-bindings"
 export { CompatibilityLevel } from "@polkadot-api/metadata-compatibility"
+export { BlockNotPinnedError } from "@polkadot-api/observable-client"

--- a/packages/observable-client/CHANGELOG.md
+++ b/packages/observable-client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Throw \`BlockNotPinned\` when trying to access a non-pinned block.
+
 ## 0.11.1 - 2025-05-30
 
 ### Fixed


### PR DESCRIPTION
Unfortunately, there were instances where we were throwing random runtime errors when trying to run a chain-interaction against a block that's not pinned. This PR fixes the issue.