### PR TITLE
fix(ci): add fallback RPCs to forklift tests

### DIFF
--- a/integration-tests/forklift/forklift.yaml
+++ b/integration-tests/forklift/forklift.yaml
@@ -1,4 +1,9 @@
-endpoint: wss://rpc.ibp.network/paseo
+endpoint:
+  - wss://rpc.ibp.network/paseo
+  - wss://asset-hub-paseo-rpc.n.dwellir.com
+  - wss://asset-hub-paseo.dotters.network
+  - wss://sys.turboflakes.io/asset-hub-paseo
+  - wss://pas-rpc.stakeworld.io/assethub
 block: "0x446a006b992b7a760f718f0f7040aa94a10f8c329b46af7315ea7947fac2691e"
 port: 8132
 

--- a/integration-tests/forklift/src/lib/forklift.ts
+++ b/integration-tests/forklift/src/lib/forklift.ts
@@ -95,7 +95,7 @@ export const startForklift = async () => {
   }
 
   console.log("Connecting to forklift…")
-  const timeout = 15000
+  const timeout = 30000
   const success = await Promise.race([
     client
       .getUnsafeApi()


### PR DESCRIPTION
Lately we have a bunch of "can't connect after 15s" fails on our integration tests - My suspicion is that sometimes the action can't connect to the RPC

Previously we had this with chopsticks as well, but we couldn't add fallback endpoints. Now we do

There's another flaky test `Ivalid followSubscription` in zombienet that I'm investigating. I thought I fixed it in #1357, but I've seen it again. 