### PR TITLE
feat: add event watchBest API

### DIFF
--- a/examples/bun/src/events.ts
+++ b/examples/bun/src/events.ts
@@ -1,0 +1,63 @@
+import { sr25519CreateDerive } from "@polkadot-labs/hdkd"
+import {
+  DEV_PHRASE,
+  entropyToMiniSecret,
+  mnemonicToEntropy,
+} from "@polkadot-labs/hdkd-helpers"
+import { getPolkadotSigner, withMetadataHash } from "polkadot-api/signer"
+import { createClient } from "polkadot-api"
+import { MultiAddress, wnd } from "@polkadot-api/descriptors"
+import { chainSpec } from "polkadot-api/chains/westend"
+import { getSmProvider } from "polkadot-api/sm-provider"
+import { start } from "polkadot-api/smoldot"
+import { filter } from "rxjs"
+
+// let's create Bob signer
+const miniSecret = entropyToMiniSecret(mnemonicToEntropy(DEV_PHRASE))
+const derive = sr25519CreateDerive(miniSecret)
+const bobKeyPair = derive("//Bob")
+const bob = getPolkadotSigner(bobKeyPair.publicKey, "Sr25519", bobKeyPair.sign)
+
+// create the client with smoldot
+const smoldot = start()
+const client = createClient(
+  getSmProvider(() => smoldot.addChain({ chainSpec })),
+)
+
+console.log("Waiting for initial finalized…")
+await client.getFinalizedBlock()
+
+// get the safely typed API
+const typedApi = client.getTypedApi(wnd)
+
+// Subscribe to finalized events
+const watchSub = typedApi.event.Balances.Transfer.watch()
+  .pipe(filter((value) => value.events.length > 0))
+  .subscribe((evt) => console.log("watch (finalized)", evt.block, evt.events))
+
+// Subscribe to best-block events
+const watchBestSub = typedApi.event.Balances.Transfer.watchBest()
+  .pipe(filter((value) => value.events.length > 0))
+  .subscribe((evt) => console.log("watchBest", evt.type, evt.block, evt.events))
+
+// create the transaction sending ALICE some assets
+const ALICE = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+typedApi.tx.Balances.transfer_allow_death({
+  dest: MultiAddress.Id(ALICE),
+  value: 12345n,
+})
+  .signSubmitAndWatch(bob)
+  .subscribe(async (r) => {
+    console.log({
+      type: r.type,
+      hash: r.txHash,
+    })
+
+    if (r.type === "finalized") {
+      await new Promise((res) => setTimeout(res, 3000))
+      watchSub.unsubscribe()
+      watchBestSub.unsubscribe()
+      client.destroy()
+      smoldot.terminate()
+    }
+  })

--- a/examples/bun/tsconfig.json
+++ b/examples/bun/tsconfig.json
@@ -22,6 +22,8 @@
     // Some stricter flags (disabled by default)
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "noPropertyAccessFromIndexSignature": false
+    "noPropertyAccessFromIndexSignature": false,
+
+    "types": ["bun"]
   }
 }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- new `event.Pallet.name.watchBest` API
+
 ## 2.0.2 - 2026-04-16
 
 ### Fixed

--- a/packages/client/src/event.ts
+++ b/packages/client/src/event.ts
@@ -1,16 +1,27 @@
-import { BlockInfo, ChainHead$ } from "@polkadot-api/observable-client"
+import {
+  BlockInfo,
+  ChainHead$,
+  isBestOrFinalizedBlock,
+} from "@polkadot-api/observable-client"
 import { HexString, SizedHex } from "@polkadot-api/substrate-bindings"
 import {
   Observable,
   combineLatest,
-  concat,
   defer,
   firstValueFrom,
-  from,
   map,
   switchMap,
   take,
-  tap,
+  filter as rFilter,
+  mergeMap,
+  EMPTY,
+  of,
+  takeUntil,
+  pairwise,
+  startWith,
+  Subject,
+  withLatestFrom,
+  merge,
 } from "rxjs"
 import { ValueCompat } from "./compatibility"
 import { concatMapEager, shareLatest } from "./utils"
@@ -60,6 +71,9 @@ export type EvClient<T> = {
     block: BlockInfo
     events: PalletEvent<T>[]
   }>
