### PR TITLE
fix: memory spike when decoding multiple SS58 addresses

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Memory spike when decoding multiple SS58 addresses.
+
 ## 2.1.3 - 2026-05-11
 
 ### Fixed

--- a/packages/substrate-bindings/CHANGELOG.md
+++ b/packages/substrate-bindings/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Memory spike when decoding multiple SS58 addresses.
+
 ## 0.20.1 to 0.20.2 - 2026-04-29
 
 ### Fixed

--- a/packages/substrate-bindings/src/utils/ss58-util.ts
+++ b/packages/substrate-bindings/src/utils/ss58-util.ts
@@ -49,9 +49,14 @@ const prefixBytesToNumber = (bytes: Uint8Array) => {
 const pkToBigint = (publicKey: Uint8Array) => {
   let result = 0n
   const dv = new DataView(publicKey.buffer)
-  for (let i = 0; i < 4; i++) {
+  const big64s = Math.floor(publicKey.length / 8)
+  for (let i = 0; i < big64s; i++) {
     result = result << 64n
     result = result | dv.getBigUint64(i * 8)
+  }
+  for (let offset = big64s * 8; offset < publicKey.length; offset++) {
+    result = result << 8n
+    result = result | BigInt(dv.getUint8(offset))
   }
   return result
 }

--- a/packages/substrate-bindings/src/utils/ss58-util.ts
+++ b/packages/substrate-bindings/src/utils/ss58-util.ts
@@ -50,14 +50,10 @@ const pkToBigint = (publicKey: Uint8Array) => {
   let result = 0n
   const dv = new DataView(publicKey.buffer)
   const big64s = Math.floor(publicKey.length / 8)
-  for (let i = 0; i < big64s; i++) {
-    result = result << 64n
-    result = result | dv.getBigUint64(i * 8)
-  }
-  for (let offset = big64s * 8; offset < publicKey.length; offset++) {
-    result = result << 8n
-    result = result | BigInt(dv.getUint8(offset))
-  }
+  for (let i = 0; i < big64s; i++)
+    result = (result << 64n) | dv.getBigUint64(i * 8)
+  for (let offset = big64s * 8; offset < publicKey.length; offset++)
+    result = (result << 8n) | BigInt(dv.getUint8(offset))
   return result
 }
 

--- a/packages/substrate-bindings/src/utils/ss58-util.ts
+++ b/packages/substrate-bindings/src/utils/ss58-util.ts
@@ -46,13 +46,23 @@ const prefixBytesToNumber = (bytes: Uint8Array) => {
   return dv.byteLength === 1 ? dv.getUint8(0) : dv.getUint16(0)
 }
 
+const pkToBigint = (publicKey: Uint8Array) => {
+  let result = 0n
+  const dv = new DataView(publicKey.buffer)
+  for (let i = 0; i < 4; i++) {
+    result = result << 64n
+    result = result | dv.getBigUint64(i * 8)
+  }
+  return result
+}
+
 const withSs58Cache = (fn: (publicKey: Uint8Array) => SS58String) => {
-  let cache: Record<number, any> = {}
+  let cache = new Map<bigint, SS58String>()
   let activityCount = 0
   let latestCount = 0
   const checkActivity = () => {
     if (activityCount === latestCount) {
-      cache = {}
+      cache.clear()
       activityCount = latestCount = 0
     } else {
       latestCount = activityCount
@@ -63,10 +73,11 @@ const withSs58Cache = (fn: (publicKey: Uint8Array) => SS58String) => {
   return (publicKey: Uint8Array): SS58String => {
     if (++activityCount === 1) checkActivity()
 
-    let entry = cache
-    const lastIdx = publicKey.length - 1
-    for (let i = 0; i <= lastIdx; i++) entry = entry[publicKey[i]] ||= {}
-    return (entry[publicKey[lastIdx]] ||= fn(publicKey))
+    const bigKey = pkToBigint(publicKey)
+    if (!cache.has(bigKey)) {
+      cache.set(bigKey, fn(publicKey))
+    }
+    return cache.get(bigKey)!
   }
 }
 


### PR DESCRIPTION
Fixes the big part of #1375

This massively reduces the memory consumption of the cache we have for SS58 addresses. Encoding a public key into an ss58 is a somewhat expensive operation (as it needs to calculate checksums), which quickly adds up when multiple entries have to be decoded.

It seems we actually had a leak with this cache, as the GC was not able to properly clean up after it was cleared. With this change, it reduces the amount of memory used significantly (x10) as well as makes sure the cache is properly cleaned up.

In the future we can improve this by making the cache bounded as well, but for now it solves the massive memory spike reported.