### PR TITLE
feat: infer asset from ChainDefinition

### DIFF
--- a/examples/bun/src/custom-signed-extensions.ts
+++ b/examples/bun/src/custom-signed-extensions.ts
@@ -15,22 +15,28 @@ const transfer = api.tx.Balances.transfer_allow_death({
 })
 
 transfer
-  .getEstimatedFees(papiTestCreator)
+  .getEstimatedFees(papiTestCreator, {
+    customSignedExtensions: { CheckAppId: { value: 0 } },
+  })
   .then((estimatedFees) => console.log({ estimatedFees }), console.error)
 
 // TODO: add custom signed-extension support to TxCreator-based flows.
-transfer.createSubmitAndWatch(papiTestCreator).subscribe({
-  next: (e) => {
-    console.log(e.type)
-    if (e.type === "finalized") {
-      console.log("The tx is now in a finalized block, check it out:")
-      console.log(
-        `https://explorer.avail.so/?rpc=wss%3A%2F%2Fturing-rpc.avail.so%2Fws#/explorer/query/${e.block.hash}`,
-      )
-    }
-  },
-  error: console.error,
-  complete() {
-    client.destroy()
-  },
-})
+transfer
+  .createSubmitAndWatch(papiTestCreator, {
+    customSignedExtensions: { CheckAppId: { value: 0 } },
+  })
+  .subscribe({
+    next: (e) => {
+      console.log(e.type)
+      if (e.type === "finalized") {
+        console.log("The tx is now in a finalized block, check it out:")
+        console.log(
+          `https://explorer.avail.so/?rpc=wss%3A%2F%2Fturing-rpc.avail.so%2Fws#/explorer/query/${e.block.hash}`,
+        )
+      }
+    },
+    error: console.error,
+    complete() {
+      client.destroy()
+    },
+  })

--- a/packages/client/src/offline.ts
+++ b/packages/client/src/offline.ts
@@ -3,6 +3,7 @@ import {
   getLookupFn,
   MetadataLookup,
 } from "@polkadot-api/metadata-builders"