+
+  // a -> (b -> c -> d -> e)
+  // a -> b -> c -> (d -> e)
 
   /**
    * Filter a bunch of `SystemEvent` and return the decoded `payload` of every
@@ -113,14 +127,15 @@ export const createEventEntry = <T>(
   )
 
   const best$ = defer(() => {
-    // In the order they were emitted
-    let blocksEmitted: Array<{
-      block: BlockInfo
-      events: PalletEvent<T>[]
-    }> = []
-
-    const getBlockEvents$ = (blockHash: HexString) =>
-      combineLatest([
+    const getBlockEvents$ = (blockHash: HexString) => {
+      const isIrrelevant$ = isBestOrFinalizedBlock(
+        chainHead.pinnedBlocks$,
+        blockHash,
+      ).pipe(
+        rFilter((x) => x === null),
+        take(1),
+      )
+      return combineLatest([
         compatibility,
         chainHead.getRuntimeContext$(blockHash),
       ]).pipe(
@@ -130,57 +145,114 @@ export const createEventEntry = <T>(
             throw new Error(`Runtime entry Event(${pallet}.${name}) not found`)
           return getEventsAtBlock$(blockHash, getCompat(ctx).isValueCompatible)
         }),
+        takeUntil(isIrrelevant$),
       )
+    }
 
-    return chainHead.bestBlocks$.pipe(
-      switchMap((bestBlockChain) => {
-        const finalizedBlock = bestBlockChain.at(-1)!
-        const bestBlocks = bestBlockChain.slice(0, -1)
-        const bestBlockSet = new Set(bestBlocks.map((b) => b.hash))
+    // In the order they were emitted
+    let blocksEmitted: Array<{
+      block: BlockInfo
+      events: PalletEvent<T>[]
+    }> = []
+    const pending = new Set<HexString>()
 
-        // Only emit drop/finalized for blocks we actually delivered to the subscriber
-        const removed = blocksEmitted.filter(
-          ({ block }) => !bestBlockSet.has(block.hash),
-        )
-        // Blocks that disappeared due to being finalized.
-        // Assumption: `best` is always updated before `finalized`. Otherwise it
-        // could end up with missing blocks
-        const finalized = removed.filter(
-          ({ block }) => block.number <= finalizedBlock.number,
-        )
-        // Blocks that disappeared due to a reorg.
-        const drops = removed.filter(
-          ({ block }) => block.number > finalizedBlock.number,
-        )
-        const removed$ = from([
-          ...finalized.map((action) => ({
-            ...action,
-            type: "finalized" as const,
-          })),
-          ...drops
-            .reverse()
-            .map((action) => ({ ...action, type: "drop" as const })),
-        ])
-
-        blocksEmitted = blocksEmitted.filter(({ block }) =>
-          bestBlockSet.has(block.hash),
-        )
-        const emittedSet = new Set(blocksEmitted.map(({ block }) => block.hash))
-        const toLoad = bestBlocks.filter((b) => !emittedSet.has(b.hash))
-
-        const new$ = from(toLoad.reverse()).pipe(
-          concatMapEager((block) =>
-            getBlockEvents$(block.hash).pipe(
-              map((events) => ({ type: "new" as const, block, events })),
-            ),
-          ),
-          tap(({ block, events }) => blocksEmitted.push({ block, events })),
-        )
-
-        return concat(removed$, new$)
+    const newOnes = new Subject<BlockInfo>()
+    const new$ = newOnes.pipe(
+      concatMapEager((block) =>
+        getBlockEvents$(block.hash).pipe(map((events) => ({ events, block }))),
+      ),
+      rFilter((x) => pending.has(x.block.hash)),
+      withLatestFrom(chainHead.finalized$),
+      mergeMap(([{ events, block }, finalized]) => {
+        pending.delete(block.hash)
+        if (finalized.number < block.number) {
+          blocksEmitted.push({ block, events })
+          return of({
+            type: "new" as "new",
+            block,
+            events,
+          })
+        }
+        return [
+          {
+            type: "new" as "new",
+            block,
+            events,
+          },
+          {
+            type: "finalized" as "finalized",
+            block,
+            events,
+          },
+        ]
       }),
     )
-  }).pipe(shareLatest)
+
+    return merge(
+      new$,
+      chainHead.bestBlocks$.pipe(
+        map((x) => x.slice(0).reverse()),
+        startWith([] as BlockInfo[]),
+        pairwise(),
+        mergeMap(([prev, next]) => {
+          if (prev.length === 0)
+            return next.map((x) => ({ type: "new" as "new", block: x }))
+
+          if (prev[0].hash !== next[0].hash) {
+            const firstEmitted = blocksEmitted[0]
+            if (!firstEmitted) return []
+            const nFinalized = next[0]!.number - firstEmitted.block.number + 1
+            const events = blocksEmitted.slice(0, nFinalized)
+            blocksEmitted = blocksEmitted.slice(nFinalized)
+            return events.map((e) => ({
+              type: "finalized" as "finalized",
+              block: e.block,
+              events: e.events,
+            }))
+          }
+
+          let dropped: Array<{ block: BlockInfo; events: PalletEvent<any>[] }> =
+            []
+          for (let i = 0; i < blocksEmitted.length; i++) {
+            if (blocksEmitted[i].block.hash !== next[i + 1]?.hash) {
+              dropped = blocksEmitted.slice(i)
+              blocksEmitted = blocksEmitted.slice(0, i)
+              break
+            }
+          }
+
+          let diffIdx = prev.length
+          for (let i = 0; i < prev.length; i++) {
+            if (prev[i].hash !== next[i].hash) {
+              diffIdx = i
+              break
+            }
+          }
+          const newOnes = next.slice(diffIdx)
+
+          return [
+            ...dropped.map((e) => ({
+              type: "drop" as "drop",
+              block: e.block,
+              events: e.events,
+            })),
+            ...newOnes.map((x) => ({ type: "new" as "new", block: x })),
+          ]
+        }),
+        mergeMap((x) => {
+          if (x.type === "new") {
+            pending.add(x.block.hash)
+            newOnes.next(x.block)
+            return EMPTY
+          }
+          if (x.type === "drop") {
+            pending.delete(x.block.hash)
+          }
+          return of(x)
+        }),
+      ),
+    )
+  })
 
   const filter: EvClient<T>["filter"] = (events) =>
     events

--- a/packages/client/src/event.ts
+++ b/packages/client/src/event.ts
@@ -3,10 +3,14 @@ import { HexString, SizedHex } from "@polkadot-api/substrate-bindings"
 import {
   Observable,
   combineLatest,
+  concat,
+  defer,
   firstValueFrom,
+  from,
   map,
   switchMap,
   take,
+  tap,
 } from "rxjs"
 import { ValueCompat } from "./compatibility"
 import { concatMapEager, shareLatest } from "./utils"
@@ -47,6 +51,12 @@ export type EvClient<T> = {
    * event kind chosen) in the `finalized` blocks.
    */
   watch: () => Observable<{
+    block: BlockInfo
+    events: PalletEvent<T>[]
+  }>
+
+  watchBest: () => Observable<{
+    type: "new" | "drop" | "finalized"
     block: BlockInfo
     events: PalletEvent<T>[]
   }>
