### PR TITLE
fix(docgen): adapt to typescript 6.0

### DIFF
--- a/packages/docgen/CHANGELOG.md
+++ b/packages/docgen/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.3.5 - 2026-04-27
+
+### Fixed
+
+- Ensure compilation with Typescript 6.0
+
 ## 0.3.1 to 0.3.4 - 2026-04-21
 
 ### Fixed

--- a/packages/docgen/package.json
+++ b/packages/docgen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot-api/docgen",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "author": "Yuri Volkov (https://github.com/mutantcornholio)",
   "repository": {
     "type": "git",

--- a/packages/docgen/src/generateDocs.ts
+++ b/packages/docgen/src/generateDocs.ts
@@ -115,12 +115,12 @@ export async function generateDocs(opts: Options) {
 function getTsConfig(): string {
   return JSON.stringify({
     compilerOptions: {
-      lib: ["es2021"],
-      module: "commonjs",
-      moduleResolution: "node",
+      lib: ["ES2023"],
+      module: "esnext",
+      moduleResolution: "bundler",
       strict: true,
       skipLibCheck: true,
-      target: "es2021",
+      target: "es2022",
     },
     include: ["./**/*.ts"],
   })


### PR DESCRIPTION
Due to `moduleResolution = node`, typescript was emitting a warning and `typedoc` was treating it as an error.