### PR TITLE
feat(legacy-provider): infer hasher

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 0.14.13 - 2025-09-05
 
 ### Fixed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,7 +37,6 @@
   },
   "dependencies": {
     "@commander-js/extra-typings": "^14.0.0",
-    "@noble/hashes": "^2.0.0",
     "@polkadot-api/codegen": "workspace:*",
     "@polkadot-api/ink-contracts": "workspace:*",
     "@polkadot-api/json-rpc-provider": "workspace:*",

--- a/packages/json-rpc/legacy-provider/CHANGELOG.md
+++ b/packages/json-rpc/legacy-provider/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- The hasher is now inferred. Therefore, `withLegacy` does not receive any arguments.
+
 ## 0.2.5 - 2025-09-05
 
 ### Fixed

--- a/packages/json-rpc/legacy-provider/src/downstream/archive.ts
+++ b/packages/json-rpc/legacy-provider/src/downstream/archive.ts
@@ -95,7 +95,7 @@ export const createArchive = (
         )
       case archiveMethods.finalizedHeight:
         return obsReply(
-          upstream.getBlocks.finalized$.pipe(
+          upstream.finalized$.pipe(
             map((x) => x.number),
             take(1),
           ),
@@ -105,7 +105,9 @@ export const createArchive = (
       case archiveMethods.hashByHeight:
         return obsReply(upstream.getBlockHash$(firstArg))
       case archiveMethods.header:
-        return obsReply(upstream.getHeader(firstArg).pipe(map((h) => h.header)))
+        return obsReply(
+          upstream.getHeader$(firstArg).pipe(map((h) => h.header)),
+        )
       case archiveMethods.stopStorage: {
         const sub = subscriptions.get(firstArg)
         return sub ? sub() : err(rId, -32602, "Invalid args")

--- a/packages/json-rpc/legacy-provider/src/downstream/downstream.ts
+++ b/packages/json-rpc/legacy-provider/src/downstream/downstream.ts
@@ -4,7 +4,6 @@ import { chainSpecMethods, createChainSpec } from "./chainspec"
 import { chainHeadMethods, createChainHead } from "./chain-head"
 import { createTransactionFns, transactionMethods } from "./transaction"
 import { archiveMethods, createArchive } from "./archive"
-import { Blake2256 } from "@polkadot-api/substrate-bindings"
 import { withNumericIds } from "@/with-numeric"
 
 const supportedMethods = [
@@ -17,9 +16,9 @@ const supportedMethods = [
   .flat()
 
 export const createDownstream =
-  (hasher: (input: Uint8Array) => Uint8Array = Blake2256) =>
+  () =>
   (upstreamProvider: JsonRpcProvider): JsonRpcProvider => {
-    const upstream = createUpstream(withNumericIds(upstreamProvider), hasher)
+    const upstream = createUpstream(withNumericIds(upstreamProvider))
     return (onMessage) => {
       const jsonRpc = (
         input:

--- a/packages/json-rpc/legacy-provider/src/downstream/transaction.ts
+++ b/packages/json-rpc/legacy-provider/src/downstream/transaction.ts
@@ -34,7 +34,7 @@ export const createTransactionFns = (
           .pipe(
             catchError((_, source) => concat(timer(5_000), source)),
             takeUntil(
-              upstream.getBlocks.finalized$.pipe(
+              upstream.finalized$.pipe(
                 ignoreElements(),
                 catchError(() => {
                   ongoing.delete(token)

--- a/packages/json-rpc/legacy-provider/src/upstream/blocks/index.ts
+++ b/packages/json-rpc/legacy-provider/src/upstream/blocks/index.ts
@@ -2,10 +2,11 @@ import type { ClientRequest } from "@polkadot-api/raw-client"
 import { getBlocks } from "./blocks"
 import { getUpstreamEvents } from "./upstream-events"
 import { Observable } from "rxjs"
-import { DecentHeader, ShittyHeader } from "@/types"
 
 export const getBlocks$ = (
   request: ClientRequest<any, any>,
-  getHeader: (hash: string) => Observable<DecentHeader>,
-  fromShittyHeader: (header: ShittyHeader) => DecentHeader,
-) => getBlocks(getUpstreamEvents(request, getHeader, fromShittyHeader))
+  request$: <Args extends Array<any>, Payload>(
+    method: string,
+    params: Args,
+  ) => Observable<Payload>,
+) => getBlocks(getUpstreamEvents(request, request$))

--- a/packages/json-rpc/legacy-provider/src/utils/get-hasher-from-block.ts
+++ b/packages/json-rpc/legacy-provider/src/utils/get-hasher-from-block.ts
@@ -1,0 +1,14 @@
+import { Blake2256, Keccak256 } from "@polkadot-api/substrate-bindings"
+import { getFromShittyHeader } from "./fromShittyHeader"
+import { ShittyHeader } from "@/types"
+
+const hashers = [Blake2256, Keccak256]
+const fns = hashers.map(getFromShittyHeader)
+const noHasher = (_: Uint8Array): Uint8Array => {
+  throw new Error("Hasher not supported")
+}
+
+export const getHasherFromBlock =
+  (shitHeader: ShittyHeader) =>
+  (hash: string): ((data: Uint8Array) => Uint8Array) =>
+    hashers[fns.findIndex((fn) => fn(shitHeader).hash === hash)] || noHasher

--- a/packages/json-rpc/legacy-provider/src/utils/with-latest-from-bp.ts
+++ b/packages/json-rpc/legacy-provider/src/utils/with-latest-from-bp.ts
@@ -1,0 +1,43 @@
+import { Observable } from "rxjs"
+
+export const withLatestFromBp =
+  <T, S>(latest$: Observable<T>) =>
+  (base$: Observable<S>) =>
+    new Observable<[T, S]>((observer) => {
+      let latest: T
+      let prev: S[] | null = []
+
+      const subscription = base$.subscribe({
+        next(v) {
+          if (prev) prev.push(v)
+          else observer.next([latest, v])
+        },
+        error(e) {
+          observer.error(e)
+        },
+        complete() {
+          observer.complete()
+        },
+      })
+
+      subscription.add(
+        latest$.subscribe({
+          next(v) {
+            latest = v
+            if (prev) {
+              const copy = [...prev]
+              prev = null
+              copy.forEach((p) => observer.next([latest, p]))
+            }
+          },
+          error(e) {
+            observer.error(e)
+          },
+          complete() {
+            if (prev) observer.error(new Error("Empty complete"))
+          },
+        }),
+      )
+
+      return subscription
+    })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,9 +278,6 @@ importers:
       '@commander-js/extra-typings':
         specifier: ^14.0.0
         version: 14.0.0(commander@14.0.0)
-      '@noble/hashes':
-        specifier: ^2.0.0
-        version: 2.0.0
       '@polkadot-api/codegen':
         specifier: workspace:*
         version: link:../codegen


### PR DESCRIPTION
While using the CLI on a slow network, I noticed it was occasionally displaying console errors. This happens because if the CLI can’t fetch the descriptors quickly enough, it falls back to fetching them in parallel with the `legacyProvider`. To do that, it has to try different hashers, which ends up producing low-level errors that get logged to the console.

This PR changes the `legacyProvider` so it no longer asks the user for the hasher. Instead, it infers the hasher directly from the network, avoiding those extra error logs.