### PR TITLE
feat(cli): generate contract types for solidity contracts

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- `sol` subcommand analogous to `ink` for managing solidity contracts.
+
 ## 0.14.15 - 2025-09-18
 
 ### Fixed

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,6 +1,7 @@
 import { Option, program } from "@commander-js/extra-typings"
 import type { add, generate, ink, remove, update } from "./commands"
 import * as knownChains from "@polkadot-api/known-chains"
+import { sol } from "./commands/sol"
 
 export type Commands = {
   add: typeof add
@@ -104,6 +105,27 @@ export function getCli({
     .addOption(skipCodegen)
     .addOption(whitelist)
     .action(ink.remove)
+
+  const solCommand = program
+    .command("sol")
+    .description("Add, update or remove solidity contracts")
+  solCommand
+    .command("add")
+    .description("Add or update a solidity contract")
+    .argument("<file>", ".abi file for the contract")
+    .argument("<key>", "Key identifier for the contract")
+    .addOption(config)
+    .addOption(skipCodegen)
+    .addOption(whitelist)
+    .action(sol.add)
+  solCommand
+    .command("remove")
+    .description("Remove a solidity contract")
+    .argument("<key>", "Key identifier for the contract to remove")
+    .addOption(config)
+    .addOption(skipCodegen)
+    .addOption(whitelist)
+    .action(sol.remove)
 
   return program
 }

--- a/packages/cli/src/commands/sol.ts
+++ b/packages/cli/src/commands/sol.ts
@@ -1,0 +1,62 @@
+import {
+  defaultConfig,
+  papiFolder,
+  readPapiConfig,
+  writePapiConfig,
+} from "@/papiConfig"
+import { existsSync } from "node:fs"
+import * as fs from "node:fs/promises"
+import { join } from "node:path"
+import { CommonOptions } from "./commonOptions"
+import { generate } from "./generate"
+
+export const sol = {
+  async add(file: string, key: string, options: CommonOptions) {
+    const abi = JSON.parse(await fs.readFile(file, "utf-8"))
+
+    const config = (await readPapiConfig(options.config)) ?? defaultConfig
+    const solConfig = (config.sol ||= {})
+    if (key in solConfig) {
+      console.warn(`Replacing existing ${key} config`)
+    }
+
+    const contractsFolder = join(papiFolder, "contracts")
+    if (!existsSync(contractsFolder)) {
+      await fs.mkdir(contractsFolder, { recursive: true })
+    }
+    const fileName = join(contractsFolder, key + ".json")
+    await fs.writeFile(fileName, JSON.stringify(abi, null, 2))
+
+    solConfig[key] = fileName
+    await writePapiConfig(options.config, config)
+
+    if (!options.skipCodegen) {
+      generate({
+        config: options.config,
+      })
+    }
+  },
+  async remove(key: string, options: CommonOptions) {
+    const config = (await readPapiConfig(options.config)) ?? defaultConfig
+    const solConfig = (config.sol ||= {})
+    if (!(key in solConfig)) {
+      console.log(`${key} contract not found in config`)
+      return
+    }
+
+    const fileName = solConfig[key]
+    delete solConfig[key]
+
+    if (existsSync(fileName)) {
+      await fs.rm(fileName)
+    }
+
+    await writePapiConfig(options.config, config)
+
+    if (!options.skipCodegen) {
+      generate({
+        config: options.config,
+      })
+    }
+  },
+}

--- a/packages/cli/src/papiConfig.ts
+++ b/packages/cli/src/papiConfig.ts
@@ -38,6 +38,7 @@ export type PapiConfig = {
   descriptorPath: string
   entries: Record<string, EntryConfig>
   ink?: Record<string, string>
+  sol?: Record<string, string>
   options?: Partial<PapiConfigOptions>
 }
 

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+
+- **CLI**
+  - `sol` subcommand analogous to `ink` for managing solidity contracts.
+
 ## 1.18.0 - 2025-09-18
 
 ### Added

--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- `generateSolTypes(abi)` to generate contract descriptors from ABI
+
 ## 0.18.4 - 2025-09-15
 
 ### Fixed

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -9,3 +9,4 @@ export {
   type KnownTypes,
 } from "./known-types"
 export { generateInkTypes } from "./ink-types"
+export { generateSolTypes } from "./sol-types"

--- a/packages/codegen/src/sol-types.ts
+++ b/packages/codegen/src/sol-types.ts
@@ -1,0 +1,192 @@
+type AbiPrimitive =
+  | `uint${number}`
+  | `uint`
+  | `int${number}`
+  | `int`
+  | "address"
+  | "bool"
+  | `fixed${number}x${number}`
+  | `ufixed${number}x${number}`
+  | "fixed"
+  | "ufixed"
+  | `bytes${number}`
+  | "function"
+  | "bytes"
+  | "string"
+
+type AbiType =
+  | AbiPrimitive
+  | `${AbiPrimitive}[${number}]`
+  | `${AbiPrimitive}[]`
+  | `tuple`
+
+type TypedVariable = {
+  name: string
+  type: AbiType
+  components: TypedVariable[]
+}
+type FunctionAbi = {
+  type: "function" | "constructor" | "receive" | "fallback"
+  name?: string
+  inputs?: Array<TypedVariable>
+  outputs?: Array<TypedVariable>
+  stateMutability: "pure" | "view" | "nonpayable" | "payable"
+}
+
+type EventAbi = {
+  type: "event"
+  name: string
+  inputs: Array<TypedVariable>
+  anonymous?: boolean
+}
+
+type ErrorAbi = {
+  type: "error"
+  name: string
+  inputs: Array<TypedVariable>
+}
+
+type Abi = Array<FunctionAbi | EventAbi | ErrorAbi>
+
+const intRegex = /^u?int(\d+)$/
+const fixedRegex = /^u?fixed\d+x(\d+)$/
+function generatePrimitiveType(primitive: AbiPrimitive) {
+  switch (primitive) {
+    case "uint":
+    case "int":
+      return "bigint"
+    case "address":
+      return "Address"
+    case "bool":
+      return "bool"
+    case "fixed":
+    case "ufixed":
+      return "Decimal<18>"
+    case "function":
+      return "FunctionRef"
+    case "bytes":
+      return "Uint8Array"
+    case "string":
+      return "string"
+  }
+
+  if (primitive.startsWith("bytes")) {
+    return "Uint8Array"
+  }
+
+  const intMatch = intRegex.exec(primitive)
+  if (intMatch) {
+    return Number(intMatch[1]) > 53 ? "bigint" : "number"
+  }
+
+  const fixedMatch = fixedRegex.exec(primitive)
+  if (fixedMatch) {
+    return `Decimal<${fixedMatch[1]}>`
+  }
+
+  throw new Error("Can't map " + primitive)
+}
+
+const arrayRegex = /^(.+)\[(\d+)\]$/
+function generateVariableType(variable: TypedVariable) {
+  if (variable.type === "tuple") {
+    return generateStructType(variable.components)
+  }
+
+  if (variable.type.endsWith("[]")) {
+    return `Array<${generatePrimitiveType(variable.type.replace("[]", "") as AbiPrimitive)}>`
+  }
+
+  const arrayMatch = arrayRegex.exec(variable.type)
+  if (arrayMatch) {
+    return `Array<${generatePrimitiveType(arrayMatch[1] as AbiPrimitive)}>`
+  }
+
+  return generatePrimitiveType(variable.type as AbiPrimitive)
+}
+
+function generateStructType(params?: Array<TypedVariable>): string {
+  if (!params || !params.length) return `{}`
+
+  const unnamedTypes = params.filter((v) => !v.name)
+  const namedTypes = params.filter((v) => !!v.name)
+
+  if (namedTypes.length == 0) {
+    if (unnamedTypes.length === 1) {
+      return generateVariableType(unnamedTypes[0])
+    }
+
+    return "[" + unnamedTypes.map(generateVariableType).join(", ") + "]"
+  }
+
+  if (unnamedTypes.length) {
+    namedTypes.push({
+      name: "args",
+      type: "tuple",
+      components: unnamedTypes,
+    })
+  }
+
+  return `{${namedTypes.map((v): string => `"${v.name}": ${generateVariableType(v)}`).join(",\n")}}`
+}
+
+function generateFunctionType(fnAbi: FunctionAbi) {
+  return `"${fnAbi}": { message: ${generateStructType(fnAbi.inputs)}, response: ${generateStructType(fnAbi.outputs)} }`
+}
+
+export function generateSolTypes(abi: Abi) {
+  const messages = abi.filter((v) => v.type === "function") as FunctionAbi[]
+
+  const receive = abi.find((v) => v.type === "receive") as
+    | FunctionAbi
+    | undefined
+  if (receive) {
+    messages.push({
+      name: "receive",
+      ...receive,
+      type: "function",
+    })
+  }
+
+  const fallback = abi.find((v) => v.type === "fallback") as
+    | FunctionAbi
+    | undefined
+  if (fallback) {
+    messages.push({
+      name: "fallback",
+      ...fallback,
+      type: "function",
+    })
+  }
+
+  const messagesDescriptor = `{ ${messages.map(generateFunctionType).join(",\n")} }`
+
+  const constructor = (abi.find((v) => v.type === "constructor") as
+    | FunctionAbi
+    | undefined) ?? {
+    type: "constructor",
+    stateMutability: "pure",
+  }
+
+  const constructorsDescriptor = `{ ${generateFunctionType({
+    name: "new",
+    ...constructor,
+  })} }`
+
+  const result = `
+    import type { InkDescriptors } from 'polkadot-api/ink';
+
+    type Address = \`0x\${string}\`
+    type Decimal<T extends number> = { value: bigint, decimals: T }
+    type FunctionRef = { address: Address, selector: Uint8Array }
+
+    type StorageDescriptor = {};
+    type MessagesDescriptor = ${messagesDescriptor};
+    type ConstructorsDescriptor = ${constructorsDescriptor};
+    type EventDescriptor = Enum<{}>;
+
+    export const descriptor: InkDescriptors<StorageDescriptor, MessagesDescriptor, ConstructorsDescriptor, EventDescriptor> = { abi: ${JSON.stringify(abi)} } as any;
+  `
+
+  return result
+}

--- a/packages/codegen/src/sol-types.ts
+++ b/packages/codegen/src/sol-types.ts
@@ -178,6 +178,11 @@ export function generateSolTypes(abi: Abi) {
     ...constructor,
   })} }`
 
+  const events = abi.filter((v) => v.type === "event")
+  const eventsDescriptor = `Enum<{
+    ${events.map((evt) => `"${evt.name}": ${generateStructType(evt.inputs)}`).join(",\n")}
+  }>`
+
   const result = `
     import type { InkDescriptors } from 'polkadot-api/ink';
     import type { Enum, Binary } from 'polkadot-api';
