### PR TITLE
feat: add legacy-provider

### DIFF
--- a/.github/workflows/zombienet.yml
+++ b/.github/workflows/zombienet.yml
@@ -68,8 +68,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Logs
-          path: |
-            integration-tests/zombie-tests/zombienet_logs
-            integration-tests/zombie-tests/${{matrix.version}}_SMOLDOT
-            integration-tests/zombie-tests/${{matrix.version}}_JSON_RPC
-            integration-tests/zombie-tests/${{matrix.version}}_JSON_RPC_INNER
+          path: integration-tests/zombie-tests/${{matrix.version}}*

--- a/.github/workflows/zombienet.yml
+++ b/.github/workflows/zombienet.yml
@@ -18,6 +18,7 @@ jobs:
           - polkadot-stable2503-5
         kind:
           - ws
+          - ws-legacy
           - sm
     runs-on: ubuntu-latest
     steps:
@@ -69,5 +70,6 @@ jobs:
           name: Logs
           path: |
             integration-tests/zombie-tests/zombienet_logs
-            integration-tests/zombie-tests/${{matrix.version}}_JSON_RPC
             integration-tests/zombie-tests/${{matrix.version}}_SMOLDOT
+            integration-tests/zombie-tests/${{matrix.version}}_JSON_RPC
+            integration-tests/zombie-tests/${{matrix.version}}_JSON_RPC_INNER

--- a/integration-tests/zombie-tests/package.json
+++ b/integration-tests/zombie-tests/package.json
@@ -8,12 +8,13 @@
     "build": "pnpm build-external",
     "lint": "prettier --check \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