+import { TxCreatorBindings, TxPayloadV1 } from "@polkadot-api/polkadot-signer"
 import {
   Blake2256,
   decAnyMetadata,
@@ -12,9 +13,8 @@ import {
 import { fromHex, mergeUint8, toHex } from "@polkadot-api/utils"
 import { concat, NEVER, of } from "rxjs"
 import type { ChainDefinition } from "./descriptors"
-import type { OfflineTxEntry } from "./tx"
+import type { ExtensionConstraints, OfflineTxEntry } from "./tx"
 import type { OfflineApi } from "./types"
-import { TxCreatorBindings, TxPayloadV1 } from "@polkadot-api/polkadot-signer"
 
 const getOfflineExtensions = (
   genesis: string,
@@ -42,7 +42,10 @@ const getOfflineExtensions = (
   return [...mortalityExt, ...nonceExt]
 }
 
-const createOfflineTxEntry = <Arg extends {} | undefined, Asset>(
+const createOfflineTxEntry = <
+  Arg extends {} | undefined,
+  EC extends ExtensionConstraints,
+>(
   bindings: TxCreatorBindings,
   pallet: string,
   name: string,
@@ -50,7 +53,7 @@ const createOfflineTxEntry = <Arg extends {} | undefined, Asset>(
   metadataRaw: Uint8Array,
   lookupFn: MetadataLookup,
   dynamicBuilder: ReturnType<typeof getDynamicBuilder>,
-): OfflineTxEntry<Arg, Asset> => {
+): OfflineTxEntry<Arg, EC> => {
   let codecs
   try {
     codecs = dynamicBuilder.buildCall(pallet, name)

--- a/packages/client/src/offline.ts
+++ b/packages/client/src/offline.ts
@@ -42,7 +42,7 @@ const getOfflineExtensions = (
   return [...mortalityExt, ...nonceExt]
 }
 
-const createOfflineTxEntry = <Arg extends {} | undefined>(
+const createOfflineTxEntry = <Arg extends {} | undefined, Asset>(
   bindings: TxCreatorBindings,
   pallet: string,
   name: string,
@@ -50,7 +50,7 @@ const createOfflineTxEntry = <Arg extends {} | undefined>(
   metadataRaw: Uint8Array,
   lookupFn: MetadataLookup,
   dynamicBuilder: ReturnType<typeof getDynamicBuilder>,
-): OfflineTxEntry<Arg> => {
+): OfflineTxEntry<Arg, Asset> => {
   let codecs
   try {
     codecs = dynamicBuilder.buildCall(pallet, name)

--- a/packages/client/src/static-apis.ts
+++ b/packages/client/src/static-apis.ts
@@ -7,10 +7,10 @@ import { stgGetKey } from "@/utils/stg-get-key"
 import { ChainHead$, RuntimeContext } from "@polkadot-api/observable-client"
 import { TxCreatorBindings } from "@polkadot-api/polkadot-signer"
 import { mergeMap, Observable } from "rxjs"
-import { createTxEntry, Transaction } from "./tx"
+import { createTxEntry, ExtensionConstraints, Transaction } from "./tx"
 import { withWeakCache } from "./utils/with-weak-cache"
 
-export const createStaticApis = <Asset>(
+export const createStaticApis = <EC extends ExtensionConstraints>(
   bindings: TxCreatorBindings,
   chainHead: ChainHead$,
   broadcast$: (tx: Uint8Array) => Observable<never>,
@@ -18,7 +18,7 @@ export const createStaticApis = <Asset>(
 ) => {
   const txFromCallData =
     ({ dynamicBuilder, lookup }: RuntimeContext) =>
-    (callData: Uint8Array): Transaction<Asset> => {
+    (callData: Uint8Array): Transaction<EC> => {
       try {
         const {
           type: pallet,

--- a/packages/client/src/static-apis.ts
+++ b/packages/client/src/static-apis.ts
@@ -10,7 +10,7 @@ import { mergeMap, Observable } from "rxjs"
 import { createTxEntry, Transaction } from "./tx"
 import { withWeakCache } from "./utils/with-weak-cache"
 
-export const createStaticApis = (
+export const createStaticApis = <Asset>(
   bindings: TxCreatorBindings,
   chainHead: ChainHead$,
   broadcast$: (tx: Uint8Array) => Observable<never>,
@@ -18,7 +18,7 @@ export const createStaticApis = (
 ) => {
   const txFromCallData =
     ({ dynamicBuilder, lookup }: RuntimeContext) =>
-    (callData: Uint8Array): Transaction => {
+    (callData: Uint8Array): Transaction<Asset> => {
       try {
         const {
           type: pallet,

--- a/packages/client/src/tx/tx.ts
+++ b/packages/client/src/tx/tx.ts
@@ -26,7 +26,13 @@ import {
   take,
 } from "rxjs"
 import { InvalidTxError, submit, submit$ } from "./submit-fns"
-import { PaymentInfo, Transaction, TxCreatorOptions, TxEntry } from "./types"
+import {
+  ExtensionConstraints,
+  PaymentInfo,
+  Transaction,
+  TxCreatorOptions,
+  TxEntry,
+} from "./types"
 
 export { InvalidTxError, submit, submit$ }
 
@@ -43,14 +49,17 @@ const [, queryInfoDecFallback] = Struct({
   partial_fee: u128,
 })
 
-export const createTxEntry = <Arg extends {} | undefined, Asset>(
+export const createTxEntry = <
+  Arg extends {} | undefined,
+  EC extends ExtensionConstraints,
+>(
   bindings: TxCreatorBindings,
   pallet: string,
   name: string,
   chainHead: ChainHead$,
   broadcast: (tx: Uint8Array) => Observable<never>,
   compatibility: ValueCompat,
-): TxEntry<Arg, Asset> => {
+): TxEntry<Arg, EC> => {
   const getCompatCtx$ = (at: HexString | null) =>
     combineLatest([chainHead.getRuntimeContext$(at), compatibility]).pipe(
       map(([ctx, getCompat]) => ({ ctx, ...getCompat(ctx) })),
@@ -82,10 +91,10 @@ export const createTxEntry = <Arg extends {} | undefined, Asset>(
       ),
     )
 
-  return (arg?: Arg): Transaction<Asset> => {
+  return (arg?: Arg): Transaction<EC> => {
     const create$ = <T extends TxCreator<any>>(
       creator: T,
-      opts: TxCreatorOptions<T, Asset> | undefined,
+      opts: TxCreatorOptions<T, EC> | undefined,
       mockedSignature: boolean,
     ) =>
       combineLatest([
@@ -125,10 +134,10 @@ export const createTxEntry = <Arg extends {} | undefined, Asset>(
         map(fromHex),
       )
 
-    const create: Transaction<Asset>["create"] = (creator, ...[options]) =>
+    const create: Transaction<EC>["create"] = (creator, ...[options]) =>
       firstValueFrom(create$(creator, options, false))
 
-    const createAndSubmit: Transaction<Asset>["createAndSubmit"] = (
+    const createAndSubmit: Transaction<EC>["createAndSubmit"] = (
       creator,
       ...[options]
     ) =>
@@ -136,7 +145,7 @@ export const createTxEntry = <Arg extends {} | undefined, Asset>(
         submit(chainHead, broadcast, tx),
       )
 
-    const createSubmitAndWatch: Transaction<Asset>["createSubmitAndWatch"] = (
+    const createSubmitAndWatch: Transaction<EC>["createSubmitAndWatch"] = (
       creator,
       ...[options]
     ) =>
@@ -146,7 +155,7 @@ export const createTxEntry = <Arg extends {} | undefined, Asset>(
 
     const getPaymentInfoWithOptions = async <T extends TxCreator<any>>(
       creator: T,
-      options: TxCreatorOptions<T, Asset> | undefined,
+      options: TxCreatorOptions<T, EC> | undefined,
     ) => {
       const encoded = await firstValueFrom(create$(creator, options, true))
       const args = toHex(mergeUint8([encoded, u32.enc(encoded.length)]))
@@ -179,7 +188,7 @@ export const createTxEntry = <Arg extends {} | undefined, Asset>(
       )
     }
 
-    const getPaymentInfo: Transaction<Asset>["getPaymentInfo"] = async (
+    const getPaymentInfo: Transaction<EC>["getPaymentInfo"] = async (
       creator,
       ...[options]
     ) => getPaymentInfoWithOptions(creator, options)
@@ -189,7 +198,7 @@ export const createTxEntry = <Arg extends {} | undefined, Asset>(
         getCallData$(arg, null).pipe(map(({ callData }) => callData)),
       )
 
-    const getEstimatedFees: Transaction<Asset>["getEstimatedFees"] = async (
+    const getEstimatedFees: Transaction<EC>["getEstimatedFees"] = async (
       creator,
       ...[options]
     ) => (await getPaymentInfoWithOptions(creator, options)).partial_fee

--- a/packages/client/src/tx/tx.ts
+++ b/packages/client/src/tx/tx.ts
@@ -43,14 +43,14 @@ const [, queryInfoDecFallback] = Struct({
   partial_fee: u128,
 })
 
-export const createTxEntry = <Arg extends {} | undefined>(
+export const createTxEntry = <Arg extends {} | undefined, Asset>(
   bindings: TxCreatorBindings,
   pallet: string,
   name: string,
   chainHead: ChainHead$,
   broadcast: (tx: Uint8Array) => Observable<never>,
   compatibility: ValueCompat,
-): TxEntry<Arg> => {
+): TxEntry<Arg, Asset> => {
   const getCompatCtx$ = (at: HexString | null) =>
     combineLatest([chainHead.getRuntimeContext$(at), compatibility]).pipe(
       map(([ctx, getCompat]) => ({ ctx, ...getCompat(ctx) })),
@@ -82,10 +82,10 @@ export const createTxEntry = <Arg extends {} | undefined>(
       ),
     )
 
-  return (arg?: Arg): Transaction => {
+  return (arg?: Arg): Transaction<Asset> => {
     const create$ = <T extends TxCreator<any>>(
       creator: T,
-      opts: TxCreatorOptions<T> | undefined,
+      opts: TxCreatorOptions<T, Asset> | undefined,
       mockedSignature: boolean,
     ) =>
       combineLatest([
@@ -125,10 +125,10 @@ export const createTxEntry = <Arg extends {} | undefined>(
         map(fromHex),
       )
 
-    const create: Transaction["create"] = (creator, ...[options]) =>
+    const create: Transaction<Asset>["create"] = (creator, ...[options]) =>
       firstValueFrom(create$(creator, options, false))
 
-    const createAndSubmit: Transaction["createAndSubmit"] = (
+    const createAndSubmit: Transaction<Asset>["createAndSubmit"] = (
       creator,
       ...[options]
     ) =>
@@ -136,7 +136,7 @@ export const createTxEntry = <Arg extends {} | undefined>(
         submit(chainHead, broadcast, tx),
       )
 
-    const createSubmitAndWatch: Transaction["createSubmitAndWatch"] = (
+    const createSubmitAndWatch: Transaction<Asset>["createSubmitAndWatch"] = (
       creator,
       ...[options]
     ) =>
@@ -146,7 +146,7 @@ export const createTxEntry = <Arg extends {} | undefined>(
 
     const getPaymentInfoWithOptions = async <T extends TxCreator<any>>(
       creator: T,
-      options: TxCreatorOptions<T> | undefined,
+      options: TxCreatorOptions<T, Asset> | undefined,
     ) => {
       const encoded = await firstValueFrom(create$(creator, options, true))
       const args = toHex(mergeUint8([encoded, u32.enc(encoded.length)]))
@@ -179,7 +179,7 @@ export const createTxEntry = <Arg extends {} | undefined>(
       )
     }
 
-    const getPaymentInfo: Transaction["getPaymentInfo"] = async (
+    const getPaymentInfo: Transaction<Asset>["getPaymentInfo"] = async (
       creator,
       ...[options]
     ) => getPaymentInfoWithOptions(creator, options)
@@ -189,7 +189,7 @@ export const createTxEntry = <Arg extends {} | undefined>(
         getCallData$(arg, null).pipe(map(({ callData }) => callData)),
       )
 
-    const getEstimatedFees: Transaction["getEstimatedFees"] = async (
+    const getEstimatedFees: Transaction<Asset>["getEstimatedFees"] = async (
       creator,
       ...[options]
     ) => (await getPaymentInfoWithOptions(creator, options)).partial_fee

--- a/packages/client/src/tx/types.ts
+++ b/packages/client/src/tx/types.ts
@@ -73,13 +73,38 @@ export type TxFinalized = {
   txHash: HexString
 } & TxEventsPayload
 export type TxFinalizedPayload = { txHash: HexString } & TxEventsPayload
+
+type UncoveredRequiredExtensions<
+  TxC extends TxCreator<any>,
+  EC extends ExtensionConstraints,
+> = Exclude<
+  EC["requiredExtensions"]["_type"],
+  (TxC extends TxCreator<infer Specs> ? Specs[number]["id"] : never) | undefined
+>
+type UncoveredRequiredExtensionArgs<
+  TxC extends TxCreator<any>,
+  EC extends ExtensionConstraints,
+> = {
+  [K in UncoveredRequiredExtensions<TxC, EC>]: EC["extensions"][K]
+}
+
+type Optionalize<T> =
+  IsAny<T> extends true
+    ? { customSignedExtensions?: T }
+    : {} extends T
+      ? { customSignedExtensions?: T }
+      : { customSignedExtensions: T }
+
 export type TxCreatorOptions<
   T extends TxCreator<any>,
   EC extends ExtensionConstraints,
-> = ArgsForCreator<T, EC>
+> = Simplify<
+  ArgsForCreator<T, EC> &
+    Optionalize<Simplify<UncoveredRequiredExtensionArgs<T, EC>>>
+>
 
 type IsAny<T> = 0 extends 1 & T ? true : false
-type Optionalize<T> =
+type OptionalizeArgs<T> =
   IsAny<T> extends true
     ? [txOptions?: T]
     : {} extends T
@@ -88,7 +113,7 @@ type Optionalize<T> =
 type TxCreatorOptionsArg<
   T extends TxCreator<any>,
   EC extends ExtensionConstraints,
-> = Optionalize<TxCreatorOptions<T, EC>>
+> = OptionalizeArgs<TxCreatorOptions<T, EC>>
 
 export type PaymentInfo = {
   weight: {
@@ -251,3 +276,7 @@ export type TxFromBinary<EC extends ExtensionConstraints> = {
    */
   (callData: Uint8Array, options?: PullOptions): Promise<Transaction<EC>>
 }
+
+type Simplify<T> = {
+  [K in keyof T]: T[K]
+} & {}

--- a/packages/client/src/tx/types.ts
+++ b/packages/client/src/tx/types.ts
@@ -1,6 +1,6 @@
 import { PullOptions, TxCallData } from "@/types"
 import { SystemEvent } from "@polkadot-api/observable-client"
-import { TxCreator } from "@polkadot-api/polkadot-signer"
+import { ArgsForCreator, TxCreator } from "@polkadot-api/polkadot-signer"
 import { Enum, HexString } from "@polkadot-api/substrate-bindings"
 import { Observable } from "rxjs"
 
@@ -72,16 +72,25 @@ export type TxFinalized = {
   txHash: HexString
 } & TxEventsPayload
 export type TxFinalizedPayload = { txHash: HexString } & TxEventsPayload
-export type TxCreatorOptions<T extends TxCreator<any>> =
-  T extends TxCreator<infer A> ? A : never
+export type TxCreatorOptions<T extends TxCreator<any>, Asset> = ArgsForCreator<
+  T,
+  {
+    extensions: {
+      ChargeAssetTxPayment: {
+        additionalSigned: never
+        type: Asset
+      }
+    }
+  }
+>
 
 type IsAny<T> = 0 extends 1 & T ? true : false
-type TxCreatorOptionsArg<T extends TxCreator<any>> =
-  IsAny<TxCreatorOptions<T>> extends true
-    ? [txOptions?: TxCreatorOptions<T>]
-    : {} extends TxCreatorOptions<T>
-      ? [txOptions?: TxCreatorOptions<T>]
-      : [txOptions: TxCreatorOptions<T>]
+type TxCreatorOptionsArg<T extends TxCreator<any>, Asset> =
+  IsAny<TxCreatorOptions<T, Asset>> extends true
+    ? [txOptions?: TxCreatorOptions<T, Asset>]
+    : {} extends TxCreatorOptions<T, Asset>
+      ? [txOptions?: TxCreatorOptions<T, Asset>]
+      : [txOptions: TxCreatorOptions<T, Asset>]
 
 export type PaymentInfo = {
   weight: {
@@ -96,7 +105,7 @@ export type PaymentInfo = {
   partial_fee: bigint
 }
 
-export type Transaction = {
+export type Transaction<Asset> = {
   /**
    * Creates a signed transaction asynchronously. If the creator fails (or the
    * user cancels the signature) it'll throw an error.
@@ -107,7 +116,7 @@ export type Transaction = {
    */
   create<T extends TxCreator<any>>(
     creator: T,
-    ...txOptions: TxCreatorOptionsArg<T>
+    ...txOptions: TxCreatorOptionsArg<T, Asset>
   ): Promise<Uint8Array>
 
   /**
@@ -122,7 +131,7 @@ export type Transaction = {
    */
   createSubmitAndWatch<T extends TxCreator<any>>(
     creator: T,
-    ...txOptions: TxCreatorOptionsArg<T>
+    ...txOptions: TxCreatorOptionsArg<T, Asset>
   ): Observable<TxEvent>
 
   /**
@@ -137,7 +146,7 @@ export type Transaction = {
    */
   createAndSubmit<T extends TxCreator<any>>(
     creator: T,
-    ...txOptions: TxCreatorOptionsArg<T>
+    ...txOptions: TxCreatorOptionsArg<T, Asset>
   ): Promise<TxFinalizedPayload>
 
   /**
@@ -164,7 +173,7 @@ export type Transaction = {
    */
   getEstimatedFees<T extends TxCreator<any>>(
     creator: T,
-    ...txOptions: TxCreatorOptionsArg<T>
+    ...txOptions: TxCreatorOptionsArg<T, Asset>
   ): Promise<bigint>
 
   /**
@@ -177,7 +186,7 @@ export type Transaction = {
    */
   getPaymentInfo<T extends TxCreator<any>>(
     creator: T,
-    ...txOptions: TxCreatorOptionsArg<T>
+    ...txOptions: TxCreatorOptionsArg<T, Asset>
   ): Promise<PaymentInfo>
 
   /**
@@ -187,7 +196,7 @@ export type Transaction = {
   decodedCall: TxCallData
 }
 
-export type TxEntry<Arg extends {} | undefined> = {
+export type TxEntry<Arg extends {} | undefined, Asset> = {
   /**
    * Synchronously create the transaction object ready to sign, submit,
    * estimate fees, etc.
@@ -195,7 +204,7 @@ export type TxEntry<Arg extends {} | undefined> = {
    * @param args  All parameters required by the transaction.
    * @returns Transaction object.
    */
-  (...args: Arg extends undefined ? [] : [data: Arg]): Transaction
+  (...args: Arg extends undefined ? [] : [data: Arg]): Transaction<Asset>
 }
 
 export type OfflineTxEntry<Arg extends {} | undefined> = (input: Arg) => {
@@ -223,7 +232,7 @@ export type OfflineTxEntry<Arg extends {} | undefined> = (input: Arg) => {
   decodedCall: TxCallData
 }
 
-export type TxFromBinary = {
+export type TxFromBinary<Asset> = {
   /**
    * Asynchronously create the transaction object from a binary call data ready
    * to sign, submit, estimate fees, etc.
@@ -231,5 +240,5 @@ export type TxFromBinary = {
    * @param callData  SCALE-encoded call data.
    * @returns Transaction object.
    */
-  (callData: Uint8Array, options?: PullOptions): Promise<Transaction>
+  (callData: Uint8Array, options?: PullOptions): Promise<Transaction<Asset>>
 }

--- a/packages/client/src/tx/types.ts
+++ b/packages/client/src/tx/types.ts
@@ -1,3 +1,4 @@
+import { PlainDescriptor } from "@/descriptors"
 import { PullOptions, TxCallData } from "@/types"
 import { SystemEvent } from "@polkadot-api/observable-client"
 import { ArgsForCreator, TxCreator } from "@polkadot-api/polkadot-signer"
@@ -72,25 +73,22 @@ export type TxFinalized = {
   txHash: HexString
 } & TxEventsPayload
 export type TxFinalizedPayload = { txHash: HexString } & TxEventsPayload
-export type TxCreatorOptions<T extends TxCreator<any>, Asset> = ArgsForCreator<
-  T,
-  {
-    extensions: {
-      ChargeAssetTxPayment: {
-        additionalSigned: never
-        type: Asset
-      }
-    }
-  }
->
+export type TxCreatorOptions<
+  T extends TxCreator<any>,
+  EC extends ExtensionConstraints,
+> = ArgsForCreator<T, EC>
 
 type IsAny<T> = 0 extends 1 & T ? true : false
-type TxCreatorOptionsArg<T extends TxCreator<any>, Asset> =
-  IsAny<TxCreatorOptions<T, Asset>> extends true
-    ? [txOptions?: TxCreatorOptions<T, Asset>]
-    : {} extends TxCreatorOptions<T, Asset>
-      ? [txOptions?: TxCreatorOptions<T, Asset>]
-      : [txOptions: TxCreatorOptions<T, Asset>]
+type Optionalize<T> =
+  IsAny<T> extends true
+    ? [txOptions?: T]
+    : {} extends T
+      ? [txOptions?: T]
+      : [txOptions: T]
+type TxCreatorOptionsArg<
+  T extends TxCreator<any>,
+  EC extends ExtensionConstraints,
+> = Optionalize<TxCreatorOptions<T, EC>>
 
 export type PaymentInfo = {
   weight: {
@@ -105,7 +103,12 @@ export type PaymentInfo = {
   partial_fee: bigint
 }
 
-export type Transaction<Asset> = {
+export type ExtensionConstraints = {
+  extensions: Record<string, { value?: any; additionalSigned?: any }>
+  requiredExtensions: PlainDescriptor<string>
+}
+
+export type Transaction<EC extends ExtensionConstraints> = {
   /**
    * Creates a signed transaction asynchronously. If the creator fails (or the
    * user cancels the signature) it'll throw an error.
@@ -116,7 +119,7 @@ export type Transaction<Asset> = {
    */
   create<T extends TxCreator<any>>(
     creator: T,
-    ...txOptions: TxCreatorOptionsArg<T, Asset>
+    ...txOptions: TxCreatorOptionsArg<T, EC>
   ): Promise<Uint8Array>
 
   /**
@@ -131,7 +134,7 @@ export type Transaction<Asset> = {
    */
   createSubmitAndWatch<T extends TxCreator<any>>(
     creator: T,
-    ...txOptions: TxCreatorOptionsArg<T, Asset>
+    ...txOptions: TxCreatorOptionsArg<T, EC>
   ): Observable<TxEvent>
 
   /**
@@ -146,7 +149,7 @@ export type Transaction<Asset> = {
    */
   createAndSubmit<T extends TxCreator<any>>(
     creator: T,
-    ...txOptions: TxCreatorOptionsArg<T, Asset>
+    ...txOptions: TxCreatorOptionsArg<T, EC>
   ): Promise<TxFinalizedPayload>
 
   /**
@@ -173,7 +176,7 @@ export type Transaction<Asset> = {
    */
   getEstimatedFees<T extends TxCreator<any>>(
     creator: T,
-    ...txOptions: TxCreatorOptionsArg<T, Asset>
+    ...txOptions: TxCreatorOptionsArg<T, EC>
   ): Promise<bigint>
 
   /**
@@ -186,7 +189,7 @@ export type Transaction<Asset> = {
    */
   getPaymentInfo<T extends TxCreator<any>>(
     creator: T,
-    ...txOptions: TxCreatorOptionsArg<T, Asset>
+    ...txOptions: TxCreatorOptionsArg<T, EC>
   ): Promise<PaymentInfo>
 
   /**
@@ -196,7 +199,10 @@ export type Transaction<Asset> = {
   decodedCall: TxCallData
 }
 
-export type TxEntry<Arg extends {} | undefined, Asset> = {
+export type TxEntry<
+  Arg extends {} | undefined,
+  EC extends ExtensionConstraints,
+> = {
   /**
    * Synchronously create the transaction object ready to sign, submit,
    * estimate fees, etc.
@@ -204,12 +210,13 @@ export type TxEntry<Arg extends {} | undefined, Asset> = {
    * @param args  All parameters required by the transaction.
    * @returns Transaction object.
    */
-  (...args: Arg extends undefined ? [] : [data: Arg]): Transaction<Asset>
+  (...args: Arg extends undefined ? [] : [data: Arg]): Transaction<EC>
 }
 
-export type OfflineTxEntry<Arg extends {} | undefined, Asset> = (
-  input: Arg,
-) => {
+export type OfflineTxEntry<
+  Arg extends {} | undefined,
+  EC extends ExtensionConstraints,
+> = (input: Arg) => {
   /**
    * Creates a signed transaction asynchronously. If the creator fails (or the
    * user cancels the signature) it'll throw an error.
@@ -220,7 +227,7 @@ export type OfflineTxEntry<Arg extends {} | undefined, Asset> = (
    */
   create: <T extends TxCreator<any>>(
     creator: T,
-    txOptions: TxCreatorOptions<T, Asset> & { nonce: number },
+    txOptions: TxCreatorOptions<T, EC> & { nonce: number },
   ) => Promise<Uint8Array>
 
   /**
@@ -234,7 +241,7 @@ export type OfflineTxEntry<Arg extends {} | undefined, Asset> = (
   decodedCall: TxCallData
 }
 
-export type TxFromBinary<Asset> = {
+export type TxFromBinary<EC extends ExtensionConstraints> = {
   /**
    * Asynchronously create the transaction object from a binary call data ready
    * to sign, submit, estimate fees, etc.
@@ -242,5 +249,5 @@ export type TxFromBinary<Asset> = {
    * @param callData  SCALE-encoded call data.
    * @returns Transaction object.
    */
-  (callData: Uint8Array, options?: PullOptions): Promise<Transaction<Asset>>
+  (callData: Uint8Array, options?: PullOptions): Promise<Transaction<EC>>
 }

--- a/packages/client/src/tx/types.ts
+++ b/packages/client/src/tx/types.ts
@@ -207,7 +207,9 @@ export type TxEntry<Arg extends {} | undefined, Asset> = {
   (...args: Arg extends undefined ? [] : [data: Arg]): Transaction<Asset>
 }
 
-export type OfflineTxEntry<Arg extends {} | undefined> = (input: Arg) => {
+export type OfflineTxEntry<Arg extends {} | undefined, Asset> = (
+  input: Arg,
+) => {
   /**
    * Creates a signed transaction asynchronously. If the creator fails (or the
    * user cancels the signature) it'll throw an error.
@@ -218,7 +220,7 @@ export type OfflineTxEntry<Arg extends {} | undefined> = (input: Arg) => {
    */
   create: <T extends TxCreator<any>>(
     creator: T,
-    txOptions: T extends TxCreator<infer A> ? A & { nonce: number } : never,
+    txOptions: TxCreatorOptions<T, Asset> & { nonce: number },
   ) => Promise<Uint8Array>
 
   /**

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -84,10 +84,13 @@ export type TxApi<A extends Record<string, Record<string, any>>, Asset> = {
   }
 }
 
-export type OfflineTxApi<A extends Record<string, Record<string, any>>> = {
+export type OfflineTxApi<
+  A extends Record<string, Record<string, any>>,
+  Asset,
+> = {
   [K in keyof A]: {
     [KK in keyof A[K]]: A[K][KK] extends {} | undefined
-      ? OfflineTxEntry<A[K][KK]>
+      ? OfflineTxEntry<A[K][KK], Asset>
       : unknown
   }
 }
@@ -189,7 +192,7 @@ export type TypedApi<D extends ChainDefinition, Safe = true> = {
 
 export type OfflineApi<D extends ChainDefinition> = {
   constants: OfflineConstApi<ConstFromPalletsDef<D["descriptors"]["pallets"]>>
-  tx: OfflineTxApi<TxFromPalletsDef<D["descriptors"]["pallets"]>>
+  tx: OfflineTxApi<TxFromPalletsDef<D["descriptors"]["pallets"]>, D["asset"]>
 }
 
 export type TransactionValidityError<D extends ChainDefinition> =

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -17,6 +17,7 @@ import { EvClient } from "./event"
 import { RuntimeCall } from "./runtime-call"
 import { StorageEntry } from "./storage"
 import type {
+  ExtensionConstraints,
   OfflineTxEntry,
   TxBroadcastEvent,
   TxEntry,
@@ -76,21 +77,24 @@ export type ViewFnApi<A extends Record<string, Record<string, any>>> = {
   }
 }
 
-export type TxApi<A extends Record<string, Record<string, any>>, Asset> = {
+export type TxApi<
+  A extends Record<string, Record<string, any>>,
+  EC extends ExtensionConstraints,
+> = {
   [K in keyof A]: {
     [KK in keyof A[K]]: A[K][KK] extends {} | undefined
-      ? TxEntry<A[K][KK], Asset>
-      : TxEntry<any, Asset>
+      ? TxEntry<A[K][KK], EC>
+      : TxEntry<any, EC>
   }
 }
 
 export type OfflineTxApi<
   A extends Record<string, Record<string, any>>,
-  Asset,
+  EC extends ExtensionConstraints,
 > = {
   [K in keyof A]: {
     [KK in keyof A[K]]: A[K][KK] extends {} | undefined
-      ? OfflineTxEntry<A[K][KK], Asset>
+      ? OfflineTxEntry<A[K][KK], EC>
       : unknown
   }
 }
@@ -180,19 +184,19 @@ export type StaticApis<D extends ChainDefinition, Safe> = {
 }
 
 export type TypedApi<D extends ChainDefinition, Safe = true> = {
-  tx: TxApi<TxFromPalletsDef<D["descriptors"]["pallets"]>, D["asset"]>
+  tx: TxApi<TxFromPalletsDef<D["descriptors"]["pallets"]>, D>
   constants: ConstApi<ConstFromPalletsDef<D["descriptors"]["pallets"]>>
   apis: RuntimeCallsApi<ApisFromDef<D["descriptors"]["apis"]>>
   view: ViewFnApi<ViewFnsFromPalletsDef<D["descriptors"]["pallets"]>>
   query: StorageApi<QueryFromPalletsDef<D["descriptors"]["pallets"]>>
   event: EvApi<EventsFromPalletsDef<D["descriptors"]["pallets"]>>
-  txFromCallData: TxFromBinary<D["asset"]>
+  txFromCallData: TxFromBinary<D>
   getStaticApis: (options?: PullOptions) => Promise<StaticApis<D, Safe>>
 }
 
 export type OfflineApi<D extends ChainDefinition> = {
   constants: OfflineConstApi<ConstFromPalletsDef<D["descriptors"]["pallets"]>>
-  tx: OfflineTxApi<TxFromPalletsDef<D["descriptors"]["pallets"]>, D["asset"]>
+  tx: OfflineTxApi<TxFromPalletsDef<D["descriptors"]["pallets"]>, D>
 }
 
 export type TransactionValidityError<D extends ChainDefinition> =

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -76,11 +76,11 @@ export type ViewFnApi<A extends Record<string, Record<string, any>>> = {
   }
 }
 
-export type TxApi<A extends Record<string, Record<string, any>>> = {
+export type TxApi<A extends Record<string, Record<string, any>>, Asset> = {
   [K in keyof A]: {
     [KK in keyof A[K]]: A[K][KK] extends {} | undefined
-      ? TxEntry<A[K][KK]>
-      : TxEntry<any>
+      ? TxEntry<A[K][KK], Asset>
+      : TxEntry<any, Asset>
   }
 }
 
@@ -177,13 +177,13 @@ export type StaticApis<D extends ChainDefinition, Safe> = {
 }
 
 export type TypedApi<D extends ChainDefinition, Safe = true> = {
-  tx: TxApi<TxFromPalletsDef<D["descriptors"]["pallets"]>>
+  tx: TxApi<TxFromPalletsDef<D["descriptors"]["pallets"]>, D["asset"]>
   constants: ConstApi<ConstFromPalletsDef<D["descriptors"]["pallets"]>>
   apis: RuntimeCallsApi<ApisFromDef<D["descriptors"]["apis"]>>
   view: ViewFnApi<ViewFnsFromPalletsDef<D["descriptors"]["pallets"]>>
   query: StorageApi<QueryFromPalletsDef<D["descriptors"]["pallets"]>>
   event: EvApi<EventsFromPalletsDef<D["descriptors"]["pallets"]>>
-  txFromCallData: TxFromBinary
+  txFromCallData: TxFromBinary<D["asset"]>
   getStaticApis: (options?: PullOptions) => Promise<StaticApis<D, Safe>>
 }
 

--- a/packages/signers/ledger-signer/src/ledger-signer.ts
+++ b/packages/signers/ledger-signer/src/ledger-signer.ts
@@ -304,7 +304,7 @@ export class LedgerSigner {
     path1: number,
     path2: number = 0,
   ) {
-    const creator: TxCreator<{}> = async (payload, _, mocked) => {
+    const creator: TxCreator<[]> = async (payload, _, mocked) => {
       const txExtVersion = payload.txExtVersion ?? 0
       if (txExtVersion !== 0)
         throw new Error("Only txExtVersion 0 is allowed for extrinsic v4")
@@ -371,12 +371,9 @@ export class LedgerSigner {
         : v.slice(PUBKEY_LEN[this.#schema]),
     )
 
-    return Object.assign(
-      withNonce(publicKey)(withCommonExtensions()(creator)),
-      {
-        publicKey,
-        signBytes: getSignBytes(async (x) => this.#sign(path1, path2, x)),
-      },
-    )
+    return Object.assign(withNonce(publicKey)(withCommonExtensions(creator)), {
+      publicKey,
+      signBytes: getSignBytes(async (x) => this.#sign(path1, path2, x)),
+    })
   }
 }

--- a/packages/signers/ledger-signer/src/ledger-signer.ts
+++ b/packages/signers/ledger-signer/src/ledger-signer.ts
@@ -304,7 +304,7 @@ export class LedgerSigner {
     path1: number,
     path2: number = 0,
   ) {
-    const creator: TxCreator<[]> = async (payload, _, mocked) => {
+    const creator: TxCreator<[]> = async (payload, _, _bindings, mocked) => {
       const txExtVersion = payload.txExtVersion ?? 0
       if (txExtVersion !== 0)
         throw new Error("Only txExtVersion 0 is allowed for extrinsic v4")

--- a/packages/signers/pjs-signer/src/from-pjs-account.ts
+++ b/packages/signers/pjs-signer/src/from-pjs-account.ts
@@ -39,7 +39,7 @@ export function getTxCreatorFromPjs(
       type: "bytes",
     }).then(({ signature }) => fromHex(signature))
   const publicKey = getPublicKey(address)
-  const creator: TxCreator<{}> = async (payload, _, mocked) => {
+  const creator: TxCreator<[]> = async (payload, _, mocked) => {
     const decMeta = unifyMetadata(decAnyMetadata(payload.context.metadata))
 
     const pjs: Partial<SignerPayloadJSON> = {}
@@ -109,7 +109,7 @@ export function getTxCreatorFromPjs(
     )
   }
 
-  return Object.assign(withNonce(publicKey)(withCommonExtensions()(creator)), {
+  return Object.assign(withNonce(publicKey)(withCommonExtensions(creator)), {
     publicKey,
     signBytes,
   })

--- a/packages/signers/pjs-signer/src/from-pjs-account.ts
+++ b/packages/signers/pjs-signer/src/from-pjs-account.ts
@@ -39,7 +39,7 @@ export function getTxCreatorFromPjs(
       type: "bytes",
     }).then(({ signature }) => fromHex(signature))
   const publicKey = getPublicKey(address)
-  const creator: TxCreator<[]> = async (payload, _, mocked) => {
+  const creator: TxCreator<[]> = async (payload, _, _bindings, mocked) => {
     const decMeta = unifyMetadata(decAnyMetadata(payload.context.metadata))
 
     const pjs: Partial<SignerPayloadJSON> = {}

--- a/packages/signers/polkadot-signer/src/index.ts
+++ b/packages/signers/polkadot-signer/src/index.ts
@@ -1,1 +1,2 @@
 export type * from "./types"
+export type * from "./txArgs"

--- a/packages/signers/polkadot-signer/src/txArgs.ts
+++ b/packages/signers/polkadot-signer/src/txArgs.ts
@@ -2,8 +2,8 @@ export interface TxChainDefinition {
   extensions: Record<
     string,
     {
-      type: unknown
-      additionalSigned: unknown
+      value?: unknown
+      additionalSigned?: unknown
     }
   >
 }

--- a/packages/signers/polkadot-signer/src/txArgs.ts
+++ b/packages/signers/polkadot-signer/src/txArgs.ts
@@ -1,0 +1,42 @@
+export interface TxChainDefinition {
+  extensions: Record<
+    string,
+    {
+      type: unknown
+      additionalSigned: unknown
+    }
+  >
+}
+
+export interface TxArgSpec {
+  chain: TxChainDefinition
+  id: string
+  params: object
+}
+type ApplyArgSpec<
+  Spec extends TxArgSpec,
+  Chain extends TxChainDefinition,
+> = (Spec & { chain: Chain })["params"]
+
+export type ArgsForArgSpecs<
+  Specs extends readonly TxArgSpec[],
+  Chain extends TxChainDefinition,
+> = Simplify<
+  UnionToIntersection<
+    {
+      [I in keyof Specs]: Specs[I] extends TxArgSpec
+        ? ApplyArgSpec<Specs[I], Chain>
+        : never
+    }[number]
+  >
+>
+
+// Type utils
+type Simplify<T> = {
+  [K in keyof T]: T[K]
+} & {}
+type UnionToIntersection<U> = (
+  U extends unknown ? (arg: U) => void : never
+) extends (arg: infer I) => void
+  ? I
+  : never

--- a/packages/signers/polkadot-signer/src/types.ts
+++ b/packages/signers/polkadot-signer/src/types.ts
@@ -1,4 +1,5 @@
 import { Observable } from "rxjs"
+import { ArgsForArgSpecs, TxArgSpec, TxChainDefinition } from "./txArgs"
 
 export interface TxPayloadV1 {
   /**
@@ -106,15 +107,21 @@ export interface TxPayloadV1 {
   }
 }
 
+declare const txCreatorArgSpecs: unique symbol
 /**
  * Creates a SCALE-encoded extrinsic (ready to broadcast).
  */
-export type TxCreator<T> = (
-  input: TxPayloadV1,
-  opts: T,
-  bindings: TxCreatorBindings,
-  mockedSignature: boolean,
-) => Promise<string>
+export interface TxCreator<Specs extends TxArgSpec[]> {
+  [txCreatorArgSpecs]?: Specs;
+  <Chain extends TxChainDefinition>(
+    input: TxPayloadV1,
+    opts: ArgsForArgSpecs<Specs, Chain>,
+    bindings: TxCreatorBindings,
+    mockedSignature: boolean,
+  ): Promise<string>
+}
+export type ArgsForCreator<Creator, Chain extends TxChainDefinition> =
+  Creator extends TxCreator<infer Specs> ? ArgsForArgSpecs<Specs, Chain> : never
 
 interface Block {
   /**
@@ -210,4 +217,6 @@ export type TxCreatorBindings = {
   hasher: (payload: Uint8Array) => Observable<Uint8Array>
 }
 
-export type TxCreatorEnhancer<T> = <A>(inner: TxCreator<A>) => TxCreator<T & A>
+export type TxCreatorEnhancer<T extends TxArgSpec[]> = <A extends TxArgSpec[]>(
+  inner: TxCreator<A>,
+) => TxCreator<[...T, ...A]>

--- a/packages/signers/signer/src/from-raw-signer.ts
+++ b/packages/signers/signer/src/from-raw-signer.ts
@@ -1,5 +1,9 @@
 import { merkleizeMetadata } from "@polkadot-api/merkleize-metadata"
-import { TxCreator, TxCreatorEnhancer } from "@polkadot-api/polkadot-signer"
+import {
+  TxArgSpec,
+  TxCreator,
+  TxCreatorEnhancer,
+} from "@polkadot-api/polkadot-signer"
 import {
   createV4Tx,
   getSignBytes,
@@ -18,7 +22,7 @@ export const getTxCreator = (
   signingType: "Ecdsa" | "Ed25519" | "Sr25519",
   sign: (input: Uint8Array) => Promise<Uint8Array> | Uint8Array,
 ) => {
-  const creator: TxCreator<{}> = async (
+  const creator: TxCreator<[]> = async (
     payload,
     _,
     txCreatorBindings,
@@ -58,7 +62,7 @@ export const getTxCreator = (
     )
   }
 
-  return Object.assign(withNonce(publicKey)(withCommonExtensions()(creator)), {
+  return Object.assign(withNonce(publicKey)(withCommonExtensions(creator)), {
     publicKey,
     signBytes: getSignBytes(sign),
   })
@@ -69,7 +73,14 @@ const oneU8 = Uint8Array.from([1])
 
 export const withMetadataHash: (
   networkInfo: Parameters<typeof merkleizeMetadata>[1],
-) => TxCreatorEnhancer<{}> = (networkInfo) => (inner) => {
+) => TxCreatorEnhancer<
+  [
+    TxArgSpec & {
+      id: "CheckMetadataHash"
+      params: {}
+    },
+  ]
+> = (networkInfo) => (inner) => {
   return async (payload, opts, bindings, mocked) => {
     if (payload.extensions.find(({ id }) => id === METADATA_IDENTIFIER))
       return inner(payload, opts, bindings, mocked)

--- a/packages/signers/signers-common/src/lookupFromMetadata.ts
+++ b/packages/signers/signers-common/src/lookupFromMetadata.ts
@@ -1,0 +1,26 @@
+import {
+  getDynamicBuilder,
+  getLookupFn,
+  MetadataLookup,
+} from "@polkadot-api/metadata-builders"
+import { decAnyMetadata, unifyMetadata } from "@polkadot-api/substrate-bindings"
+
+let memoized: {
+  key: string
+  value: {
+    lookupFn: MetadataLookup
+    builder: ReturnType<typeof getDynamicBuilder>
+  }
+} | null = null
+
+export const getLookupFromRawMetadata = (metadata: string) => {
+  if (memoized?.key === metadata) return memoized.value
+
+  const lookupFn = getLookupFn(unifyMetadata(decAnyMetadata(metadata)))
+  const builder = getDynamicBuilder(lookupFn)
+  memoized = {
+    key: metadata,
+    value: { lookupFn, builder },
+  }
+  return memoized.value
+}

--- a/packages/signers/signers-common/src/tx-creator/common-enhancer/extensions/index.ts
+++ b/packages/signers/signers-common/src/tx-creator/common-enhancer/extensions/index.ts
@@ -208,7 +208,7 @@ type ChargeAssetTransactionPaymentParams<Chain extends TxChainDefinition> = {
   /**
    * Asset to pay fees with. Default: `None`
    */
-  asset?: Chain["extensions"]["ChargeAssetTxPayment"]["type"]
+  asset?: Chain["extensions"]["ChargeAssetTxPayment"]["value"]
 }
 export interface ChargeAssetTxPaymentSpec extends TxArgSpec {
   id: "ChargeAssetTxPayment"

--- a/packages/signers/signers-common/src/tx-creator/common-enhancer/extensions/index.ts
+++ b/packages/signers/signers-common/src/tx-creator/common-enhancer/extensions/index.ts
@@ -1,12 +1,23 @@
 import {
   getDynamicBuilder,
+  getLookupFn,
   MetadataLookup,
 } from "@polkadot-api/metadata-builders"
-import { TxCreatorBindings, TxPayloadV1 } from "@polkadot-api/polkadot-signer"
-import { compact } from "@polkadot-api/substrate-bindings"
+import {
+  ArgsForArgSpecs,
+  TxArgSpec,
+  TxChainDefinition,
+  TxCreatorBindings,
+  TxCreatorEnhancer,
+  TxPayloadV1,
+} from "@polkadot-api/polkadot-signer"
+import {
+  compact,
+  decAnyMetadata,
+  unifyMetadata,
+} from "@polkadot-api/substrate-bindings"
 import { toHex } from "@polkadot-api/utils"
 import { firstValueFrom, skipWhile } from "rxjs"
-import type { CommonOpts } from ".."
 import { mortal } from "./mortal-enc"
 import { getSystemVersionProp } from "./system-version"
 
@@ -25,39 +36,140 @@ const both = (extra: string, additionalSigned: string) => ({
   additionalSigned,
 })
 
-export const extensions: Record<
-  string,
-  (opts: {
-    bindings: TxCreatorBindings
-    context: TxPayloadV1["context"]
-    lookupFn: MetadataLookup
-    dynamicBuilder: ReturnType<typeof getDynamicBuilder>
-    opts: CommonOpts
-  }) => Promise<{ extra: string; additionalSigned: string }>
-> = {
-  CheckGenesis: async ({ context: { genesisHash } }) =>
-    additionalSigned(genesisHash),
-  CheckMetadataHash: async () => both(zero, zero),
-  CheckSpecVersion: async ({ lookupFn, dynamicBuilder }) =>
-    additionalSigned(
-      getSystemVersionProp(
-        lookupFn,
-        dynamicBuilder,
-        "CheckSpecVersion",
-        "spec_version",
-      ),
-    ),
+const enhancerFromExtensionPayload =
+  <T extends TxArgSpec>(
+    id: T["id"],
+    mapFn: (opts: {
+      bindings: TxCreatorBindings
+      context: TxPayloadV1["context"]
+      lookupFn: MetadataLookup
+      dynamicBuilder: ReturnType<typeof getDynamicBuilder>
+      opts: ArgsForArgSpecs<[T], TxChainDefinition>
+    }) => Promise<{ extra: string; additionalSigned: string }>,
+  ): TxCreatorEnhancer<[T]> =>
+  (inner) =>
+  async (payload, opts, bindings, mocked) => {
+    if (payload.extensions.some((ext) => ext.id === id))
+      return inner(payload, opts, bindings, mocked)
 
-  CheckTxVersion: async ({ lookupFn, dynamicBuilder }) =>
-    additionalSigned(
-      getSystemVersionProp(
-        lookupFn,
-        dynamicBuilder,
-        "CheckTxVersion",
-        "transaction_version",
-      ),
+    const lookupFn = getLookupFn(
+      unifyMetadata(decAnyMetadata(payload.context.metadata)),
+    )
+    if (!(id in lookupFn.metadata.extrinsic.extensions))
+      return inner(payload, opts, bindings, mocked)
+
+    const builder = getDynamicBuilder(lookupFn)
+
+    const myOptions = opts as ArgsForArgSpecs<[T], TxChainDefinition>
+    const extension = await mapFn({
+      bindings,
+      context: payload.context,
+      dynamicBuilder: builder,
+      lookupFn,
+      opts: myOptions,
+    })
+
+    return inner(
+      {
+        ...payload,
+        extensions: [
+          ...payload.extensions,
+          {
+            id,
+            ...extension,
+          },
+        ],
+      },
+      opts,
+      bindings,
+      mocked,
+    )
+  }
+
+export const withCheckGenesis = enhancerFromExtensionPayload<
+  TxArgSpec & {
+    id: "CheckGenesis"
+    params: {}
+  }
+>("CheckGenesis", async ({ context: { genesisHash } }) =>
+  additionalSigned(genesisHash),
+)
+
+export const withCheckMetadataHash = enhancerFromExtensionPayload<
+  TxArgSpec & {
+    id: "CheckMetadataHash"
+    params: {}
+  }
+>("CheckMetadataHash", async () => both(zero, zero))
+
+export const withCheckSpecVersion = enhancerFromExtensionPayload<
+  TxArgSpec & {
+    id: "CheckSpecVersion"
+    params: {}
+  }
+>("CheckSpecVersion", async ({ lookupFn, dynamicBuilder }) =>
+  additionalSigned(
+    getSystemVersionProp(
+      lookupFn,
+      dynamicBuilder,
+      "CheckSpecVersion",
+      "spec_version",
     ),
-  CheckMortality: async ({
+  ),
+)
+
+export const withCheckTxVersion = enhancerFromExtensionPayload<
+  TxArgSpec & {
+    id: "CheckTxVersion"
+    params: {}
+  }
+>("CheckTxVersion", async ({ lookupFn, dynamicBuilder }) =>
+  additionalSigned(
+    getSystemVersionProp(
+      lookupFn,
+      dynamicBuilder,
+      "CheckTxVersion",
+      "transaction_version",
+    ),
+  ),
+)
+
+export const withChargeTransactionPayment = enhancerFromExtensionPayload<
+  TxArgSpec & {
+    id: "ChargeTransactionPayment"
+    params: {
+      tip?: bigint
+    }
+  }
+>("ChargeTransactionPayment", async ({ opts: { tip } }) =>
+  value(toHex(compact.enc(tip ?? 0))),
+)
+
+export const withCheckMortality = enhancerFromExtensionPayload<
+  TxArgSpec & {
+    id: "CheckMortality"
+    params: {
+      /**
+       * Mortality of the transaction.
+       * If no `at` is passed, transaction will be alive for, at least, `period`
+       * number of blocks after the current best block height.
+       * If `at` is passed, transaction will be alive for `period` number of
+       * blocks after `at`.
+       *
+       * Default: `{ mortal: true, period: 20 }`
+       */
+      mortality?:
+        | { mortal: false }
+        | {
+            mortal: true
+            period: number
+            at?: { hash: string; number: number }
+          }
+    }
+  }
+>(
+  "CheckMortality",
+  async ({
     bindings: { blocks },
     context: { genesisHash },
     opts: { mortality },
@@ -92,16 +204,29 @@ export const extensions: Record<
       finalized.hash,
     )
   },
-  ChargeTransactionPayment: async ({ opts: { tip } }) =>
-    value(toHex(compact.enc(tip ?? 0))),
-  ChargeAssetTxPayment: async ({
-    opts: { tip, asset },
-    lookupFn,
-    dynamicBuilder,
-  }) => {
-    const { enc } = dynamicBuilder.buildDefinition(
-      lookupFn.metadata.extrinsic.extensions["ChargeAssetTxPayment"].type,
-    )
-    return value(toHex(enc({ tip: tip ?? 0, asset_id: asset })))
-  },
+)
+
+type ChargeAssetTransactionPaymentParams<Chain extends TxChainDefinition> = {
+  /**
+   * Tip in fundamental units. Default: `0`
+   */
+  tip?: bigint
+  /**
+   * Asset to pay fees with. Default: `None`
+   */
+  asset?: Chain["extensions"]["ChargeAssetTxPayment"]["type"]
 }
+export interface ChargeAssetTxPaymentSpec extends TxArgSpec {
+  id: "ChargeAssetTxPayment"
+  params: ChargeAssetTransactionPaymentParams<this["chain"]>
+}
+export const withChargeAssetTxPayment =
+  enhancerFromExtensionPayload<ChargeAssetTxPaymentSpec>(
+    "ChargeAssetTxPayment",
+    async ({ opts: { tip, asset }, lookupFn, dynamicBuilder }) => {
+      const { enc } = dynamicBuilder.buildDefinition(
+        lookupFn.metadata.extrinsic.extensions["ChargeAssetTxPayment"].type,
+      )
+      return value(toHex(enc({ tip: tip ?? 0, asset_id: asset })))
+    },
+  )

--- a/packages/signers/signers-common/src/tx-creator/common-enhancer/extensions/index.ts
+++ b/packages/signers/signers-common/src/tx-creator/common-enhancer/extensions/index.ts
@@ -1,6 +1,6 @@
+import { getLookupFromRawMetadata } from "@/lookupFromMetadata"
 import {
   getDynamicBuilder,
-  getLookupFn,
   MetadataLookup,
 } from "@polkadot-api/metadata-builders"
 import {
@@ -11,11 +11,7 @@ import {
   TxCreatorEnhancer,
   TxPayloadV1,
 } from "@polkadot-api/polkadot-signer"
-import {
-  compact,
-  decAnyMetadata,
-  unifyMetadata,
-} from "@polkadot-api/substrate-bindings"
+import { compact } from "@polkadot-api/substrate-bindings"
 import { toHex } from "@polkadot-api/utils"
 import { firstValueFrom, skipWhile } from "rxjs"
 import { mortal } from "./mortal-enc"
@@ -52,13 +48,11 @@ const enhancerFromExtensionPayload =
     if (payload.extensions.some((ext) => ext.id === id))
       return inner(payload, opts, bindings, mocked)
 
-    const lookupFn = getLookupFn(
-      unifyMetadata(decAnyMetadata(payload.context.metadata)),
+    const { lookupFn, builder } = getLookupFromRawMetadata(
+      payload.context.metadata,
     )
     if (!(id in lookupFn.metadata.extrinsic.extensions))
       return inner(payload, opts, bindings, mocked)
-
-    const builder = getDynamicBuilder(lookupFn)
 
     const myOptions = opts as ArgsForArgSpecs<[T], TxChainDefinition>
     const extension = await mapFn({

--- a/packages/signers/signers-common/src/tx-creator/common-enhancer/index.ts
+++ b/packages/signers/signers-common/src/tx-creator/common-enhancer/index.ts
@@ -1,87 +1,47 @@
-import { getDynamicBuilder, getLookupFn } from "@polkadot-api/metadata-builders"
-import { TxCreatorEnhancer, TxPayloadV1 } from "@polkadot-api/polkadot-signer"
-import { decAnyMetadata, unifyMetadata } from "@polkadot-api/substrate-bindings"
-import { toHex } from "@polkadot-api/utils"
-import { extensions } from "./extensions"
+import {
+  TxArgSpec,
+  TxCreator,
+  TxCreatorEnhancer,
+} from "@polkadot-api/polkadot-signer"
+import {
+  withChargeAssetTxPayment,
+  withChargeTransactionPayment,
+  withCheckGenesis,
+  withCheckMetadataHash,
+  withCheckMortality,
+  withCheckSpecVersion,
+  withCheckTxVersion,
+} from "./extensions"
 
-export type CommonOpts = {
-  /**
-   * Tip in fundamental units. Default: `0`
-   */
-  tip?: bigint
-  /**
-   * Asset to pay fees with. Default: `None`
-   */
-  asset?: unknown
-  /**
-   * Mortality of the transaction.
-   * If no `at` is passed, transaction will be alive for, at least, `period`
-   * number of blocks after the current best block height.
-   * If `at` is passed, transaction will be alive for `period` number of blocks
-   * after `at`.
-   *
-   * Default: `{ mortal: true, period: 20 }`
-   */
-  mortality?:
-    | { mortal: false }
-    | { mortal: true; period: number; at?: { hash: string; number: number } }
+export type { ChargeAssetTxPaymentSpec } from "./extensions"
+
+type EnhancerSpecs<E> = E extends TxCreatorEnhancer<infer T> ? T : never
+type PipeEnhancerSpecs<
+  Enhancers extends readonly TxCreatorEnhancer<TxArgSpec[]>[],
+  Acc extends TxArgSpec[] = [],
+> = Enhancers extends readonly [
+  infer Head extends TxCreatorEnhancer<TxArgSpec[]>,
+  ...infer Tail extends readonly TxCreatorEnhancer<TxArgSpec[]>[],
+]
+  ? PipeEnhancerSpecs<Tail, [...EnhancerSpecs<Head>, ...Acc]>
+  : Acc
+
+function pipe<Enhancers extends readonly TxCreatorEnhancer<TxArgSpec[]>[]>(
+  ...enhancers: Enhancers
+): TxCreatorEnhancer<PipeEnhancerSpecs<Enhancers>> {
+  return ((inner: TxCreator<TxArgSpec[]>) =>
+    enhancers.reduce(
+      (acc, enhancer) => enhancer(acc),
+      inner,
+    )) as TxCreatorEnhancer<PipeEnhancerSpecs<Enhancers>>
 }
 
-export const withCommonExtensions =
-  (): TxCreatorEnhancer<CommonOpts> => (inner) => {
-    return async (payload, opts, txCreatorBindings, mocked) => {
-      const lookupFn = getLookupFn(
-        unifyMetadata(decAnyMetadata(payload.context.metadata)),
-      )
-      const builder = getDynamicBuilder(lookupFn)
-      const exts = Object.values(lookupFn.metadata.extrinsic.extensions)
-      const foundExts = payload.extensions.reduce(
-        (acc, val) => {
-          acc[val.id] = val
-          return acc
-        },
-        {} as Record<string, (typeof payload.extensions)[number]>,
-      )
-      const encoded: TxPayloadV1["extensions"] = (
-        await Promise.all(
-          exts.map(async ({ identifier, type, additionalSigned }) => {
-            const ext = foundExts[identifier]
-            if (ext) return ext
-            const mapper = extensions[identifier]
-            if (mapper) {
-              return {
-                id: identifier,
-                ...(await mapper({
-                  bindings: txCreatorBindings,
-                  context: payload.context,
-                  lookupFn,
-                  dynamicBuilder: builder,
-                  opts,
-                })),
-              }
-            }
-            // if there is no mapper, try if the extension is optional (or void)
-            try {
-              const exp = builder.buildDefinition(type).enc(undefined)
-              const imp = builder
-                .buildDefinition(additionalSigned)
-                .enc(undefined)
-              return {
-                id: identifier,
-                extra: toHex(exp),
-                additionalSigned: toHex(imp),
-              }
-            } catch {
-              return null
-            }
-          }),
-        )
-      ).filter((v) => v != null)
-      return inner(
-        { ...payload, extensions: encoded },
-        opts,
-        txCreatorBindings,
-        mocked,
-      )
-    }
-  }
+export const withCommonExtensions = pipe(
+  withChargeAssetTxPayment,
+  withChargeTransactionPayment,
+  withCheckGenesis,
+  withCheckMetadataHash,
+  withCheckMortality,
+  withCheckSpecVersion,
+  withCheckTxVersion,
+)

--- a/packages/signers/signers-common/src/tx-creator/common-enhancer/index.ts
+++ b/packages/signers/signers-common/src/tx-creator/common-enhancer/index.ts
@@ -1,8 +1,10 @@
+import { getLookupFromRawMetadata } from "@/lookupFromMetadata"
 import {
   TxArgSpec,
   TxCreator,
   TxCreatorEnhancer,
 } from "@polkadot-api/polkadot-signer"
+import { toHex } from "@polkadot-api/utils"
 import {
   withChargeAssetTxPayment,
   withChargeTransactionPayment,
@@ -36,6 +38,51 @@ function pipe<Enhancers extends readonly TxCreatorEnhancer<TxArgSpec[]>[]>(
     )) as TxCreatorEnhancer<PipeEnhancerSpecs<Enhancers>>
 }
 
+const withEmptyExtensions: TxCreatorEnhancer<[]> =
+  (inner) => async (payload, opts, bindings, mocked) => {
+    const extensions = [...payload.extensions]
+    const foundExts = extensions.reduce(
+      (acc, val) => {
+        acc[val.id] = val
+        return acc
+      },
+      {} as Record<string, (typeof payload.extensions)[number]>,
+    )
+
+    const { lookupFn, builder } = getLookupFromRawMetadata(
+      payload.context.metadata,
+    )
+
+    Object.values(lookupFn.metadata.extrinsic.extensions).forEach(
+      ({ identifier, type, additionalSigned }) => {
+        if (identifier in foundExts) return
+
+        // Try filling it in as void
+        try {
+          const exp = builder.buildDefinition(type).enc(undefined)
+          const imp = builder.buildDefinition(additionalSigned).enc(undefined)
+          extensions.push({
+            id: identifier,
+            extra: toHex(exp),
+            additionalSigned: toHex(imp),
+          })
+        } catch {
+          return
+        }
+      },
+    )
+
+    return inner(
+      {
+        ...payload,
+        extensions,
+      },
+      opts,
+      bindings,
+      mocked,
+    )
+  }
+
 export const withCommonExtensions = pipe(
   withChargeAssetTxPayment,
   withChargeTransactionPayment,
@@ -44,4 +91,5 @@ export const withCommonExtensions = pipe(
   withCheckMortality,
   withCheckSpecVersion,
   withCheckTxVersion,
+  withEmptyExtensions,
 )

--- a/packages/signers/signers-common/src/tx-creator/common-enhancer/index.ts
+++ b/packages/signers/signers-common/src/tx-creator/common-enhancer/index.ts
@@ -83,8 +83,56 @@ const withEmptyExtensions: TxCreatorEnhancer<[]> =
     )
   }
 
+const withCustomExtensions: TxCreatorEnhancer<[]> =
+  (inner) => async (payload, opts, bindings, mocked) => {
+    const customSignedExtensions = ((opts as any).customSignedExtensions ??
+      {}) as Record<
+      string,
+      {
+        value: unknown
+        additionalSigned: unknown
+      }
+    >
+    const { lookupFn, builder } = getLookupFromRawMetadata(
+      payload.context.metadata,
+    )
+
+    const extensions = [...payload.extensions]
+    Object.values(lookupFn.metadata.extrinsic.extensions).forEach(
+      ({ identifier, type, additionalSigned }) => {
+        const params = customSignedExtensions[identifier]
+        if (!params) return
+
+        try {
+          const exp = builder.buildDefinition(type).enc(params.value)
+          const imp = builder
+            .buildDefinition(additionalSigned)
+            .enc(params.additionalSigned)
+          extensions.push({
+            id: identifier,
+            extra: toHex(exp),
+            additionalSigned: toHex(imp),
+          })
+        } catch {
+          throw new Error(`Invalid extension ${identifier} parameter`)
+        }
+      },
+    )
+
+    return inner(
+      {
+        ...payload,
+        extensions,
+      },
+      opts,
+      bindings,
+      mocked,
+    )
+  }
+
 export const withCommonExtensions = pipe(
   withEmptyExtensions,
+  withCustomExtensions,
   withChargeAssetTxPayment,
   withChargeTransactionPayment,
   withCheckGenesis,

--- a/packages/signers/signers-common/src/tx-creator/common-enhancer/index.ts
+++ b/packages/signers/signers-common/src/tx-creator/common-enhancer/index.ts
@@ -84,6 +84,7 @@ const withEmptyExtensions: TxCreatorEnhancer<[]> =
   }
 
 export const withCommonExtensions = pipe(
+  withEmptyExtensions,
   withChargeAssetTxPayment,
   withChargeTransactionPayment,
   withCheckGenesis,
@@ -91,5 +92,4 @@ export const withCommonExtensions = pipe(
   withCheckMortality,
   withCheckSpecVersion,
   withCheckTxVersion,
-  withEmptyExtensions,
 )

--- a/packages/signers/signers-common/src/tx-creator/nonce-enhancer/index.ts
+++ b/packages/signers/signers-common/src/tx-creator/nonce-enhancer/index.ts
@@ -1,18 +1,11 @@
-import { getDynamicBuilder, getLookupFn } from "@polkadot-api/metadata-builders"
+import { getLookupFromRawMetadata } from "@/lookupFromMetadata"
 import {
   ArgsForArgSpecs,
   TxArgSpec,
   TxChainDefinition,
   TxCreatorEnhancer,
 } from "@polkadot-api/polkadot-signer"
-import {
-  decAnyMetadata,
-  u16,
-  u32,
-  u64,
-  u8,
-  unifyMetadata,
-} from "@polkadot-api/substrate-bindings"
+import { u16, u32, u64, u8 } from "@polkadot-api/substrate-bindings"
 import { toHex } from "@polkadot-api/utils"
 import {
   catchError,
@@ -130,10 +123,10 @@ export const withNonce =
             }),
           ),
         ))
-      const lookupFn = getLookupFn(
-        unifyMetadata(decAnyMetadata(payload.context.metadata)),
+      const { lookupFn, builder } = getLookupFromRawMetadata(
+        payload.context.metadata,
       )
-      const builder = getDynamicBuilder(lookupFn)
+
       const nonceLookupType =
         lookupFn.metadata.extrinsic.extensions[NONCE_ID]?.type
       if (nonceLookupType != null) {

--- a/packages/signers/signers-common/src/tx-creator/nonce-enhancer/index.ts
+++ b/packages/signers/signers-common/src/tx-creator/nonce-enhancer/index.ts
@@ -1,5 +1,10 @@
 import { getDynamicBuilder, getLookupFn } from "@polkadot-api/metadata-builders"
-import { TxCreatorEnhancer } from "@polkadot-api/polkadot-signer"
+import {
+  ArgsForArgSpecs,
+  TxArgSpec,
+  TxChainDefinition,
+  TxCreatorEnhancer,
+} from "@polkadot-api/polkadot-signer"
 import {
   decAnyMetadata,
   u16,
@@ -32,18 +37,25 @@ const lenToDecoder = {
   8: u64.dec,
 }
 
-type Opts = {
-  /**
-   * Nonce for the transaction.
-   * Default: higher nonce found in any tip of the chain.
-   */
-  nonce?: number
+export interface NonceArgSpec extends TxArgSpec {
+  id: "CheckNonce"
+  params: {
+    /**
+     * Nonce for the transaction.
+     * Default: higher nonce found in any tip of the chain.
+     */
+    nonce?: number
+  }
 }
 
 export const withNonce =
-  (pubkey: Uint8Array): TxCreatorEnhancer<Opts> =>
+  (pubkey: Uint8Array): TxCreatorEnhancer<[NonceArgSpec]> =>
   (inner) => {
     return async (payload, opts, txCreatorBindings, mocked) => {
+      const nonceOptions = opts as ArgsForArgSpecs<
+        [NonceArgSpec],
+        TxChainDefinition
+      >
       if (payload.extensions.find(({ id }) => id === NONCE_ID))
         return inner(payload, opts, txCreatorBindings, mocked)
       const getNonceAtBlock = (at: string) =>
@@ -89,7 +101,7 @@ export const withNonce =
           ),
         ).pipe(take(1))
       const nonce =
-        opts.nonce ??
+        nonceOptions.nonce ??
         (await firstValueFrom(
           txCreatorBindings.blocks.pipe(
             // with first finalized we know the observable is settled


### PR DESCRIPTION
The TxCreator interface gets more complex, but I like that it's very granular on the extensions it can take.

TBD do a better wiring up from descriptors to the `TxChainDefinition`. Currently I'm passing the Asset down to avoid changing codegen, but my idea is to make the client completely independent from the Asset. It will pass down the types available from the metadata, and each signed extension will be responsible to take what they need from there.