### PR TITLE
Feat/client improvements

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- `getMetadata$` and `getMetadata` client APIs to facilitate the retrieval of the most modern stable version of the metadata.
+
 ## 1.16.4 - 2025-09-01
 
 ### Fixed

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Added
 
 - `getMetadata$` and `getMetadata` client APIs to facilitate the retrieval of the most modern stable version of the metadata.
+- `BlockInfo` now exposes `hasNewRuntime` property.
+
+### Fixed
+
+- `blocks$` completes when there is no block continuity.
 
 ## 1.16.4 - 2025-09-01
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -358,7 +358,7 @@ export function createClient(
   const getMetadata$ = (at: HexString) =>
     chainHead.getRuntimeContext$(at).pipe(map((ctx) => ctx.metadataRaw))
 
-  return {
+  const result: PolkadotClient = {
     getChainSpecData,
 
     getMetadata$,
@@ -414,4 +414,8 @@ export function createClient(
 
     _request,
   }
+
+  ;(result as any).___INTERNAL_DO_NOT_USE = chainHead
+
+  return result
 }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -355,8 +355,15 @@ export function createClient(
     (runtimeToken ??= createRuntimeToken(chainHead))
   const { broadcastTx$ } = client
 
+  const getMetadata$ = (at: HexString) =>
+    chainHead.getRuntimeContext$(at).pipe(map((ctx) => ctx.metadataRaw))
+
   return {
     getChainSpecData,
+
+    getMetadata$,
+    getMetadata: (atBlock: HexString, signal?: AbortSignal) =>
+      firstValueFromWithSignal(getMetadata$(atBlock), signal),
 
     blocks$: chainHead.newBlocks$,
     hodlBlock: (block: HexString) => chainHead.holdBlock(block, true),

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -204,6 +204,23 @@ export interface PolkadotClient {
   getChainSpecData: () => Promise<ChainSpecData>
 
   /**
+   * Retrieves the most modern stable version of the metadata for a given block.
+   *
+   * @param atBlock  The block-hash of the block.
+   * @returns Observable that emits the most modern stable version of the
+   *          metadata, and immediately completes.
+   */
+  getMetadata$: (atBlock: HexString) => Observable<Uint8Array>
+  /**
+   * Retrieves the most modern stable version of the metadata for a given block.
+   *
+   * @param atBlock  The block-hash of the block.
+   * @returns An abortable Promise that resolves into the most modern
+   *          stable version of the metadata.
+   */
+  getMetadata: (atBlock: HexString, signal?: AbortSignal) => Promise<Uint8Array>
+
+  /**
    * Observable that emits `BlockInfo` for every new finalized block. It's a
    * multicast and stateful observable, that will synchronously replay its
    * latest known state.

--- a/packages/observable-client/CHANGELOG.md
+++ b/packages/observable-client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Remove unnecessary cache
+
 ## 0.13.8 - 2025-09-01
 
 ### Fixed

--- a/packages/observable-client/CHANGELOG.md
+++ b/packages/observable-client/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## Unreleased
 
+### Added
+
+- `BlockInfo` now exposes `hasNewRuntime` property.
+
 ### Fixed
 
 - Remove unnecessary cache
+- `newBlocks$` completes when there is no block continuity.
 
 ## 0.13.8 - 2025-09-01
 

--- a/packages/observable-client/src/chainHead/streams/follow.ts
+++ b/packages/observable-client/src/chainHead/streams/follow.ts
@@ -16,6 +16,7 @@ type EnhancedFollowEventWithRuntime =
       number: number
       parentHash: string
       runtimeChanges: Set<string>
+      hasNewRuntime: boolean
     })
   | NewBlockWithRuntime
   | BestBlockChanged
@@ -96,6 +97,9 @@ const withInitializedNumber = (
                     runtimeChanges: new Set(changes),
                     number: header.number,
                     parentHash: header.parentHash,
+                    hasNewRuntime: header.digests.some(
+                      (d) => d.type === "runtimeUpdated",
+                    ),
                   })
                   pending!.forEach((e) => {
                     observer.next(e)

--- a/packages/observable-client/src/getObservableClient.ts
+++ b/packages/observable-client/src/getObservableClient.ts
@@ -10,7 +10,7 @@ import { Archive$, getArchive } from "./archive"
 const ofNullFn = () => of(null)
 
 export interface ObservableClient {
-  chainHead$: (nSubscribers?: number) => ChainHead$
+  chainHead$: () => ChainHead$
   archive: (
     getRuntime: (codeHash: string) => Observable<RuntimeContext | null>,
   ) => Archive$
@@ -18,65 +18,23 @@ export interface ObservableClient {
   destroy: UnsubscribeFn
 }
 
-const clientCache = new Map<
-  SubstrateClient,
-  { client: ObservableClient; refCount: number }
->()
-
 export const getObservableClient = (
   substrateClient: SubstrateClient,
-  cache: Partial<{
+  {
+    getMetadata,
+    setMetadata,
+  }: Partial<{
     getMetadata: (codeHash: string) => Observable<Uint8Array | null>
     setMetadata: (codeHash: string, rawMetadata: Uint8Array) => void
   }> = {},
-): ObservableClient => {
-  const { getMetadata, setMetadata } = cache
-  const cached = clientCache.get(substrateClient)
-  if (cached) {
-    cached.refCount++
-    return cached.client
-  }
-
-  const destroy = () => {
-    const cached = clientCache.get(substrateClient)
-    if (!cached || cached.refCount <= 1) {
-      clientCache.delete(substrateClient)
-      substrateClient.destroy()
-    } else {
-      cached.refCount--
-    }
-  }
-
-  let cachedChainhead:
-    | readonly [ChainHead$, (nSubscribers: number) => void]
-    | null = null
-  let currentSubscribers = 0
-  let expectedSubscribers: null | number = null
-
-  const client: ObservableClient = {
-    chainHead$: (_expectedSubscribers) => {
-      currentSubscribers++
-      expectedSubscribers ||= _expectedSubscribers || 1
-      cachedChainhead ||= getChainHead$(
-        substrateClient.chainHead,
-        getMetadata || ofNullFn,
-        setMetadata || noop,
-      )
-      const [result, start] = cachedChainhead
-      if (expectedSubscribers === currentSubscribers) {
-        const copiedCurrentSubscribers = currentSubscribers
-        currentSubscribers = 0
-        expectedSubscribers = null
-        cachedChainhead = null
-        start(copiedCurrentSubscribers)
-      }
-      return result
-    },
-    archive: getArchive(substrateClient.archive),
-    broadcastTx$: getBroadcastTx$(substrateClient.transaction),
-    destroy,
-  }
-
-  clientCache.set(substrateClient, { client, refCount: 1 })
-  return client
-}
+): ObservableClient => ({
+  chainHead$: () =>
+    getChainHead$(
+      substrateClient.chainHead,
+      getMetadata || ofNullFn,
+      setMetadata || noop,
+    ),
+  archive: getArchive(substrateClient.archive),
+  broadcastTx$: getBroadcastTx$(substrateClient.transaction),
+  destroy: substrateClient.destroy,
+})

--- a/packages/observable-client/tests/observableClient.spec.ts
+++ b/packages/observable-client/tests/observableClient.spec.ts
@@ -49,6 +49,7 @@ describe("observableClient chainHead", () => {
         hash: initialized.finalizedBlockHashes[0],
         number: header.number,
         parent: header.parentHash,
+        hasNewRuntime: false,
       } satisfies BlockInfo)
       expect(error).not.toHaveBeenCalled()
       expect(complete).not.toHaveBeenCalled()
@@ -78,6 +79,7 @@ describe("observableClient chainHead", () => {
         hash: newBlock.blockHash,
         number: initialNumber + 1,
         parent: newBlock.parentBlockHash,
+        hasNewRuntime: false,
       } satisfies BlockInfo)
       expect(error).not.toHaveBeenCalled()
       expect(complete).not.toHaveBeenCalled()
@@ -109,6 +111,7 @@ describe("observableClient chainHead", () => {
         hash: newBlock.blockHash,
         number: initialNumber + 1,
         parent: newBlock.parentBlockHash,
+        hasNewRuntime: false,
       } satisfies BlockInfo)
       expect(error).not.toHaveBeenCalled()
       expect(complete).not.toHaveBeenCalled()

--- a/packages/substrate-client/CHANGELOG.md
+++ b/packages/substrate-client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Remove unnecessary cache
+
 ## 0.4.4 - 2025-08-11
 
 ### Fixed


### PR DESCRIPTION
Various improvements that we discussed IRL.

There is a commit for each one of them:
- Expose methods on the top client for accessing the best possible metadata version for a given block.
- Remove the hacky caches
- Expose the undocumented, and non-typed property `___INTERNAL_DO_NOT_USE` from the client (useful for dev-tools, debugging and advanced uses)
- Expose the `hasNewRuntime` property on the `BlockInfo` and also make the `blocks$` observable complete when there is no continuity.