### PR TITLE
fix(ink): align compact type generation with PJS metadata

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - **WS Provider:**
   - Immediate heartbeat disconnections if `heartbeatTimeout` is too large
+- **Ink!:**
+  - Align compact type generation with PJS metadata
 
 ## 1.20.1 - 2025-10-31
 

--- a/packages/ink-contracts/CHANGELOG.md
+++ b/packages/ink-contracts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Align compact type generation with PJS metadata
+
 ## 0.4.1 to 0.4.2 - 2025-10-31
 
 ### Fixed

--- a/packages/ink-contracts/src/metadata-pjs-types.ts
+++ b/packages/ink-contracts/src/metadata-pjs-types.ts
@@ -113,7 +113,9 @@ const def = Variant({
   array: arr,
   tuple: Vector(compactNumber),
   primitive,
-  compact: compactNumber,
+  compact: Struct({
+    type: compactNumber,
+  }),
   bitSequence,
 })
 


### PR DESCRIPTION
It seems compact values in ink metadata are encoded this way. I guess we didn't encounter compact values before, do you have any insight regarding this @voliva?
Verified in both v5 and v6.

V5 metadata: [bittensor.json](https://github.com/user-attachments/files/23415256/bittensor.json)

V6 metadata: [my_contract.json](https://github.com/user-attachments/files/23415263/my_contract.json)

Closes #1207 