### PR TITLE
refactor: use `never` for type branding

### DIFF
--- a/packages/substrate-bindings/src/codecs/scale/Hex.ts
+++ b/packages/substrate-bindings/src/codecs/scale/Hex.ts
@@ -1,7 +1,7 @@
 import { fromHex, toHex } from "@polkadot-api/utils"
 import { Bytes, Codec, Decoder, Encoder, createCodec } from "scale-ts"
 
-export type HexString = string & { __hexString?: unknown }
+export type HexString = string & { readonly __hexString?: never }
 
 const enc = (nBytes?: number): Encoder<HexString> => {
   const _enc = Bytes.enc(nBytes)

--- a/packages/substrate-bindings/src/storage.ts
+++ b/packages/substrate-bindings/src/storage.ts
@@ -27,7 +27,7 @@ const hashers: Map<(input: Uint8Array) => Uint8Array, number> = new Map([
   [Twox256, -32],
 ])
 
-export type OpaqueKeyHash = string & { __opaqueKeyHash?: unknown }
+export type OpaqueKeyHash = string & { readonly __opaqueKeyHash?: never }
 
 export const Storage = (pallet: string) => {
   const palledEncoded = Twox128(textEncoder.encode(pallet))

--- a/packages/substrate-bindings/src/utils/ss58-util.ts
+++ b/packages/substrate-bindings/src/utils/ss58-util.ts
@@ -4,7 +4,7 @@ import { blake2b } from "@noble/hashes/blake2.js"
 const SS58_PREFIX = new TextEncoder().encode("SS58PRE")
 const CHECKSUM_LENGTH = 2
 
-export type SS58String = string & { __SS58String?: unknown }
+export type SS58String = string & { readonly __SS58String?: never }
 export type SS58AddressInfo =
   | { isValid: false }
   | { isValid: true; ss58Format: number; publicKey: Uint8Array }


### PR DESCRIPTION
Slightly (already pretty clear tbh) that you shouldn't use this property. With `exactOptionalPropertyTypes` enabled assigning value will be disabled entirely.