### PR TITLE
fix(legacy-provider): avoid redundant `initialized` event

### DIFF
--- a/packages/json-rpc/legacy-provider/CHANGELOG.md
+++ b/packages/json-rpc/legacy-provider/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.2.2 - 2025-08-17
+
+### Fixed
+
+- Avoid redundant `finalized` event.
+
 ## 0.2.1 - 2025-08-14
 
 ### Fixed

--- a/packages/json-rpc/legacy-provider/package.json
+++ b/packages/json-rpc/legacy-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot-api/legacy-provider",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": "Josep M Sobrepere (https://github.com/josepot)",
   "repository": {
     "type": "git",

--- a/packages/json-rpc/legacy-provider/src/upstream/blocks/blocks.ts
+++ b/packages/json-rpc/legacy-provider/src/upstream/blocks/blocks.ts
@@ -15,6 +15,7 @@ import {
   Observable,
   share,
   shareReplay,
+  skip,
   tap,
   withLatestFrom,
 } from "rxjs"
@@ -142,7 +143,10 @@ export const getBlocks = ({
 
   const updates$ = merge(
     allHeads$.pipe(map((value) => ({ type: "new" as const, value }))),
-    finalized$.pipe(map((value) => ({ type: "fin" as const, value }))),
+    finalized$.pipe(
+      skip(1),
+      map((value) => ({ type: "fin" as const, value })),
+    ),
   ).pipe(
     mergeMap((x) => {
       if (finalized === "") return EMPTY


### PR DESCRIPTION
The `updates$` stream is not supposed to re-emit the latest finalized event.