@@ -102,6 +112,76 @@ export const createEventEntry = <T>(
     shareLatest,
   )
 
+  const best$ = defer(() => {
+    // In the order they were emitted
+    let blocksEmitted: Array<{
+      block: BlockInfo
+      events: PalletEvent<T>[]
+    }> = []
+
+    const getBlockEvents$ = (blockHash: HexString) =>
+      combineLatest([
+        compatibility,
+        chainHead.getRuntimeContext$(blockHash),
+      ]).pipe(
+        take(1),
+        switchMap(([getCompat, ctx]) => {
+          if (!ctx.mappedMeta.pallets[pallet]?.event.has(name))
+            throw new Error(`Runtime entry Event(${pallet}.${name}) not found`)
+          return getEventsAtBlock$(blockHash, getCompat(ctx).isValueCompatible)
+        }),
+      )
+
+    return chainHead.bestBlocks$.pipe(
+      switchMap((bestBlockChain) => {
+        const finalizedBlock = bestBlockChain.at(-1)!
+        const bestBlocks = bestBlockChain.slice(0, -1)
+        const bestBlockSet = new Set(bestBlocks.map((b) => b.hash))
+
+        // Only emit drop/finalized for blocks we actually delivered to the subscriber
+        const removed = blocksEmitted.filter(
+          ({ block }) => !bestBlockSet.has(block.hash),
+        )
+        // Blocks that disappeared due to being finalized.
+        // Assumption: `best` is always updated before `finalized`. Otherwise it
+        // could end up with missing blocks
+        const finalized = removed.filter(
+          ({ block }) => block.number <= finalizedBlock.number,
+        )
+        // Blocks that disappeared due to a reorg.
+        const drops = removed.filter(
+          ({ block }) => block.number > finalizedBlock.number,
+        )
+        const removed$ = from([
+          ...finalized.map((action) => ({
+            ...action,
+            type: "finalized" as const,
+          })),
+          ...drops
+            .reverse()
+            .map((action) => ({ ...action, type: "drop" as const })),
+        ])
+
+        blocksEmitted = blocksEmitted.filter(({ block }) =>
+          bestBlockSet.has(block.hash),
+        )
+        const emittedSet = new Set(blocksEmitted.map(({ block }) => block.hash))
+        const toLoad = bestBlocks.filter((b) => !emittedSet.has(b.hash))
+
+        const new$ = from(toLoad.reverse()).pipe(
+          concatMapEager((block) =>
+            getBlockEvents$(block.hash).pipe(
+              map((events) => ({ type: "new" as const, block, events })),
+            ),
+          ),
+          tap(({ block, events }) => blocksEmitted.push({ block, events })),
+        )
+
+        return concat(removed$, new$)
+      }),
+    )
+  }).pipe(shareLatest)
+
   const filter: EvClient<T>["filter"] = (events) =>
     events
       .filter(({ event }) => event.type === pallet && event.value.type === name)
