### PR TITLE
feat(cli): skip re-generating descriptors if nothing has changed

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Skip codegen when detecting descriptors won't change
+
 ## 0.17.1 - 2025-12-10
 
 ### Fixed

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -1,5 +1,6 @@
 import { getMetadata } from "@/metadata"
 import { readPapiConfig } from "@/papiConfig"
+import { cliVersion } from "@/version"
 import {
   capitalize,
   generateInkTypes,
@@ -14,12 +15,14 @@ import {
 } from "@polkadot-api/metadata-compatibility"
 import {
   Binary,
+  Blake2128,
   h64,
   HexString,
-  UnifiedMetadata,
   Tuple,
+  UnifiedMetadata,
   Vector,
 } from "@polkadot-api/substrate-bindings"
+import { toHex } from "@polkadot-api/utils"
 import { spawn } from "child_process"
 import { existsSync } from "fs"
 import fsExists from "fs.promises.exists"
@@ -67,17 +70,23 @@ export async function generate(opts: GenerateOptions) {
     return
   }
 
+  const whitelistPath = opts.whitelist ?? config.options?.whitelist
+  const whitelist = whitelistPath ? await readWhitelist(whitelistPath) : null
+
+  const descriptorsDir = join(process.cwd(), config.descriptorPath)
+  if (await alreadyGenerated(descriptorsDir, chains, whitelist)) {
+    console.log("Detected previous descriptors with no changes needed.")
+    return
+  }
+
   console.log(`Generating descriptors`)
   await cleanDescriptorsPackage(config.descriptorPath)
   if (!config.options?.noDescriptorsPackage) {
     await addDescriptorsToPackageJson(config.descriptorPath)
   }
-  const descriptorsDir = join(process.cwd(), config.descriptorPath)
 
   const clientPath = opts.clientLibrary ?? "polkadot-api"
 
-  const whitelistPath = opts.whitelist ?? config.options?.whitelist
-  const whitelist = whitelistPath ? await readWhitelist(whitelistPath) : null
   const descriptorSrcDir = join(descriptorsDir, "src")
   const hash = await outputCodegen(
     chains,
@@ -91,11 +100,74 @@ export async function generate(opts: GenerateOptions) {
   }
 
   await replacePackageJson(descriptorsDir, hash)
-  await compileCodegen(descriptorsDir)
+  const cleanCodegen = await compileCodegen(descriptorsDir)
+  if (cleanCodegen) {
+    await tagGenerated(descriptorsDir, chains, whitelist)
+  }
   await fs.rm(descriptorSrcDir, { recursive: true })
   if (!config.options?.noDescriptorsPackage) {
     await runInstall()
     await flushBundlerCache()
+  }
+}
+
+async function tagGenerated(
+  descriptorsDir: string,
+  chains: {
+    key: string
+    metadataRaw: Uint8Array
+  }[],
+  whitelist: string[] | null,
+) {
+  const filePath = join(descriptorsDir, "generated.json")
+
+  await fs.writeFile(
+    filePath,
+    JSON.stringify({
+      cliVersion,
+      whitelist,
+      chains: Object.fromEntries(
+        chains.map(({ key, metadataRaw }) => [
+          key,
+          toHex(Blake2128(metadataRaw)),
+        ]),
+      ),
+    }),
+  )
+}
+async function alreadyGenerated(
+  descriptorsDir: string,
+  chains: {
+    key: string
+    metadataRaw: Uint8Array
+  }[],
+  whitelist: string[] | null,
+) {
+  const generatedJsôn = join(descriptorsDir, "generated.json")
+  if (!existsSync(generatedJsôn)) return false
+
+  try {
+    const generated = JSON.parse(
+      await fs.readFile(generatedJsôn, {
+        encoding: "utf-8",
+      }),
+    )
+    if (
+      (generated.whitelist ?? ["*"]).join(",") !=
+        (whitelist ?? ["*"]).join(",") ||
+      generated.cliVersion !== cliVersion
+    )
+      return false
+
+    return (
+      chains.length === Object.entries(generated.chains).length &&
+      chains.every(({ key, metadataRaw }) => {
+        const hash = toHex(Blake2128(metadataRaw))
+        return hash === generated.chains[key]
+      })
+    )
+  } catch {
+    return false
   }
 }
 
@@ -320,6 +392,7 @@ async function compileCodegen(packageDir: string) {
     await fs.rm(outDir, { recursive: true })
   }
 
+  // tsup only builds cjs+esm outputs, skipping all typechecks.
   await tsup.build({
     target: "es2022",
     format: ["cjs", "esm"],
@@ -334,7 +407,8 @@ async function compileCodegen(packageDir: string) {
     }),
   })
 
-  tsc.build({
+  // We need tsc to actually build the definitions file, and also perform the typecheck
+  const program = tsc.createProgramFromConfig({
     basePath: srcDir,
     compilerOptions: {
       skipLibCheck: true,
@@ -348,6 +422,18 @@ async function compileCodegen(packageDir: string) {
       outDir,
     },
   })
+  tsc.emit(program)
+
+  const errors = [
+    program.getGlobalDiagnostics(),
+    program.getOptionsDiagnostics(),
+    program.getSemanticDiagnostics(),
+    program.getSyntacticDiagnostics(),
+    program.getDeclarationDiagnostics(),
+    program.getConfigFileParsingDiagnostics(),
+  ].flat()
+
+  return errors.length === 0
 }
 
 const cacheMetadataStr = `

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,0 +1,2 @@
+import { version } from "../package.json"
+export const cliVersion = version

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+
+- **CLI**
+  - Skip re-generating descriptors if nothing has changed.
+
 ### Fixed
 
 - **Ink contracts**


### PR DESCRIPTION
Closes #1087

Not only the chain codehash had to be tracked, but also the whitelist config and the CLI version.

For this reason, the solution added by this PR is to generate an adittional json file in the descriptors package that describe these settings. The CLI then checks if that file exists and nothing changes, then skips codegen (which saves some seconds when e.g. adding a dependency) 