### PR TITLE
fix: add missing Other variant to DigestItem codec

### DIFF
--- a/packages/substrate-bindings/CHANGELOG.md
+++ b/packages/substrate-bindings/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Add missing `Other` variant to `DigestItem` codec
+
 ## 0.15.0 - 2025-07-16
 
 ### Added

--- a/packages/substrate-bindings/src/codecs/blockHeader.ts
+++ b/packages/substrate-bindings/src/codecs/blockHeader.ts
@@ -26,7 +26,7 @@ const diggestVal = Struct({
 
 const diggest = Variant(
   {
-    other: Hex(),
+    other: Bytes(),
     consensus: diggestVal,
     seal: diggestVal,
     preRuntime: diggestVal,

--- a/packages/substrate-bindings/src/codecs/blockHeader.ts
+++ b/packages/substrate-bindings/src/codecs/blockHeader.ts
@@ -26,12 +26,13 @@ const diggestVal = Struct({
 
 const diggest = Variant(
   {
+    other: Hex(),
     consensus: diggestVal,
     seal: diggestVal,
     preRuntime: diggestVal,
     runtimeUpdated: _void,
   },
-  [4, 5, 6, 8],
+  [0, 4, 5, 6, 8],
 )
 
 const hex32 = Hex(32)


### PR DESCRIPTION
This PR fixes a bug in the DigestItem codec implementation where the "Other" variant was not being handled, despite being correctly defined in the DigestItem enum type.

### The Issue

The DigestItem enum in `known-types.ts` correctly defines all variants according to the polkadot-sdk specification:
- `Other` (index 0)
- `Consensus` (index 4)  
- `Seal` (index 5)
- `PreRuntime` (index 6)
- `RuntimeEnvironmentUpdated` (index 8)

However, the codec implementation in `packages/substrate-bindings/src/codecs/blockHeader.ts` was only handling indices `[4, 5, 6, 8]`, missing index 0 for the "Other" variant.

### The Fix

Added the missing "Other" variant to the codec implementation:
```typescript
const diggest = Variant(
  {
    other: Bytes(),  // Added this line
    consensus: diggestVal,
    seal: diggestVal,
    preRuntime: diggestVal,
    runtimeUpdated: _void,
  },
  [0, 4, 5, 6, 8],  // Added index 0
)
```
### References

- [polkadot-sdk DigestItem definition](https://github.com/paritytech/polkadot-sdk/blob/8b21416986049b26bf99e61bf1c43b7347ed564f/substrate/primitives/runtime/src/generic/digest.rs#L77)