### PR TITLE
fix(client): narrow type of `at` property of `CallOptions`

### DIFF
--- a/packages/client/src/runtime-call.ts
+++ b/packages/client/src/runtime-call.ts
@@ -5,7 +5,15 @@ import { map, mergeMap } from "rxjs"
 import { CompatibilityFunctions, CompatibilityHelper } from "./compatibility"
 
 type CallOptions = Partial<{
-  at: string
+  /**
+   * `at` could be a blockHash, `best`, or `finalized` (default)
+   */
+  at: "best" | "finalized" | ({} & string)
+  /**
+   * `signal` allows you to abort an ongoing Promise. See [MDN
+   * docs](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) for
+   * more information
+   */
   signal: AbortSignal
 }>
 

--- a/packages/client/src/storage.ts
+++ b/packages/client/src/storage.ts
@@ -41,7 +41,7 @@ type CallOptions = Partial<{
   /**
    * `at` could be a blockHash, `best`, or `finalized` (default)
    */
-  at: string
+  at: "best" | "finalised" | ({} & string)
   /**
    * `signal` allows you to abort an ongoing Promise. See [MDN
    * docs](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) for

--- a/packages/client/src/viewFns.ts
+++ b/packages/client/src/viewFns.ts
@@ -6,7 +6,15 @@ import { CompatibilityFunctions, CompatibilityHelper } from "./compatibility"
 import { compactNumber, _void } from "@polkadot-api/substrate-bindings"
 
 type CallOptions = Partial<{
-  at: string
+  /**
+   * `at` could be a blockHash, `best`, or `finalized` (default)
+   */
+  at: "best" | "finalized" | ({} & string)
+  /**
+   * `signal` allows you to abort an ongoing Promise. See [MDN
+   * docs](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) for
+   * more information
+   */
   signal: AbortSignal
 }>
 

--- a/packages/client/src/viewFns.ts
+++ b/packages/client/src/viewFns.ts
@@ -7,7 +7,7 @@ import { compactNumber, _void } from "@polkadot-api/substrate-bindings"
 
 type CallOptions = Partial<{
   /**
-   * `at` could be a blockHash, `best`, or `finalized` (default)
+   * `at` could be a block-hash, `best`, or `finalized` (default)
    */
   at: "best" | "finalized" | ({} & string)
   /**


### PR DESCRIPTION
This change will give the user the options to autocomplete the special values of `best` and `finalized` for the `at` property of the `CallOptions`, but also allows of an arbitrary string like before in order to pass a blockhash value.