@@ -190,7 +195,7 @@ export function generateSolTypes(abi: Abi) {
     type StorageDescriptor = {};
     type MessagesDescriptor = ${messagesDescriptor};
     type ConstructorsDescriptor = ${constructorsDescriptor};
-    type EventDescriptor = Enum<{}>;
+    type EventDescriptor = ${eventsDescriptor};
 
     export const descriptor: InkDescriptors<StorageDescriptor, MessagesDescriptor, ConstructorsDescriptor, EventDescriptor> = { abi: ${JSON.stringify(abi)} } as any;
   `

--- a/packages/ink-contracts/CHANGELOG.md
+++ b/packages/ink-contracts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Add support solidity contracts
+
 ## 0.3.11 - 2025-09-15
 
 ### Fixed

--- a/packages/ink-contracts/src/ink-client.ts
+++ b/packages/ink-contracts/src/ink-client.ts
@@ -112,6 +112,10 @@ export const getInkClient = <
 >(
   inkContract: D,
 ): InkClient<D> => {
+  if (!inkContract.metadata) {
+    throw new Error("Ink client needs the contract metadata")
+  }
+
   const lookup = getInkLookup(inkContract.metadata)
   const builder = getInkDynamicBuilder(lookup)
 

--- a/packages/ink-contracts/src/ink-descriptors.ts
+++ b/packages/ink-contracts/src/ink-descriptors.ts
@@ -1,4 +1,3 @@
-import { StringRecord } from "@polkadot-api/substrate-bindings"
 import { InkMetadata } from "./metadata-types"
 
 export type Event = { type: string; value: unknown }
@@ -22,8 +21,8 @@ export interface InkDescriptors<
 export type InkCallableDescriptor = Record<
   string,
   {
-    message: StringRecord<unknown>
-    response: StringRecord<unknown>
+    message: unknown
+    response: unknown
     default?: boolean
     payable?: boolean
     mutates?: boolean

--- a/packages/ink-contracts/src/ink-descriptors.ts
+++ b/packages/ink-contracts/src/ink-descriptors.ts
@@ -9,7 +9,8 @@ export interface InkDescriptors<
   C extends InkCallableDescriptor,
   E extends Event,
 > {
-  metadata: InkMetadata
+  metadata?: InkMetadata
+  abi?: unknown
   __types: {
     storage: S
     messages: M


### PR DESCRIPTION
This adds support for solidity contracts, by adding `papi sol` subcommand (analogous to `papi ink`) for managing solidity contracts.

The top-level client doesn't currently support solidity encoding, as there are plenty of ethereum libraries that deal with solidity encoding at this abstraction level.

This feature is basically to have a similar codegen of contract types to those of `ink`, so that the same system can be used for solidity in the PAPI ink-sdk to have a consistent API between both languages.
