### PR TITLE
fix(ws-middleware): deliver legacy subscription notifications once

### DIFF
--- a/integration-tests/forklift/forklift.yaml
+++ b/integration-tests/forklift/forklift.yaml
@@ -1,9 +1,8 @@
 endpoint:
+  - wss://paseo-rpc.n.dwellir.com
   - wss://rpc.ibp.network/paseo
-  - wss://asset-hub-paseo-rpc.n.dwellir.com
-  - wss://asset-hub-paseo.dotters.network
-  - wss://sys.turboflakes.io/asset-hub-paseo
-  - wss://pas-rpc.stakeworld.io/assethub
+  - wss://paseo.dotters.network
+  - wss://pas-rpc.stakeworld.io
 block: "0x446a006b992b7a760f718f0f7040aa94a10f8c329b46af7315ea7947fac2691e"
 port: 8132
 

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix receiving duplicate legacy notifications on `._request` subscriptions.
+
 ## 2.1.5 - 2026-06-02
 
 ### Fixed

--- a/packages/json-rpc/ws-middleware/CHANGELOG.md
+++ b/packages/json-rpc/ws-middleware/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix receiving duplicate legacy notifications from upstream
+
 ## 0.3.3 to 0.3.4 - 2026-05-19
 
 ### Fixed

--- a/packages/json-rpc/ws-middleware/src/hybrid.ts
+++ b/packages/json-rpc/ws-middleware/src/hybrid.ts
@@ -23,14 +23,15 @@ export const hybridMiddleware = (methods: string[]): Middleware => {
 
   return (base) => {
     const multiplexed = multiplex(base)
-    const modernProvider = modern(multiplexed())
-    const legacyProvider = withLegacy(
-      multiplexed((req) =>
-        ["chainHead_v1", "archive_v1"].every(
-          (prefix) => !req.method.startsWith(prefix),
-        ),
-      ),
-    )
+    // The modern and legacy filters must complement each other, otherwise a
+    // notification is delivered by both providers and the consumer sees it twice.
+    const isModernReq = (req: JsonRpcRequest) =>
+      ["chainHead_v1", "archive_v1"].some((prefix) =>
+        req.method.startsWith(prefix),
+      )
+
+    const modernProvider = modern(multiplexed(isModernReq))
+    const legacyProvider = withLegacy(multiplexed((req) => !isModernReq(req)))
 
     return (onMsg, onHalt) => {
       const modernConnection = modernProvider((message) => {


### PR DESCRIPTION

When a legacy or custom RPC subscription is opened through a `getWsProvider` connection, every notification is delivered to the consumer **twice**.

```ts
const client = createClient(getWsProvider(ENDPOINT))
client
  ._subscribe("statement_subscribeStatement", "statement_unsubscribeStatement", [filter])
  .subscribe({ next: () => count++ }) // count increases by 2 per notification
```
## Root cause

`hybridMiddleware` multiplexes a single socket into a "modern" and a "legacy" provider that share one `msg$` notification stream (see `multiplex`). Each `multiplexed(filter)` call subscribes to that shared stream with its own notification filter.


