### PR TITLE
fix(codegen): incorrect empty object type

### DIFF
--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Replaced `{}` with `Record<string, never>` to accurately type "empty object".
+
 ## 0.17.1 - 2025-07-23
 
 ### Fixed

--- a/packages/codegen/src/internal-types/generate-typescript.ts
+++ b/packages/codegen/src/internal-types/generate-typescript.ts
@@ -153,19 +153,22 @@ export const generateObjectCode = (
   }))
 
   return {
-    code: `{${innerValues
-      .map(({ label, docs, value, result }) => {
-        const docsPrefix = docs.length
-          ? `\n/**\n${docs.map((doc) => ` * ${doc.trim()}`).join("\n")}\n */\n`
-          : ""
-        if (result === null)
-          return docsPrefix + `${JSON.stringify(label)}: undefined`
+    code:
+      innerValues.length === 0
+        ? "Record<string, never>"
+        : `{${innerValues
+            .map(({ label, docs, value, result }) => {
+              const docsPrefix = docs.length
+                ? `\n/**\n${docs.map((doc) => ` * ${doc.trim()}`).join("\n")}\n */\n`
+                : ""
+              if (result === null)
+                return docsPrefix + `${JSON.stringify(label)}: undefined`
 
-        const isOptional = value?.type === "option"
-        const key = JSON.stringify(label) + (isOptional ? "?" : "")
-        return docsPrefix + `${key}: ${result.code}`
-      })
-      .join(", ")}}`,
+              const isOptional = value?.type === "option"
+              const key = JSON.stringify(label) + (isOptional ? "?" : "")
+              return docsPrefix + `${key}: ${result.code}`
+            })
+            .join(", ")}}`,
     imports: mergeImports(innerValues.map((v) => v.result?.imports ?? {})),
   }
 }


### PR DESCRIPTION
The `{}` type allows any non-nullish value. `Record<string, never>` will actually enforce "empty object".

One apparent issue caused by this bug is when encoding an ink! message that takes no arguments:

```ts
psp22
  .message("PSP22Metadata::token_name")
  // Any non-nullish value will be accepted
  .encode("foo bar")
```