### PR TITLE
fix: prevent uncaught RPC error on unpin

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
 - Avoid runtime error when the reply to `chainHead_v1_follow` comes synchronously.
+- Prevent uncaught RPC error on unpin
 
 ## 1.15.2 - 2025-08-01
 

--- a/packages/observable-client/CHANGELOG.md
+++ b/packages/observable-client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Prevent uncaught RPC error on unpin
+
 ## 0.13.3 - 2025-08-01
 
 ### Fixed

--- a/packages/observable-client/src/chainHead/chainHead.ts
+++ b/packages/observable-client/src/chainHead/chainHead.ts
@@ -168,7 +168,9 @@ export const getChainHead$ = (
     setCachedMetadata,
     blockUsage$,
     (blocks) => {
-      unpin(blocks)
+      unpin(blocks).catch((err) => {
+        console.error("unpin", err)
+      })
       blocks.forEach((hash) => {
         cache.delete(hash)
       })


### PR DESCRIPTION
Some RPCs are erroring on `chainHead_v1_unpin`, by throwing an "Invalid Block Hash" error, even though the block being unpinned was reported by the RPC server and is being unpinned as per the spec.

It happens mainly radiumblock, which is what I have used to debug this, but I've also had it randomly (and extremely rarely) happen with IBP2 (dotters). I've sent a message to the RadiumBlock team to see if they take a look at what might be happening.

Problem is some runtimes (at least bun, and I think nodejs from a specific version onward?) will halt the process when an uncaught exception is thrown, as it was the case for unpin (as it's something being handled internally by polkadot-api). This PR basically adds a `.catch()` to catch the error, but logs it into the console as I still think we should really not swallow these kind of errors.

Another thing up for discussion I guess is what to do with the unpinning logic when one of these errors happen… my suggestion is ignore it. If blocks are not getting unpinned, the RPC/Client can always throw a stop event and papi will recover from that. Not ideal, but it should work.