### PR TITLE
ci: missing zombie-cli dep

### DIFF
--- a/.github/workflows/zombienet.yml
+++ b/.github/workflows/zombienet.yml
@@ -46,7 +46,9 @@ jobs:
         run: pnpm install
       - uses: cargo-bins/cargo-binstall@v1.20.0
       - name: Install zombienet
-        run: cargo binstall --locked zombie-cli
+        run: |
+          sudo apt-get update && sudo apt-get install -y protobuf-compiler
+          cargo binstall --locked -y zombie-cli
       - name: Download Polkadot and parachain binaries
         run: |
           _files=(polkadot polkadot-execute-worker polkadot-prepare-worker)


### PR DESCRIPTION
Once in a while, `binstall` does not not hit cache with zombie-cli binary, and it compiles it. In this case, there is a dependency missing, and the whole workflow fails. It is very annoying to rerun, this fixes it for that specific corner case.