-    "e2e": "papi update && vitest run --test-timeout=300000"
+    "e2e": "papi update && vitest run --test-timeout=300000 --bail=1"
   },
   "dependencies": {
     "@noble/curves": "^1.9.2",
     "@polkadot-api/cli": "workspace:*",
     "@polkadot-api/descriptors": "file:.papi/descriptors",
+    "@polkadot-api/legacy-provider": "workspace:*",
     "@polkadot-api/substrate-bindings": "workspace:*",
     "@polkadot-api/substrate-client": "workspace:*",
     "@polkadot-api/utils": "workspace:*",

--- a/integration-tests/zombie-tests/src/main.spec.ts
+++ b/integration-tests/zombie-tests/src/main.spec.ts
@@ -35,9 +35,10 @@ import { getMetadata, MultiAddress, roc } from "@polkadot-api/descriptors"
 import { accounts } from "./keyring"
 import { getPolkadotSigner } from "polkadot-api/signer"
 import { fromHex } from "@polkadot-api/utils"
-import { withPolkadotSdkCompat } from "polkadot-api/polkadot-sdk-compat"
 import { withLogsRecorder } from "polkadot-api/logs-provider"
 import { appendFileSync } from "fs"
+import { withLegacy } from "@polkadot-api/legacy-provider"
+import { withPolkadotSdkCompat } from "polkadot-api/polkadot-sdk-compat"
 
 const fakeSignature = new Uint8Array(64)
 const getFakeSignature = () => fakeSignature
@@ -76,7 +77,7 @@ const setTickDate = () => {
 }
 setTickDate()
 
-if (PROVIDER !== "sm" && PROVIDER !== "ws")
+if (PROVIDER !== "sm" && PROVIDER !== "ws" && PROVIDER !== "ws-legacy")
   throw new Error(`$PROVIDER env has to be "ws" or "sm". Got ${PROVIDER}`)
 let ARCHIVE = false
 const rawClient = createRawClient(
@@ -100,6 +101,7 @@ const ED = 10_000_000_000n
 const FEE_VARIATION_TOLERANCE = 10_000_000n
 
 console.log("got the chainspec")
+appendFileSync(`./${VERSION}_JSON_RPC_INNER`, "\n")
 
 describe("E2E", async () => {
   let client: PolkadotClient
@@ -113,8 +115,24 @@ describe("E2E", async () => {
       enhancer(getSmProvider(smoldot.addChain({ chainSpec }))),
     )
   } else {
+    const legacyEnhancer = PROVIDER === "ws" ? identity : withLegacy()
+    const compatEnhancer = PROVIDER === "ws" ? withPolkadotSdkCompat : identity
     client = createClient(
-      enhancer(withPolkadotSdkCompat(getWsProvider("ws://127.0.0.1:9934"))),
+      enhancer(
+        compatEnhancer(
+          getWsProvider({
+            endpoints: ["ws://127.0.0.1:9934"],
+            innerEnhancer: (base) =>
+              legacyEnhancer(
+                withLogsRecorder(
+                  (log) =>
+                    appendFileSync(`./${VERSION}_JSON_RPC_INNER`, log + "\n"),
+                  base,
+                ),
+              ),
+          }),
+        ),
+      ),
       { getMetadata },
     )
     const { methods } = await client._request<{ methods: string[] }, []>(
@@ -331,9 +349,9 @@ describe("E2E", async () => {
           (e): e is TxEvent & { type: "bestChainBlockIncluded" } =>
             e.type === "txBestBlocksState" && e.found,
         ),
-        switchMap(({ block: { hash: at } }) =>
-          transfer.signSubmitAndWatch(alice, { at }),
-        ),
+        switchMap(({ block: { hash: at } }) => {
+          return transfer.signSubmitAndWatch(alice, { at })
+        }),
       ),
     )
 
@@ -602,10 +620,30 @@ describe("E2E", async () => {
 
       beforeAll(async () => {
         do {
+          const legacyEnhancer = PROVIDER === "ws" ? identity : withLegacy()
+          const compatEnhancer =
+            PROVIDER === "ws" ? withPolkadotSdkCompat : identity
           newClient?.destroy()
           console.log("creating archive client")
           newClient = createClient(
-            withPolkadotSdkCompat(getWsProvider("ws://127.0.0.1:9934")),
+            enhancer(
+              compatEnhancer(
+                getWsProvider({
+                  endpoints: ["ws://127.0.0.1:9934"],
+                  innerEnhancer: (base) =>
+                    legacyEnhancer(
+                      withLogsRecorder(
+                        (log) =>
+                          appendFileSync(
+                            `./${VERSION}_JSON_RPC_INNER`,
+                            log + "\n",
+                          ),
+                        base,
+                      ),
+                    ),
+                }),
+              ),
+            ),
           )
         } while ((await newClient.getFinalizedBlock()).hash === oldBlock.hash)
         oldApi = newClient.getTypedApi(roc)

--- a/integration-tests/zombie-tests/src/main.spec.ts
+++ b/integration-tests/zombie-tests/src/main.spec.ts
@@ -55,14 +55,14 @@ let appendSmLog:
   | undefined = undefined
 
 if (VERSION) {
-  const jsonRpcFileName = `./${VERSION}_JSON_RPC`
+  const jsonRpcFileName = `./${VERSION}_${PROVIDER}_JSON_RPC`
   enhancer = (input) =>
     withLogsRecorder(
       (log) => appendFileSync(jsonRpcFileName, log + "\n"),
       input,
     )
 
-  const smoldotFileName = `./${VERSION}_SMOLDOT`
+  const smoldotFileName = `./${VERSION}_${PROVIDER}_SMOLDOT`
   appendSmLog = (level: number, target: string, message: string) => {
     const msg = `${tickDate} (${level})${target}\n${message}\n`
     if (level <= 3) console.log(msg)
@@ -101,7 +101,6 @@ const ED = 10_000_000_000n
 const FEE_VARIATION_TOLERANCE = 10_000_000n
 
 console.log("got the chainspec")
-appendFileSync(`./${VERSION}_JSON_RPC_INNER`, "\n")
 
 describe("E2E", async () => {
   let client: PolkadotClient
@@ -126,7 +125,10 @@ describe("E2E", async () => {
               legacyEnhancer(
                 withLogsRecorder(
                   (log) =>
-                    appendFileSync(`./${VERSION}_JSON_RPC_INNER`, log + "\n"),
+                    appendFileSync(
+                      `./${VERSION}_${PROVIDER}_JSON_RPC_INNER`,
+                      log + "\n",
+                    ),
                   base,
                 ),
               ),
@@ -635,7 +637,7 @@ describe("E2E", async () => {
                       withLogsRecorder(
                         (log) =>
                           appendFileSync(
-                            `./${VERSION}_JSON_RPC_INNER`,
+                            `./${VERSION}_${PROVIDER}_JSON_RPC_INNER`,
                             log + "\n",
                           ),
                         base,

--- a/packages/json-rpc/legacy-provider/CHANGELOG.md
+++ b/packages/json-rpc/legacy-provider/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+### Changed
+
+Initial release

--- a/packages/json-rpc/legacy-provider/README.md
+++ b/packages/json-rpc/legacy-provider/README.md
@@ -1,0 +1,1 @@
+# @polkadot-api/legacy-provider

--- a/packages/json-rpc/legacy-provider/package.json
+++ b/packages/json-rpc/legacy-provider/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@polkadot-api/legacy-provider",
+  "version": "0.1.0",
+  "author": "Josep M Sobrepere (https://github.com/josepot)",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/polkadot-api/polkadot-api.git"
+  },
+  "license": "MIT",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "node": {
+        "production": {
+          "import": "./dist/esm/index.mjs",
+          "require": "./dist/min/index.js",
+          "default": "./dist/index.js"
+        },
+        "import": "./dist/esm/index.mjs",
+        "require": "./dist/index.js",
+        "default": "./dist/index.js"
+      },
+      "module": "./dist/esm/index.mjs",
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/esm/index.mjs",
+  "browser": "./dist/esm/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build-core": "tsc --noEmit && rollup -c ../../../rollup.config.js",
+    "build": "pnpm build-core",
+    "test": "echo 'no tests'",
+    "lint": "prettier --check README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
+    "format": "prettier --write README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
+    "prepack": "pnpm run build"
+  },
+  "dependencies": {
+    "@polkadot-api/utils": "workspace:*",
+    "@polkadot-api/raw-client": "workspace:*",
+    "@polkadot-api/substrate-bindings": "workspace:*",
+    "@polkadot-api/json-rpc-provider": "workspace:*"
+  },
+  "peerDependencies": {
+    "rxjs": ">=7.8.0"
+  },
+  "devDependencies": {
+    "@polkadot-api/json-rpc-provider": "workspace:*",
+    "rxjs": "^7.8.2"
+  }
+}

--- a/packages/json-rpc/legacy-provider/src/downstream/archive.ts
+++ b/packages/json-rpc/legacy-provider/src/downstream/archive.ts
@@ -1,0 +1,120 @@
+import { createUpstream } from "@/upstream/upstream"
+import { createOpaqueToken } from "@/utils/create-opaque-token"
+import { finalize, map, Observable, take } from "rxjs"
+import { areItemsValid, getStg$ } from "./storage"
+
+export const archiveMethods = Object.fromEntries(
+  [
+    "body",
+    "call",
+    "finalizedHeight",
+    "genesisHash",
+    "hashByHeight",
+    "header",
+    "stopStorage",
+    "storage",
+  ].map((key) => [key, `archive_v1_${key}`] as const),
+)
+
+export const createArchive = (
+  upstream: ReturnType<typeof createUpstream>,
+  reply: (id: string, result: any) => void,
+  err: (id: string, code: number, msg: string) => void,
+  notification: (method: string, subscription: string, result: any) => void,
+) => {
+  const subscriptions = new Map<string, () => void>()
+  const stg = (
+    reply: (x: string) => void,
+    at: string,
+    items: Array<{
+      key: string
+      type:
+        | "value"
+        | "hash"
+        | "descendantsValues"
+        | "descendantsHashes"
+        | "closestDescendantMerkleValue"
+    }>,
+  ) => {
+    const subId = createOpaqueToken()
+    reply(subId)
+    const innerNotifiaction = (result: any) => {
+      notification("archive_v1_storageEvent", subId, result)
+    }
+
+    const subscription = getStg$(upstream, at, items)
+      .pipe(
+        finalize(() => {
+          subscriptions.delete(subId)
+        }),
+      )
+      .subscribe(
+        (items) => {
+          items.forEach((item) =>
+            innerNotifiaction({ event: "storage", ...item }),
+          )
+        },
+        (e) => {
+          console.error(e)
+          innerNotifiaction({ event: "storageError", error: "" }) // TODO: figure this out
+        },
+        () => {
+          innerNotifiaction({ event: "storageDone" })
+        },
+      )
+
+    if (!subscription.closed)
+      subscriptions.set(subId, () => {
+        subscription.unsubscribe()
+      })
+  }
+
+  return (rId: string, name: string, params: Array<any>) => {
+    const innerReply = (value: any) => {
+      reply(rId, value)
+    }
+
+    const obsReply = (input: Observable<any>) => {
+      input.subscribe({
+        next: innerReply,
+        error: (e) => {
+          err(rId, e.code ?? -1, e.error ?? "")
+        },
+      })
+    }
+
+    const [firstArg, secondArg, thirdArg] = params
+    switch (name) {
+      case archiveMethods.body:
+        return obsReply(upstream.getBody(firstArg))
+      case archiveMethods.call:
+        return obsReply(
+          upstream
+            .runtimeCall(firstArg, secondArg, thirdArg)
+            .pipe(map((value) => ({ success: true, value }))),
+        )
+      case archiveMethods.finalizedHeight:
+        return obsReply(
+          upstream.getBlocks.finalized$.pipe(
+            map((x) => x.number),
+            take(1),
+          ),
+        )
+      case archiveMethods.genesisHash:
+        return obsReply(upstream.genesisHash)
+      case archiveMethods.hashByHeight:
+        return obsReply(upstream.getBlockHash$(firstArg))
+      case archiveMethods.header:
+        return obsReply(upstream.getHeader(firstArg).pipe(map((h) => h.header)))
+      case archiveMethods.stopStorage: {
+        const sub = subscriptions.get(firstArg)
+        return sub ? sub() : err(rId, -32602, "Invalid args")
+      }
+      case archiveMethods.storage:
+        return areItemsValid(secondArg)
+          ? stg(innerReply, firstArg, secondArg)
+          : err(rId, -32602, "Invalid args")
+    }
+    throw null
+  }
+}

--- a/packages/json-rpc/legacy-provider/src/downstream/chain-head.ts
+++ b/packages/json-rpc/legacy-provider/src/downstream/chain-head.ts
@@ -1,0 +1,285 @@
+import { createUpstream } from "@/upstream/upstream"
+import { createOpaqueToken } from "@/utils/create-opaque-token"
+import { noop } from "@polkadot-api/utils"
+import { finalize } from "rxjs"
+import { areItemsValid, getStg$ } from "./storage"
+
+export const chainHeadMethods = Object.fromEntries(
+  [
+    "body",
+    "call",
+    "continue",
+    "follow",
+    "header",
+    "stopOperation",
+    "storage",
+    "unfollow",
+    "unpin",
+  ].map((key) => [key, `chainHead_v1_${key}`] as const),
+)
+
+export const createChainHead = (
+  upstream: ReturnType<typeof createUpstream>,
+  reply: (id: string, result: any) => void,
+  err: (id: string, code: number, msg: string) => void,
+  notification: (method: string, subscription: string, result: any) => void,
+) => {
+  type SubCtx = {
+    id: string
+    up: ReturnType<typeof upstream.getBlocks>
+    operations: Map<string, () => void>
+    cleanUp: () => void
+  }
+  const subscriptions = new Map<string, SubCtx>()
+
+  const follow = (rId: string) => {
+    if (subscriptions.size === 2) {
+      return err(rId, -32800, "Limit reached")
+    }
+    const token = createOpaqueToken()
+    const up = upstream.getBlocks(token)
+    const operations = new Map<string, () => void>()
+    subscriptions.set(token, {
+      id: token,
+      up,
+      operations,
+      cleanUp: () => {
+        cleanUp()
+      },
+    })
+    let cleanUp = noop
+
+    reply(rId, token)
+    let subscription = up.blocks$.subscribe({
+      next(v) {
+        notification("chainHead_v1_followEvent", token, v)
+      },
+      error(e) {
+        console.error(e)
+        cleanUp()
+        // TODO: fix this shit
+        // notification("chainHead_v1_followEvent", token, { event: "stop" })
+      },
+    })
+    cleanUp = () => {
+      cleanUp = noop
+      subscription?.unsubscribe()
+      subscription = null as any
+      operations.forEach((cb) => {
+        cb()
+      })
+      operations.clear()
+      subscriptions.delete(token)
+    }
+    if (subscription.closed) cleanUp()
+  }
+
+  const unfollow = (rId: string, followId: string) => {
+    subscriptions.get(followId)?.cleanUp()
+    reply(rId, "null")
+  }
+
+  const stopOperation = (
+    rId: string,
+    followId: string,
+    operationId: string,
+  ) => {
+    const cb = subscriptions.get(followId)?.operations.get(operationId)
+    if (cb) cb()
+    reply(rId, "null")
+  }
+
+  const header = (
+    { up: { getHeader } }: SubCtx,
+    reply: (x: any) => void,
+    at: string,
+  ) => {
+    reply(getHeader(at))
+  }
+
+  const unpin = (
+    { up: { unpin: innerUnpin } }: SubCtx,
+    reply: (x: any) => void,
+    hashOrHashes: string | string[],
+  ) => {
+    const hashes =
+      typeof hashOrHashes === "string" ? [hashOrHashes] : hashOrHashes
+    hashes.forEach(innerUnpin)
+    reply(null)
+  }
+
+  const call = (
+    { operations, id: followId }: SubCtx,
+    reply: (x: any) => void,
+    at: string,
+    method: string,
+    args: string,
+  ) => {
+    const operationId = createOpaqueToken()
+    reply({ result: "started", operationId })
+    const subscription = upstream.runtimeCall(at, method, args).subscribe(
+      (output) => {
+        operations.delete(operationId)
+        notification("chainHead_v1_call", followId, {
+          event: "operationCallDone",
+          operationId,
+          output,
+        })
+      },
+      (e) => {
+        operations.delete(operationId)
+        console.error(e)
+        notification("chainHead_v1_call", followId, {
+          event: "operationError",
+          operationId,
+          error: "", // TODO: figure this out
+        })
+      },
+    )
+    if (!subscription.closed)
+      operations.set(operationId, () => {
+        subscription.unsubscribe()
+        operations.delete(operationId)
+      })
+  }
+  const body = (
+    { operations, id: followId }: SubCtx,
+    reply: (x: any) => void,
+    at: string,
+  ) => {
+    const operationId = createOpaqueToken()
+    reply({ result: "started", operationId })
+    const subscription = upstream.getBody(at).subscribe(
+      ({ block: { extrinsics: value } }) => {
+        operations.delete(operationId)
+        notification("chainHead_v1_body", followId, {
+          event: "operationBodyDone",
+          operationId,
+          value,
+        })
+      },
+      (e) => {
+        operations.delete(operationId)
+        console.error(e)
+        notification("chainHead_v1_body", followId, {
+          event: "operationError",
+          operationId,
+          error: "", // TODO: figure this out
+        })
+      },
+    )
+
+    if (!subscription.closed)
+      operations.set(operationId, () => {
+        subscription.unsubscribe()
+        operations.delete(operationId)
+      })
+  }
+
+  const stg = (
+    { operations, id: followId }: SubCtx,
+    reply: (x: any) => void,
+    at: string,
+    items: Array<{
+      key: string
+      type:
+        | "value"
+        | "hash"
+        | "descendantsValues"
+        | "descendantsHashes"
+        | "closestDescendantMerkleValue"
+    }>,
+  ) => {
+    const operationId = createOpaqueToken()
+    reply({ result: "started", operationId })
+    const innerNotifiaction = (msg: any) => {
+      notification("chainHead_v1_storage", followId, msg)
+    }
+    const subscription = getStg$(upstream, at, items)
+      .pipe(
+        finalize(() => {
+          operations.delete(operationId)
+        }),
+      )
+      .subscribe(
+        (items) => {
+          innerNotifiaction({
+            event: "operationStorageItems",
+            operationId,
+            items,
+          })
+        },
+        (e) => {
+          console.error(e)
+          innerNotifiaction({
+            event: "operationError",
+            operationId,
+            error: "", // TODO: figure this out
+          })
+        },
+        () => {
+          innerNotifiaction({
+            event: "operationStorageDone",
+            operationId,
+          })
+        },
+      )
+
+    if (!subscription.closed)
+      operations.set(operationId, () => {
+        subscription.unsubscribe()
+      })
+  }
+
+  return (rId: string, method: string, params: Array<any>) => {
+    if (method === chainHeadMethods.follow) return follow(rId)
+    const [followId, ...rest] = params as [string, ...any[]]
+    const ctx = subscriptions.get(followId)
+    if (!ctx) return err(rId, -32602, "Ivalid followSubscription")
+
+    const innerReply = (value: any) => {
+      reply(rId, value)
+    }
+
+    switch (method) {
+      case chainHeadMethods.unfollow:
+        return unfollow(rId, followId)
+      case chainHeadMethods.stopOperation:
+        return stopOperation(rId, followId, rest[0])
+      case chainHeadMethods.unpin: {
+        const [hashOrHashes] = rest
+        if (
+          (Array.isArray(hashOrHashes) ? hashOrHashes : [hashOrHashes]).some(
+            (hash) => typeof hash !== "string",
+          )
+        )
+          return err(rId, -32602, "Invalid args")
+        return unpin(ctx, innerReply, hashOrHashes)
+      }
+      default: {
+        const [at, ...other] = rest as [string, ...any[]]
+        if (!ctx.up.isPinned(at)) return err(rId, -32801, "Block not pinned")
+
+        switch (method) {
+          case chainHeadMethods.header:
+            return header(ctx, innerReply, at)
+          case chainHeadMethods.body:
+            return body(ctx, innerReply, at)
+          case chainHeadMethods.call: {
+            const [method, data] = other
+            if (typeof method !== "string" || typeof data !== "string")
+              return err(rId, -32602, "Invalid args")
+            return call(ctx, innerReply, at, method, data)
+          }
+          case chainHeadMethods.storage: {
+            const [items] = other
+            return areItemsValid(items)
+              ? stg(ctx, innerReply, at, items)
+              : err(rId, -32602, "Invalid args")
+          }
+        }
+      }
+    }
+    throw null
+  }
+}

--- a/packages/json-rpc/legacy-provider/src/downstream/chainspec.ts
+++ b/packages/json-rpc/legacy-provider/src/downstream/chainspec.ts
@@ -1,0 +1,30 @@
+import { createUpstream } from "@/upstream/upstream"
+
+export const chainSpecMethods = Object.fromEntries(
+  ["chainName", "genesisHash", "properties"].map(
+    (key) => [key, `chainSpec_v1_${key}`] as const,
+  ),
+)
+
+export const createChainSpec = (
+  upstream: ReturnType<typeof createUpstream>,
+  reply: (id: string, result: any) => void,
+  err: (id: string, code: number, msg: string) => void,
+) => {
+  return (rId: string, method: string) => {
+    const [, , name] = method.split("_")
+    const observable =
+      upstream[name as "chainName" | "genesisHash" | "properties"]
+    if (!observable) throw null
+
+    observable.subscribe(
+      (result) => {
+        reply(rId, result)
+      },
+      (e: any) => {
+        console.error(e)
+        err(rId, -32602, "Invalid")
+      },
+    )
+  }
+}

--- a/packages/json-rpc/legacy-provider/src/downstream/downstream.ts
+++ b/packages/json-rpc/legacy-provider/src/downstream/downstream.ts
@@ -57,7 +57,7 @@ export const createDownstream =
         chainSpec: createChainSpec(upstream, reply, err),
         chainHead: createChainHead(upstream, reply, err, notification),
         archive: createArchive(upstream, reply, err, notification),
-        transaction: createTransactionFns(upstream, reply, err),
+        transaction: createTransactionFns(upstream, reply),
       }
       return {
         send: (msg) => {

--- a/packages/json-rpc/legacy-provider/src/downstream/downstream.ts
+++ b/packages/json-rpc/legacy-provider/src/downstream/downstream.ts
@@ -1,6 +1,6 @@
 import type { JsonRpcProvider } from "@polkadot-api/json-rpc-provider"
 import { createUpstream } from "@/upstream"
-import { createChainSpec } from "./chainspec"
+import { chainSpecMethods, createChainSpec } from "./chainspec"
 import { chainHeadMethods, createChainHead } from "./chain-head"
 import { createTransactionFns, transactionMethods } from "./transaction"
 import { archiveMethods, createArchive } from "./archive"
@@ -8,7 +8,7 @@ import { Blake2256 } from "@polkadot-api/substrate-bindings"
 import { withNumericIds } from "@/with-numeric"
 
 const supportedMethods = [
-  chainHeadMethods,
+  chainSpecMethods,
   archiveMethods,
   chainHeadMethods,
   transactionMethods,
@@ -71,6 +71,7 @@ export const createDownstream =
             (id !== null && typeof id !== "string" && typeof id !== "number") ||
             typeof method !== "string"
           ) {
+            console.warn(`Invalid message:\n${msg}`)
             return
           }
           if (method === "rpc_methods") {
@@ -80,7 +81,7 @@ export const createDownstream =
                   methods: [
                     ...supportedMethods,
                     ...methods.filter(
-                      (method) => !supportedMethods.includes(method as any),
+                      (method) => !supportedMethods.includes(method),
                     ),
                   ],
                 })

--- a/packages/json-rpc/legacy-provider/src/downstream/downstream.ts
+++ b/packages/json-rpc/legacy-provider/src/downstream/downstream.ts
@@ -1,0 +1,124 @@
+import type { JsonRpcProvider } from "@polkadot-api/json-rpc-provider"
+import { createUpstream } from "@/upstream"
+import { createChainSpec } from "./chainspec"
+import { chainHeadMethods, createChainHead } from "./chain-head"
+import { createTransactionFns, transactionMethods } from "./transaction"
+import { archiveMethods, createArchive } from "./archive"
+import { Blake2256 } from "@polkadot-api/substrate-bindings"
+import { withNumericIds } from "@/with-numeric"
+
+const supportedMethods = [
+  chainHeadMethods,
+  archiveMethods,
+  chainHeadMethods,
+  transactionMethods,
+]
+  .map((methods) => Object.values(methods) as string[])
+  .flat()
+
+export const createDownstream =
+  (hasher: (input: Uint8Array) => Uint8Array = Blake2256) =>
+  (upstreamProvider: JsonRpcProvider): JsonRpcProvider => {
+    const upstream = createUpstream(withNumericIds(upstreamProvider), hasher)
+    return (onMessage) => {
+      const jsonRpc = (
+        input:
+          | ({ id: string } & (
+              | { result: any }
+              | { error: { code: number; message: string } }
+            ))
+          | {
+              method: string
+              params: { subscription: string; result: any }
+            },
+      ) =>
+        onMessage(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            ...input,
+          }),
+        )
+
+      const reply = (id: string, result: any) => {
+        jsonRpc({ id, result })
+      }
+      const err = (id: string, code: number, message: string) => {
+        jsonRpc({ id, error: { code, message } })
+      }
+      const notification = (
+        method: string,
+        subscription: string,
+        result: any,
+      ) => {
+        jsonRpc({ method, params: { subscription, result } })
+      }
+
+      const groups = {
+        chainSpec: createChainSpec(upstream, reply, err),
+        chainHead: createChainHead(upstream, reply, err, notification),
+        archive: createArchive(upstream, reply, err, notification),
+        transaction: createTransactionFns(upstream, reply, err),
+      }
+      return {
+        send: (msg) => {
+          let parsedMsg: any = null
+          try {
+            parsedMsg = JSON.parse(msg)
+          } catch {}
+          if (!parsedMsg) return
+          const { id, method, params } = parsedMsg
+          if (
+            (id !== null && typeof id !== "string" && typeof id !== "number") ||
+            typeof method !== "string"
+          ) {
+            return
+          }
+          if (method === "rpc_methods") {
+            return upstream.methods.subscribe(
+              ({ methods }) => {
+                reply(id, {
+                  methods: [
+                    ...supportedMethods,
+                    ...methods.filter(
+                      (method) => !supportedMethods.includes(method as any),
+                    ),
+                  ],
+                })
+              },
+              (e: any) => {
+                console.error(e)
+                err(id, -32602, "Invalid")
+              },
+            )
+          }
+
+          const [groupName] = method.split("_")
+          if (groupName in groups) {
+            try {
+              return groups[groupName as keyof typeof groups](
+                id,
+                method,
+                params,
+              )
+            } catch (e) {
+              if (e !== null) throw e
+            }
+          }
+
+          upstream.request(
+            method,
+            params,
+            (value) => {
+              reply(id, value)
+            },
+            (e) => {
+              err(id, e?.code || -1, e?.message || "")
+            },
+          )
+        },
+        disconnect: () => {
+          upstream.disconnect()
+        },
+      }
+    }
+  }

--- a/packages/json-rpc/legacy-provider/src/downstream/index.ts
+++ b/packages/json-rpc/legacy-provider/src/downstream/index.ts
@@ -1,0 +1,1 @@
+export * from "./downstream"

--- a/packages/json-rpc/legacy-provider/src/downstream/storage.ts
+++ b/packages/json-rpc/legacy-provider/src/downstream/storage.ts
@@ -1,0 +1,91 @@
+import { createUpstream } from "@/upstream/upstream"
+import { filter, map, merge } from "rxjs"
+
+const validStorageTypes = new Set([
+  "value",
+  "hash",
+  "closestDescendantMerkleValue",
+  "descendantsValues",
+  "descendantsHashes",
+])
+
+export type Items = Array<{
+  key: string
+  type:
+    | "value"
+    | "hash"
+    | "closestDescendantMerkleValue"
+    | "descendantsValues"
+    | "descendantsHashes"
+}>
+
+export const areItemsValid = (items: any): items is Items =>
+  Array.isArray(items) &&
+  items.every(
+    (x) =>
+      typeof x === "object" &&
+      typeof x.key === "string" &&
+      validStorageTypes.has(x.type),
+  )
+
+export const getStg$ = (
+  upstream: ReturnType<typeof createUpstream>,
+  at: string,
+  items: Array<{
+    key: string
+    type:
+      | "value"
+      | "hash"
+      | "descendantsValues"
+      | "descendantsHashes"
+      | "closestDescendantMerkleValue"
+  }>,
+) =>
+  merge(
+    ...items.map(({ key, type }) => {
+      switch (type) {
+        case "value":
+          return upstream.stgValue(at, key).pipe(
+            filter(Boolean),
+            map((value) => [
+              {
+                key,
+                value,
+              },
+            ]),
+          )
+        case "hash":
+          return upstream.stgHash(at, key).pipe(
+            filter(Boolean),
+            map((hash) => [
+              {
+                key,
+                hash,
+              },
+            ]),
+          )
+        case "descendantsValues":
+          return upstream
+            .stgDescendantValues(at, key)
+            .pipe(
+              map((values) => values.map(([key, value]) => ({ key, value }))),
+            )
+
+        case "descendantsHashes":
+          return upstream
+            .stgDescendantHashes(at, key)
+            .pipe(map((values) => values.map(([key, hash]) => ({ key, hash }))))
+
+        case "closestDescendantMerkleValue":
+          return upstream.stgClosestDescendant(at, key).pipe(
+            filter(Boolean),
+            map((closestDescendantMerkleValue) => [
+              {
+                key,
+                closestDescendantMerkleValue,
+              },
+            ]),
+          )
+      }
+    }),
+  )

--- a/packages/json-rpc/legacy-provider/src/downstream/transaction.ts
+++ b/packages/json-rpc/legacy-provider/src/downstream/transaction.ts
@@ -1,0 +1,30 @@
+import { createUpstream } from "@/upstream/upstream"
+
+export const transactionMethods = Object.fromEntries(
+  ["broadcast", "stop"].map((key) => [key, `transaction_v1_${key}`] as const),
+)
+
+export const createTransactionFns = (
+  upstream: ReturnType<typeof createUpstream>,
+  reply: (id: string, result: any) => void,
+  err: (id: string, code: number, msg: string) => void,
+) => {
+  return (rId: string, method: string, args: any[]) => {
+    if (method === transactionMethods.stop) {
+      reply(rId, null)
+    } else if (method === transactionMethods.broadcast) {
+      upstream.request(
+        "author_submitExtrinsic",
+        args,
+        (opId) => {
+          reply(rId, opId)
+        },
+        () => {
+          err(rId, -32602, "Invalid")
+        },
+      )
+    } else {
+      throw null
+    }
+  }
+}

--- a/packages/json-rpc/legacy-provider/src/downstream/transaction.ts
+++ b/packages/json-rpc/legacy-provider/src/downstream/transaction.ts
@@ -1,4 +1,13 @@
 import { createUpstream } from "@/upstream/upstream"
+import { createOpaqueToken } from "@/utils/create-opaque-token"
+import {
+  catchError,
+  concat,
+  ignoreElements,
+  Subscription,
+  takeUntil,
+  timer,
+} from "rxjs"
 
 export const transactionMethods = Object.fromEntries(
   ["broadcast", "stop"].map((key) => [key, `transaction_v1_${key}`] as const),
@@ -7,22 +16,36 @@ export const transactionMethods = Object.fromEntries(
 export const createTransactionFns = (
   upstream: ReturnType<typeof createUpstream>,
   reply: (id: string, result: any) => void,
-  err: (id: string, code: number, msg: string) => void,
 ) => {
   return (rId: string, method: string, args: any[]) => {
+    const ongoing = new Map<string, Subscription>()
     if (method === transactionMethods.stop) {
+      const [token] = args
+      const sub = ongoing.get(token)
+      sub?.unsubscribe()
+      ongoing.delete(token)
       reply(rId, null)
     } else if (method === transactionMethods.broadcast) {
-      upstream.request(
-        "author_submitExtrinsic",
-        args,
-        (opId) => {
-          reply(rId, opId)
-        },
-        () => {
-          err(rId, -32602, "Invalid")
-        },
+      const token = createOpaqueToken()
+      ongoing.set(
+        token,
+        upstream
+          .obsRequest("author_submitExtrinsic", args)
+          .pipe(
+            catchError((_, source) => concat(timer(5_000), source)),
+            takeUntil(
+              upstream.getBlocks.finalized$.pipe(
+                ignoreElements(),
+                catchError(() => {
+                  ongoing.delete(token)
+                  return [null]
+                }),
+              ),
+            ),
+          )
+          .subscribe(),
       )
+      reply(rId, token)
     } else {
       throw null
     }

--- a/packages/json-rpc/legacy-provider/src/index.ts
+++ b/packages/json-rpc/legacy-provider/src/index.ts
@@ -1,0 +1,3 @@
+import { createDownstream } from "./downstream/downstream"
+
+export const withLegacy = createDownstream

--- a/packages/json-rpc/legacy-provider/src/types.ts
+++ b/packages/json-rpc/legacy-provider/src/types.ts
@@ -1,0 +1,49 @@
+export interface ShittyHeader {
+  parentHash: string
+  number: string
+  stateRoot: string
+  extrinsicsRoot: string
+  digest: {
+    logs: Array<string>
+  }
+}
+
+export interface DecentHeader {
+  parent: string
+  hash: string
+  number: number
+  hasUpgrade: boolean
+  header: string
+}
+
+export interface Runtime {
+  specName: string
+  implName: string
+  specVersion: number
+  implVersion: number
+  transactionVersion: number
+  apis: Record<string, number>
+}
+
+export type NewBlockEvent = {
+  event: "newBlock"
+  blockHash: string
+  parentBlockHash: string
+  newRuntime: Runtime | null
+}
+
+export interface InitializedEvent {
+  event: "initialized"
+  finalizedBlockHashes: string[]
+}
+
+export interface FinalizedIevent {
+  event: "finalized"
+  finalizedBlockHashes: Array<string>
+  prunedBlockHashes: Array<string>
+}
+
+export interface BestBlockChangedEvent {
+  event: "bestBlockChanged"
+  bestBlockHash: string
+}

--- a/packages/json-rpc/legacy-provider/src/upstream/blocks/blocks.ts
+++ b/packages/json-rpc/legacy-provider/src/upstream/blocks/blocks.ts
@@ -1,0 +1,248 @@
+import {
+  BestBlockChangedEvent,
+  DecentHeader,
+  InitializedEvent,
+  NewBlockEvent,
+} from "@/types"
+import { UpstreamEvents } from "./upstream-events"
+import {
+  concat,
+  EMPTY,
+  map,
+  merge,
+  mergeMap,
+  Observable,
+  share,
+  shareReplay,
+  tap,
+  withLatestFrom,
+} from "rxjs"
+
+export const getBlocks = ({
+  initial$,
+  allHeads$,
+  finalized$: finHeader$,
+}: UpstreamEvents) => {
+  const finalized$ = finHeader$.pipe(map((x) => x.hash))
+  const blocks = new Map<
+    string,
+    DecentHeader & {
+      children: Set<string>
+      usages: Set<string>
+    }
+  >()
+  let prevFin = ""
+  let finalized = ""
+  let best = ""
+  let activeSubscriptions = new Set<string>()
+
+  const getTree = (root: string, result: string[] = []): string[] => {
+    result.push(root)
+    blocks.get(root)!.children.forEach((c) => {
+      getTree(c, result)
+    })
+    return result
+  }
+
+  const getFinalizedEvent = (): {
+    event: "finalized"
+    prunedBlockHashes: string[]
+    finalizedBlockHashes: string[]
+  } => {
+    const prunedBlockHashes: string[] = []
+    const finalizedBlockHashes: string[] = []
+
+    let current = blocks.get(finalized)!
+    let prev = blocks.get(current.parent)
+    while (prev) {
+      finalizedBlockHashes.push(current.hash)
+      prev.children.forEach((c) => {
+        if (c !== current.hash) getTree(c, prunedBlockHashes)
+      })
+      current = prev
+      if (current.hash === prevFin) break
+      prev = blocks.get(current.parent)
+    }
+    finalizedBlockHashes.reverse()
+
+    return { event: "finalized", prunedBlockHashes, finalizedBlockHashes }
+  }
+
+  const setBestFromFinalized = () => {
+    best = finalized
+    let bestHeight = 0
+    getTree(finalized)
+      .map((x) => blocks.get(x)!)
+      .forEach((x) => {
+        if (x.number > bestHeight) {
+          bestHeight = x.number
+          best = x.hash
+        }
+      })
+  }
+
+  const addBlock = (block: DecentHeader) => {
+    const { hash, parent } = block
+    const me = {
+      ...block,
+      children: new Set<string>(),
+      usages: new Set<string>(),
+    }
+    blocks.set(hash, me)
+    blocks.get(parent)?.children.add(hash)
+    return me
+  }
+
+  const ready$ = initial$.pipe(
+    withLatestFrom(finalized$),
+    map(([initial, fin]) => {
+      initial.forEach(addBlock)
+      finalized = fin
+      setBestFromFinalized()
+      return null
+    }),
+    shareReplay(1),
+  )
+
+  const getNewBlockEvent = (blockHash: string) => {
+    const block = blocks.get(blockHash)!
+    activeSubscriptions.forEach((subId) => {
+      block.usages.add(subId)
+    })
+    return {
+      event: "newBlock" as const,
+      blockHash,
+      parentBlockHash: block.parent,
+      newRuntime: block.hasUpgrade
+        ? ({} as {
+            specName: string
+            implName: string
+            specVersion: number
+            implVersion: number
+            transactionVersion: number
+            apis: Record<string, number>
+          })
+        : null,
+    }
+  }
+
+  const tryRemove = (blockHash: string, up?: boolean) => {
+    const block = blocks.get(blockHash)
+    if (!block || block.usages.size > 0) return
+
+    const { parent, children } = block
+    if (up !== true) children.forEach((c) => tryRemove(c, false))
+    if (up !== false) tryRemove(parent, true)
+    if (!blocks.has(parent) || !block.children.size) {
+      blocks.get(parent)?.children.delete(blockHash)
+      blocks.delete(blockHash)
+    }
+  }
+
+  const updates$ = merge(
+    allHeads$.pipe(map((value) => ({ type: "new" as const, value }))),
+    finalized$.pipe(map((value) => ({ type: "fin" as const, value }))),
+  ).pipe(
+    mergeMap((x) => {
+      if (finalized === "") return EMPTY
+      if (x.type === "new") {
+        const block = x.value
+        const { hash } = block
+        addBlock(block)
+        const result: Array<
+          | ReturnType<typeof getNewBlockEvent>
+          | { event: "bestBlockChanged"; bestBlockHash: string }
+        > = [getNewBlockEvent(hash)]
+        if (block.number > blocks.get(best)!.number) {
+          best = hash
+          result.push({ event: "bestBlockChanged", bestBlockHash: hash })
+        }
+        return result
+      }
+
+      prevFin = finalized
+      finalized = x.value
+      let prevBest = best
+      setBestFromFinalized()
+      const result: Array<
+        | ReturnType<typeof getFinalizedEvent>
+        | { event: "bestBlockChanged"; bestBlockHash: string }
+      > = [getFinalizedEvent()]
+
+      if (prevBest !== best)
+        result.unshift({ event: "bestBlockChanged", bestBlockHash: best })
+      return result
+    }),
+    share(),
+  )
+
+  const subscription = merge(ready$, updates$).subscribe()
+
+  const result = (subId: string) => {
+    const getInitialized = () => {
+      const finalizedBlockHashes: string[] = []
+      let current = blocks.get(finalized)
+      while (current && finalizedBlockHashes.length < 10) {
+        finalizedBlockHashes.push(current.hash)
+        current.usages.add(subId)
+        current = blocks.get(current.parent)
+      }
+      finalizedBlockHashes.reverse()
+
+      return {
+        event: "initialized" as const,
+        finalizedBlockHashes,
+      }
+    }
+
+    const unpin = (blockHash: string) => {
+      const block = blocks.get(blockHash)
+      if (block) {
+        block.usages.delete(subId)
+        tryRemove(blockHash)
+      }
+    }
+
+    const initialEvents$: Observable<
+      InitializedEvent | NewBlockEvent | BestBlockChangedEvent
+    > = ready$.pipe(
+      mergeMap(() => {
+        const others: Array<NewBlockEvent | BestBlockChangedEvent> = getTree(
+          finalized,
+        )
+          .slice(1)
+          .map(getNewBlockEvent)
+        if (others.length)
+          others.push({
+            event: "bestBlockChanged" as const,
+            bestBlockHash: best,
+          })
+        return [getInitialized(), ...others]
+      }),
+    )
+
+    return {
+      blocks$: concat(initialEvents$, updates$).pipe(
+        tap({
+          subscribe: () => {
+            activeSubscriptions.add(subId)
+          },
+          finalize: () => {
+            activeSubscriptions.delete(subId)
+          },
+        }),
+        share(),
+      ),
+      getHeader: (blockHash: string) => blocks.get(blockHash)?.header ?? null,
+      isPinned: (blockHash: string) =>
+        !!blocks.get(blockHash)?.usages.has(subId),
+      unpin,
+    }
+  }
+
+  result.stop = () => {
+    subscription.unsubscribe()
+  }
+  result.finalized$ = finHeader$
+  return result
+}

--- a/packages/json-rpc/legacy-provider/src/upstream/blocks/index.ts
+++ b/packages/json-rpc/legacy-provider/src/upstream/blocks/index.ts
@@ -1,0 +1,11 @@
+import type { ClientRequest } from "@polkadot-api/raw-client"
+import { getBlocks } from "./blocks"
+import { getUpstreamEvents } from "./upstream-events"
+import { Observable } from "rxjs"
+import { DecentHeader, ShittyHeader } from "@/types"
+
+export const getBlocks$ = (
+  request: ClientRequest<any, any>,
+  getHeader: (hash: string) => Observable<DecentHeader>,
+  fromShittyHeader: (header: ShittyHeader) => DecentHeader,
+) => getBlocks(getUpstreamEvents(request, getHeader, fromShittyHeader))

--- a/packages/json-rpc/legacy-provider/src/upstream/blocks/upstream-events.ts
+++ b/packages/json-rpc/legacy-provider/src/upstream/blocks/upstream-events.ts
@@ -1,0 +1,100 @@
+import { DecentHeader, ShittyHeader } from "@/types"
+import { ClientRequest } from "@polkadot-api/raw-client"
+import { noop } from "@polkadot-api/utils"
+import {
+  combineLatest,
+  concat,
+  map,
+  mergeMap,
+  Observable,
+  of,
+  share,
+  shareReplay,
+  take,
+  takeUntil,
+  toArray,
+} from "rxjs"
+
+export const getUpstreamEvents = (
+  request: ClientRequest<any, any>,
+  getHeader: (hash: string) => Observable<DecentHeader>,
+  fromShittyHeader: (header: ShittyHeader) => DecentHeader,
+) => {
+  const getHeaders$ = (
+    startMethod: string,
+    stopMethod: string,
+  ): Observable<DecentHeader> =>
+    new Observable<ShittyHeader>((observer) => {
+      const onError = (e: any) => {
+        observer.error(e)
+      }
+
+      let stop: (() => void) | null = null
+      ;(request as ClientRequest<string, ShittyHeader>)(startMethod, [], {
+        onSuccess: (subId, followSub) => {
+          const done = followSub(subId, {
+            next: (v) => {
+              observer.next(v)
+            },
+            error: onError,
+          })
+          const unsubscribe = () => {
+            done()
+            request(stopMethod, [subId])
+          }
+          if (stop !== null) unsubscribe()
+          else stop = unsubscribe
+        },
+        onError,
+      })
+
+      return () => {
+        stop?.()
+        stop = noop
+      }
+    }).pipe(map(fromShittyHeader))
+
+  const allHeads$ = getHeaders$(
+    "chain_subscribeAllHeads",
+    "chain_unsubscribeAllHeads",
+  ).pipe(share())
+
+  const finalized$ = getHeaders$(
+    "chain_subscribeFinalizedHeads",
+    "chain_unsubscribeFinalizedHeads",
+  ).pipe(shareReplay(1))
+
+  const getRecurseiveHeader = (hash: string): Observable<DecentHeader> =>
+    getHeader(hash).pipe(
+      mergeMap((header) =>
+        concat(of(header), getRecurseiveHeader(header.parent)),
+      ),
+    )
+
+  const gap$: Observable<DecentHeader[]> = combineLatest(
+    allHeads$.pipe(take(1)),
+    finalized$.pipe(take(1)),
+  ).pipe(
+    mergeMap(([latest, fin]) => {
+      const nMissing = latest.number - fin.number - 1
+      return concat(
+        getRecurseiveHeader(latest.parent).pipe(take(Math.max(0, nMissing))),
+        of(fin),
+      )
+    }),
+    toArray(),
+    share(),
+  )
+  const collected$ = allHeads$.pipe(takeUntil(gap$), toArray())
+  const initial$ = combineLatest([collected$, gap$]).pipe(
+    map(([collected, gap]) => [...gap.reverse(), ...collected]),
+  )
+
+  return {
+    initial$,
+    allHeads$,
+    finalized$,
+  }
+}
+
+export type UpstreamEvents = ReturnType<typeof getUpstreamEvents>

--- a/packages/json-rpc/legacy-provider/src/upstream/blocks/upstream-events.ts
+++ b/packages/json-rpc/legacy-provider/src/upstream/blocks/upstream-events.ts
@@ -64,21 +64,21 @@ export const getUpstreamEvents = (
     "chain_unsubscribeFinalizedHeads",
   ).pipe(shareReplay(1))
 
-  const getRecurseiveHeader = (hash: string): Observable<DecentHeader> =>
+  const getRecursiveHeader = (hash: string): Observable<DecentHeader> =>
     getHeader(hash).pipe(
       mergeMap((header) =>
-        concat(of(header), getRecurseiveHeader(header.parent)),
+        concat(of(header), getRecursiveHeader(header.parent)),
       ),
     )
 
-  const gap$: Observable<DecentHeader[]> = combineLatest(
+  const gap$: Observable<DecentHeader[]> = combineLatest([
     allHeads$.pipe(take(1)),
     finalized$.pipe(take(1)),
-  ).pipe(
+  ]).pipe(
     mergeMap(([latest, fin]) => {
       const nMissing = latest.number - fin.number - 1
       return concat(
-        getRecurseiveHeader(latest.parent).pipe(take(Math.max(0, nMissing))),
+        getRecursiveHeader(latest.parent).pipe(take(Math.max(0, nMissing))),
         of(fin),
       )
     }),

--- a/packages/json-rpc/legacy-provider/src/upstream/descendant-values.ts
+++ b/packages/json-rpc/legacy-provider/src/upstream/descendant-values.ts
@@ -1,0 +1,65 @@
+export const createDescendantValues = (
+  request: <Args extends Array<any>, Payload>(
+    method: string,
+    params: Args,
+    onSuccess: (value: Payload) => void,
+    onError: (e: any) => void,
+  ) => () => void,
+) => {
+  return (
+    rootKey: string,
+    at: string,
+    onValues: (input: Array<[string, string]>) => void,
+    onError: (e: any) => void,
+    onDone: () => void,
+  ): (() => void) => {
+    let isRunning = true
+    let areAllKeysDone = false
+    let onGoingValues = 0
+
+    const _onError = (e: any) => {
+      if (isRunning) {
+        isRunning = false
+        onError(e)
+      }
+    }
+
+    const PAGE_SIZE = 1000
+    const pullKeys = (startAtKey?: string) => {
+      request<[string, number, string | undefined, string], string[]>(
+        "state_getKeysPaged",
+        [rootKey, PAGE_SIZE, startAtKey || undefined, at],
+        (result) => {
+          if (!isRunning) return
+          if (result.length > 0) {
+            onGoingValues++
+            request<
+              [string[], string],
+              [{ block: string; changes: Array<[string, string]> }]
+            >(
+              "state_queryStorageAt",
+              [result, at],
+              ([{ changes }]) => {
+                if (!isRunning) return
+                onGoingValues--
+                onValues(changes)
+                if (areAllKeysDone && !onGoingValues) onDone()
+              },
+              _onError,
+            )
+          }
+          if (result.length < PAGE_SIZE) {
+            areAllKeysDone = true
+            if (!onGoingValues) onDone()
+          } else pullKeys(result.at(-1))
+        },
+        _onError,
+      )
+    }
+    pullKeys()
+
+    return () => {
+      isRunning = false
+    }
+  }
+}

--- a/packages/json-rpc/legacy-provider/src/upstream/index.ts
+++ b/packages/json-rpc/legacy-provider/src/upstream/index.ts
@@ -1,0 +1,1 @@
+export * from "./upstream"

--- a/packages/json-rpc/legacy-provider/src/upstream/upstream.ts
+++ b/packages/json-rpc/legacy-provider/src/upstream/upstream.ts
@@ -124,5 +124,6 @@ export const createUpstream = (
     disconnect,
     methods,
     request: simpleRequest,
+    obsRequest,
   }
 }

--- a/packages/json-rpc/legacy-provider/src/upstream/upstream.ts
+++ b/packages/json-rpc/legacy-provider/src/upstream/upstream.ts
@@ -1,0 +1,128 @@
+import type { JsonRpcProvider } from "@polkadot-api/json-rpc-provider"
+import { createClient } from "@polkadot-api/raw-client"
+import { getBlocks$ } from "./blocks"
+import { createDescendantValues } from "./descendant-values"
+import { map, Observable } from "rxjs"
+import { fromHex, toHex } from "@polkadot-api/utils"
+import { ShittyHeader } from "@/types"
+import { getFromShittyHeader } from "@/utils/fromShittyHeader"
+
+export const createUpstream = (
+  provider: JsonRpcProvider,
+  hasher: (input: Uint8Array) => Uint8Array,
+) => {
+  const fromShittyHeader = getFromShittyHeader(hasher)
+  const { request, disconnect } = createClient(provider)
+
+  const simpleRequest = <Args extends Array<any>, Payload>(
+    method: string,
+    params: Args,
+    onSuccess: (value: Payload) => void,
+    onError: (e: any) => void,
+  ): (() => void) => request(method, params, { onSuccess, onError })
+
+  const obsRequest = <Args extends Array<any>, Payload>(
+    method: string,
+    params: Args,
+  ): Observable<Payload> =>
+    new Observable((observer) =>
+      simpleRequest<Args, Payload>(
+        method,
+        params,
+        (v) => {
+          observer.next(v)
+          observer.complete()
+        },
+        (e) => {
+          observer.error(e)
+        },
+      ),
+    )
+
+  const getHeader = (hash: string) =>
+    obsRequest<[string], ShittyHeader>("chain_getHeader", [hash]).pipe(
+      map(fromShittyHeader),
+    )
+
+  const getBlocks = getBlocks$(request, getHeader, fromShittyHeader)
+
+  const runtimeCall = (atBlock: string, method: string, data: string) =>
+    obsRequest<[string, string, string], string | null>("state_call", [
+      method,
+      data,
+      atBlock,
+    ])
+
+  const innerStgDescendantVals = createDescendantValues(simpleRequest)
+  const stgDescendantValues = (at: string, rootKey: string) =>
+    new Observable<Array<[string, string]>>((observer) =>
+      innerStgDescendantVals(
+        rootKey,
+        at,
+        (values) => {
+          observer.next(values)
+        },
+        (e) => {
+          observer.error(e)
+        },
+        () => {
+          observer.complete()
+        },
+      ),
+    )
+
+  const stgDescendantHashes = (at: string, rootKey: string) =>
+    stgDescendantValues(at, rootKey).pipe(
+      map((results) =>
+        results.map(
+          ([key, value]) =>
+            [key, toHex(hasher(fromHex(value)))] as [string, string],
+        ),
+      ),
+    )
+
+  const stgClosestDescendant = (_: string, __: string) =>
+    new Observable<string | null>((observer) =>
+      observer.error("not implemented"),
+    )
+
+  const [stgValue, stgHash] = ["state_getStorage", "state_getStorageHash"].map(
+    (method) => (atBlock: string, key: string) =>
+      obsRequest<[string, string | undefined], string | null>(method, [
+        key,
+        atBlock,
+      ]),
+  )
+
+  const methods = obsRequest<[], { methods: string[] }>("rpc_methods", [])
+  const chainName = obsRequest<[], string>("system_name", [])
+  const properties = obsRequest<[], {}>("system_properties", [])
+  const getBody = (at: string) =>
+    obsRequest<[string], { block: { extrinsics: Array<string> } }>(
+      "chain_getBlock",
+      [at],
+    )
+
+  const getBlockHash$ = (height: number) =>
+    obsRequest<[height: number], string>("chain_getBlockHash", [height])
+  const genesisHash = getBlockHash$(0)
+
+  return {
+    getBlocks,
+    getHeader,
+    getBlockHash$,
+    stgValue,
+    stgHash,
+    stgDescendantValues,
+    stgDescendantHashes,
+    stgClosestDescendant,
+    runtimeCall,
+    getBody,
+    chainName,
+    properties,
+    genesisHash,
+    disconnect,
+    methods,
+    request: simpleRequest,
+  }
+}

--- a/packages/json-rpc/legacy-provider/src/utils/create-opaque-token.ts
+++ b/packages/json-rpc/legacy-provider/src/utils/create-opaque-token.ts
@@ -1,0 +1,5 @@
+let latestId = 1
+export const createOpaqueToken = (): string => {
+  // TODO: make this fancier
+  return `${latestId++}${Date.now()}`
+}

--- a/packages/json-rpc/legacy-provider/src/utils/fromShittyHeader.ts
+++ b/packages/json-rpc/legacy-provider/src/utils/fromShittyHeader.ts
@@ -1,0 +1,33 @@
+import { ShittyHeader } from "@/types"
+import { compact } from "@polkadot-api/substrate-bindings"
+import { fromHex, mergeUint8, toHex } from "@polkadot-api/utils"
+
+export const getFromShittyHeader =
+  (hasher: (input: Uint8Array) => Uint8Array) =>
+  ({
+    parentHash,
+    number: rawNumber,
+    stateRoot,
+    extrinsicsRoot,
+    digest,
+  }: ShittyHeader) => {
+    const number = Number(rawNumber)
+    const rawDigests = digest.logs.map(fromHex)
+
+    const rawHeader = mergeUint8([
+      fromHex(parentHash),
+      compact.enc(number),
+      fromHex(stateRoot),
+      fromHex(extrinsicsRoot),
+      compact.enc(digest.logs.length),
+      ...rawDigests,
+    ])
+
+    return {
+      parent: parentHash,
+      hash: toHex(hasher(rawHeader)),
+      number,
+      hasUpgrade: rawDigests.some(([x]) => x === 8),
+      header: toHex(rawHeader),
+    }
+  }

--- a/packages/json-rpc/legacy-provider/src/with-numeric.ts
+++ b/packages/json-rpc/legacy-provider/src/with-numeric.ts
@@ -1,0 +1,32 @@
+import type { JsonRpcProvider } from "@polkadot-api/json-rpc-provider"
+
+export const withNumericIds =
+  (base: JsonRpcProvider): JsonRpcProvider =>
+  (onMsg) => {
+    let nextId = 0
+    const numberToOriginal = new Map<number, string>()
+
+    const { send: originalSend, disconnect } = base((msg: string) => {
+      const { id, ...rest } = JSON.parse(msg)
+      let actualMsg = msg
+      if (numberToOriginal.has(id)) {
+        actualMsg = JSON.stringify({ ...rest, id: numberToOriginal.get(id) })
+        numberToOriginal.delete(id)
+      }
+      onMsg(actualMsg)
+    })
+
+    return {
+      send: (msg) => {
+        const parsedMsg = JSON.parse(msg)
+        let actualMsg = msg
+        if ("id" in parsedMsg) {
+          const id = nextId++
+          numberToOriginal.set(id, parsedMsg.id)
+          actualMsg = JSON.stringify({ ...parsedMsg, id })
+        }
+        originalSend(actualMsg)
+      },
+      disconnect,
+    }
+  }

--- a/packages/json-rpc/legacy-provider/tsconfig.json
+++ b/packages/json-rpc/legacy-provider/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base",
+  "include": ["src", "tests"],
+  "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["*"]
+    }
+  }
+}

--- a/packages/json-rpc/ws-provider/CHANGELOG.md
+++ b/packages/json-rpc/ws-provider/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- `innerEnhancer` option: allows to provide an enhancer that will be applied at the lowest possible level, before any of the internal enhancers of the ws-provider are applied.
+
 ## 0.4.1 - 2025-07-16
 
 ### Fixed

--- a/packages/json-rpc/ws-provider/src/types.ts
+++ b/packages/json-rpc/ws-provider/src/types.ts
@@ -35,6 +35,7 @@ export interface WsProviderConfig {
   endpoints: Array<string | { uri: string; protocol: string[] }>
   onStatusChanged?: (status: StatusChange) => void
   timeout?: number
+  innerEnhancer?: (input: JsonRpcProvider) => JsonRpcProvider
 }
 
 export interface GetWsProviderInput {

--- a/packages/substrate-client/CHANGELOG.md
+++ b/packages/substrate-client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Avoid runtime error when the reply to `transaction_v1_broadcast` comes synchronously.
+
 ## 0.4.2 - 2025-08-07
 
 ### Fixed

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,6 +247,9 @@ importers:
       '@polkadot-api/descriptors':
         specifier: file:.papi/descriptors
         version: file:integration-tests/zombie-tests/.papi/descriptors(polkadot-api@packages+client)
+      '@polkadot-api/legacy-provider':
+        specifier: workspace:*
+        version: link:../../packages/json-rpc/legacy-provider
       '@polkadot-api/substrate-bindings':
         specifier: workspace:*
         version: link:../../packages/substrate-bindings
@@ -506,6 +509,25 @@ importers:
       '@polkadot-api/json-rpc-provider':
         specifier: workspace:*
         version: link:../json-rpc-provider
+
+  packages/json-rpc/legacy-provider:
+    dependencies:
+      '@polkadot-api/json-rpc-provider':
+        specifier: workspace:*
+        version: link:../json-rpc-provider
+      '@polkadot-api/raw-client':
+        specifier: workspace:*
+        version: link:../../raw-client
+      '@polkadot-api/substrate-bindings':
+        specifier: workspace:*
+        version: link:../../substrate-bindings
+      '@polkadot-api/utils':
+        specifier: workspace:*
+        version: link:../../utils
+    devDependencies:
+      rxjs:
+        specifier: ^7.8.2
+        version: 7.8.2
 
   packages/json-rpc/logs-provider:
     dependencies:


### PR DESCRIPTION
## Support for Legacy RPCs via Enhancer

As you know, the PAPI client was intentionally built to support only the [new JSON-RPC specification](https://github.com/paritytech/json-rpc-interface-spec), which is vastly superior to the legacy RPC APIs.

However, despite the clear advantages of the new spec, particularly its design for better load-balancing and proxy support, node operators still lack a robust reverse-proxy solution (e.g., [Subway](https://forum.polkadot.network/t/subway-the-missing-substrate-json-rpc-gateway/2038)) that supports the new APIs properly. Ironically, while the new design was meant to simplify integration, this lack of proxy infrastructure has become a major barrier to adoption. We're actively working on addressing this gap BTW.

In parallel, a number of parachains (e.g., Interlay) have yet to upgrade their nodes to support the new spec. We’ve attempted to raise awareness around this issue ([see here](https://forum.polkadot.network/t/new-json-rpc-api-q4-2024-update/10541)), but adoption has been slower than hoped.

Given that the [`JsonRpcProvider` interface used in PAPI](https://github.com/polkadot-api/polkadot-api/blob/62ce7820f1ef392e692d03d4f3f1555f8ab32951/packages/json-rpc/json-rpc-provider/src/index.ts) is intentionally lean and decoupled from core internals, it is entirely feasible to build a compatibility layer: a proxy that *exposes the new JSON-RPC interface while internally relying on the legacy RPCs*.

Although we’ve long known this was technically possible, we previously avoided implementing it for fear of prolonging the life of the legacy RPCs. However, we now believe this was short-sighted. A compatibility layer is critical for a smooth transition period and broader adoption of the new spec. (I plan to write more about this decision in an upcoming blog post.)

---

## What this PR adds

This PR introduces a new `legacy-provider` enhancer that acts as a transparent compatibility layer. It exposes the new JSON-RPC endpoints while internally translating calls to the legacy RPC APIs.

**Important architectural note:**
All PAPI providers assume that they are interacting with the new JSON-RPC spec. For this reason, `legacy-provider-enhancer` must be applied *before* any other enhancer. To make this possible, the `ws-provider` now supports a new `innerEnhancer` option, which allows enhancers to be applied at the lowest possible level.

It's important to emphasize that the **Polkadot API client itself remains unchanged**: it continues to **only** support the new JSON-RPC interface.

---

## Limitations

There are currently two limitations with the `legacy-provider`:

* Storage queries using the `closestDescendantMerkleValue` option are **not yet supported**.
* The [`archive_v1_storageDiff`](https://paritytech.github.io/json-rpc-interface-spec/api/archive_v1_storageDiff.html#archive_v1_storagediff) endpoint is **not supported**, though this is not a concern for PAPI, as it doesn’t use this endpoint.

The first limitation affects the `watchEntries` API, which relies on `closestDescendantMerkleValue`. This means that `watchEntries` will not work when using the `legacy-provider`.