### PR TITLE
chore(observable-client): remove unpinnable add prunned

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Update dependencies
+
 ## 1.21.1 - 2025-11-25
 
 ### Fixed

--- a/packages/client/src/tx/create-tx.ts
+++ b/packages/client/src/tx/create-tx.ts
@@ -145,9 +145,7 @@ const getNonce$ = (chainHead: ChainHead$, from: HexString) => {
       return [...blocks.values()]
         .filter(
           (v) =>
-            !v.unpinnable &&
-            v.children.size === 0 &&
-            v.number >= bestBlock.number,
+            !v.pruned && v.children.size === 0 && v.number >= bestBlock.number,
         )
         .map((v) => v.hash)
     }),

--- a/packages/client/src/tx/submit-fns.ts
+++ b/packages/client/src/tx/submit-fns.ts
@@ -244,7 +244,7 @@ export const submit$ = (
 
       const getTipsFromHeight = (height: number): BlockInfo[] => {
         let tips: BlockInfo[] = [...pinnedBlocks.blocks.values()].filter(
-          (block) => !block.unpinnable && !block.children.size,
+          (block) => !block.pruned && !block.children.size,
         )
         const higherTip = Math.max(...tips.map(({ number }) => number))
         // take only tips "with chance to become canonical"

--- a/packages/observable-client/CHANGELOG.md
+++ b/packages/observable-client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Refactor: remove `unpinnable` and add `prunned`
+
 ## 0.16.5 - 2025-11-25
 
 ### Fixed

--- a/packages/observable-client/src/chainHead/streams/pinned-blocks-types.ts
+++ b/packages/observable-client/src/chainHead/streams/pinned-blocks-types.ts
@@ -6,7 +6,7 @@ export interface PinnedBlock {
   parent: string
   children: Set<string>
   runtime: string
-  unpinnable: boolean
+  pruned: boolean
   refCount: number
   recovering: boolean
   hasNewRuntime: boolean


### PR DESCRIPTION
While working on #1234 I realized that the property `unpinnable` is a bit silly, because it doesn't add much value.

A block is "unpinable" if it's either pruned or if its height is below the current finalized. Therefore, I think that it's best to remove that property in favour of a `pruned` property.