@@ -123,5 +203,5 @@ export const createEventEntry = <T>(
       ),
     )
 
-  return { watch: () => finalized$, get, filter }
+  return { watch: () => finalized$, watchBest: () => best$, get, filter }
 }

--- a/packages/client/src/event.ts
+++ b/packages/client/src/event.ts
@@ -66,14 +66,26 @@ export type EvClient<T> = {
     events: PalletEvent<T>[]
   }>
 
+  /**
+   * Observable that watches the best-block chain and emits events that describe
+   * how the status changes.
+   *
+   * - It will emit `type: new` for new blocks in the best chain, with their
+   * events. The order is consistent in increasing block number.
+   * - It will emit `type: drop` for all the blocks, and their events, that
+   * dropped from best-block chain after a reorg. The order is consistent in
+   * increasing block number (emitting first the older blocks to be removed)
+   * - It will emit `type: finalized` for all the blocks, and their events, that
+   * became finalized.
+   *
+   * The block order is always consistent in increasing block number. And it
+   * will first emit `new` events, then `drop` events, then `finalized` events.
+   */
   watchBest: () => Observable<{
     type: "new" | "drop" | "finalized"
     block: BlockInfo
     events: PalletEvent<T>[]
   }>
-
-  // a -> (b -> c -> d -> e)
-  // a -> b -> c -> (d -> e)
 
   /**
    * Filter a bunch of `SystemEvent` and return the decoded `payload` of every

--- a/packages/client/src/event.ts
+++ b/packages/client/src/event.ts
@@ -74,12 +74,12 @@ export type EvClient<T> = {
    * events. The order is consistent in increasing block number.
    * - It will emit `type: drop` for all the blocks, and their events, that
    * dropped from best-block chain after a reorg. The order is consistent in
-   * increasing block number (emitting first the older blocks to be removed)
+   * reverse block number (emitting first the newer blocks to be removed)
    * - It will emit `type: finalized` for all the blocks, and their events, that
    * became finalized.
    *
-   * The block order is always consistent in increasing block number. And it
-   * will first emit `new` events, then `drop` events, then `finalized` events.
+   * It will first emit `new` events, then `drop` events, then `finalized`
+   * events.
    */
   watchBest: () => Observable<{
     type: "new" | "drop" | "finalized"
@@ -227,7 +227,7 @@ export const createEventEntry = <T>(
             []
           for (let i = 0; i < blocksEmitted.length; i++) {
             if (blocksEmitted[i].block.hash !== next[i + 1]?.hash) {
-              dropped = blocksEmitted.slice(i)
+              dropped = blocksEmitted.slice(i).reverse()
               blocksEmitted = blocksEmitted.slice(0, i)
               break
             }


### PR DESCRIPTION
Closes #1317 

Adds `watchBest()` to `api.events.Pallet.Name`, a new observable that tracks pallet events across best-block updates, emitting `new`, `drop` (reorg), and `finalized` typed entries as the best-block chain evolves.

Every time there's a new block in the best-block chain, it will make a new emission with the list of events of that type in that block, even if there are none. Rationale is that for some use cases it can be beneficial to know up to which point we have updates, and that it's fairly trivial to filter emissions with no events.

In case there's a reorg, where the best-block changes to a different branch, it will emit `drop` entries to signal that those events that were reported previously have been dropped, followed by the `new` of the new branch.

The order is stable: Events are emitted in the same order as blocks. When there's a reorg, it will make the `drop` emissions in opposite order (as if it was undoing) followed by `new` in the correct order.

Other forks not in the best-block chain are ignored.

I'd like to add tests, but it's hard/impossible to create consistent forks and reorgs with the current test setup. I'll address these later. Meanwhile I added an example that covers the happy path.