### PR TITLE
fix(observable-client): hodlBlock waits until pinned-blocks emit

### DIFF
--- a/packages/observable-client/CHANGELOG.md
+++ b/packages/observable-client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- hodlBlock waits until pinned-blocks emit
+
 ## 0.13.7 - 2025-08-31
 
 ### Fixed


### PR DESCRIPTION
Hold block expected pinned blocks to emit synchronously. This is the case except for the very first time. Take into account this case.