### PR TITLE
ci: housekeeping workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,22 +5,26 @@ on:
   merge_group:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version:
+          - "22"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/cache@v4
         with:
           path: .turbo
           key: ${{ runner.os }}-${{ matrix.node-version }}-turbo-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.node-version }}-turbo-
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,23 +6,30 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version:
+          - "22"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/cache@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-20.x-turbo-${{ github.sha }}
+          key: ${{ runner.os }}-${{ matrix.node-version }}-turbo-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-20.x-turbo-
-      - uses: pnpm/action-setup@v3
-      - name: Setup Node.js 20.x
+            ${{ runner.os }}-${{ matrix.node-version }}-turbo-
+      - uses: pnpm/action-setup@v4
+      - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: ${{ matrix.node-version }}
           cache: pnpm
           registry-url: https://registry.npmjs.org
       - name: Install deps
@@ -42,8 +49,13 @@ jobs:
   publish:
     needs: [build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       matrix:
+        node-version:
+          - "22"
         value:
           [
             cli,
@@ -80,27 +92,27 @@ jobs:
             view-builder,
           ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check if version has been updated
         id: check
-        uses: EndBug/version-check@v2
+        uses: EndBug/version-check@d17247dd94ca7b39d0b0691399be8d7c510622c9
         with:
           diff-search: true
           file-name: ./packages/${{ matrix.value }}/package.json
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         if: steps.check.outputs.changed == 'true'
         with:
           path: .turbo
-          key: ${{ runner.os }}-20.x-turbo-${{ github.sha }}
+          key: ${{ runner.os }}-${{ matrix.node-version }}-turbo-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-20.x-turbo-
-      - uses: pnpm/action-setup@v3
+            ${{ runner.os }}-${{ matrix.node-version }}-turbo-
+      - uses: pnpm/action-setup@v4
         if: steps.check.outputs.changed == 'true'
-      - name: Setup Node.js 20.x
+      - name: Setup Node.js ${{ matrix.node-version }}
         if: steps.check.outputs.changed == 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: ${{ matrix.node-version }}
           cache: pnpm
           registry-url: https://registry.npmjs.org
       - name: Install deps
@@ -116,3 +128,4 @@ jobs:
           pnpm publish --no-git-checks --access=public --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_AUTOMATION_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/zombienet.yml
+++ b/.github/workflows/zombienet.yml
@@ -7,10 +7,15 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:
       matrix:
+        node-version:
+          - "22"
         version:
           - polkadot-v1.1.0
           - polkadot-stable2407-5
@@ -22,19 +27,19 @@ jobs:
           - sm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/cache@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-20.x-turbo-${{ github.sha }}
+          key: ${{ runner.os }}-${{ matrix.node-version }}-turbo-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-20.x-turbo-
-      - uses: pnpm/action-setup@v3
-      - name: Setup Node.js 20
+            ${{ runner.os }}-${{ matrix.node-version }}-turbo-
+      - uses: pnpm/action-setup@v4
+      - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-          cache: "pnpm"
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
       - name: Install deps
         run: pnpm install
       - name: Build core


### PR DESCRIPTION
A bit of workflow housekeeping:
- Add provenance attestation to our npm packages (adding the cool green check in NPM, proving from which commit and which workflow run we published the package) <img width="1084" height="215" alt="image" src="https://github.com/user-attachments/assets/65291943-f815-41b5-814c-44b8d18aef90" />
- Update to current node LTS, and homogenize versioning across different workflows
- Pin workflow permissions to the minimum required
- Pin version-check workflow (the only one external that is not from GitHub) to avoid supply chain attacks.
- Add Dependabot for reusable workflows update (not for PNPM packages, which is super annoying)