### PR TITLE
fix(observable-client): prevent used runtime to be deleted

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix "Cannot read properties of undefined (reading 'runtime')" issue.
+
 ## 1.15.1 - 2025-07-23
 
 ### Fixed

--- a/packages/observable-client/CHANGELOG.md
+++ b/packages/observable-client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Increase the runtime usage of the initialized blocks.
+
 ## 0.13.2 - 2025-07-23
 
 ### Fixed

--- a/packages/observable-client/src/chainHead/streams/pinned-blocks.ts
+++ b/packages/observable-client/src/chainHead/streams/pinned-blocks.ts
@@ -147,6 +147,8 @@ export const getPinnedBlocks$ = (
                 acc.finalizedRuntime = acc.runtimes[hash] = getRuntime(
                   createRuntimeGetter(acc, hash),
                 )
+
+              acc.runtimes[latestRuntime].usages.add(hash)
             }
           })
           return acc
@@ -182,6 +184,7 @@ export const getPinnedBlocks$ = (
               // it assumes pinnedBlocks.runtimes[hash] is empty and pinnedBlocks.blocks.has(hash)
               acc.runtimes[hash] = getRuntime(createRuntimeGetter(acc, hash))
             }
+
             acc.runtimes[block.runtime].addBlock(hash)
           }
 


### PR DESCRIPTION
The finalized-blocks on the `initialized` event were not being added into the usage of the initial-runtime, which means that if one of those blocks was unpinned before a new-block arrived, then the runtime wouldn't be present and the new-block would trigger a runtime error when trying to access its non-existing runtime.