### PR TITLE
fix(cli): contract descriptors are not exported

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Contract descriptors are not exported.
 - Bump descriptors package.json PAPI peer dependency.
 
 ## 0.20.1 - 2026-04-09

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -118,7 +118,7 @@ export async function generate(opts: GenerateOptions) {
   )
 
   if (config.ink || config.sol) {
-    outputContractCodegen(config, descriptorSrcDir)
+    await outputContractCodegen(config, descriptorSrcDir)
   }
 
   await replacePackageJson(descriptorsDir, hash)

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Contract descriptors are not exported.
 - Bump descriptors package.json PAPI peer dependency.
 
 ## 2.0.0 - 2026-04-09


### PR DESCRIPTION
Closes #1347

Initially, I couldn’t reproduce the issue, but it turned out to be caused by a race condition. As it turns out, this bug has existed since we introduced contract codegen in [#752](https://github.com/polkadot-api/polkadot-api/pull/752/changes#diff-e7569fc2058f33e8e3349b21677c545ca06beec413fd06985d153079bc69b332R79), but it never surfaced because we were using tsup.

With v2, we switched all codegen to Rollup + esbuild, which is faster. And this has caused the issue to appear.

Thanks for raising the issue @tien! We'll try to release a patch early this week