### PR TITLE
fix(tx-utils): sign with the payload's specVersion/transactionVersion

### DIFF
--- a/packages/tx-utils/CHANGELOG.md
+++ b/packages/tx-utils/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Immortal transactions were signed with the era bytes (`0x00`) as the `CheckMortality` checkpoint instead of the genesis hash, producing invalid signatures for every immortal pjs payload.
+- `CheckSpecVersion`/`CheckTxVersion` were signed with the `System.Version` constants of the metadata blob instead of the values carried by the pjs payload, producing invalid signatures whenever the metadata used for signing lags behind a runtime upgrade.
 
 ## 0.3.1 to 0.3.3 - 2026-05-19
 

--- a/packages/tx-utils/CHANGELOG.md
+++ b/packages/tx-utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Immortal transactions were signed with the era bytes (`0x00`) as the `CheckMortality` checkpoint instead of the genesis hash, producing invalid signatures for every immortal pjs payload.
+
 ## 0.3.1 to 0.3.3 - 2026-05-19
 
 ### Fixed

--- a/packages/tx-utils/package.json
+++ b/packages/tx-utils/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build-core": "tsc --noEmit && rollup -c ../../rollup.config.js",
     "build": "pnpm build-core",
-    "test": "echo 'no tests'",
+    "test": "vitest",
     "lint": "prettier --check README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
     "format": "prettier --write README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\""
   },
@@ -37,5 +37,8 @@
     "@polkadot-api/substrate-bindings": "workspace:*",
     "@polkadot-api/utils": "workspace:*",
     "@polkadot-api/metadata-builders": "workspace:*"
+  },
+  "devDependencies": {
+    "@polkadot-api/metadata-fixtures": "workspace:*"
   }
 }

--- a/packages/tx-utils/src/from-pjs-to-tx-data.ts
+++ b/packages/tx-utils/src/from-pjs-to-tx-data.ts
@@ -165,6 +165,10 @@ export const fromPjsToTxData = (
     mortality,
     tip: BigInt(fromPjsHexStringToNumber(input.tip)),
     nonce: fromPjsHexStringToNumber(input.nonce) as number,
+    specVersion: fromPjsHexStringToNumber(input.specVersion) as number,
+    transactionVersion: fromPjsHexStringToNumber(
+      input.transactionVersion,
+    ) as number,
     metadataHash:
       input.mode === 1 && input.metadataHash
         ? fromHex(input.metadataHash)

--- a/packages/tx-utils/src/from-pjs-to-tx-data.ts
+++ b/packages/tx-utils/src/from-pjs-to-tx-data.ts
@@ -151,7 +151,7 @@ export const fromPjsToTxData = (
   const eraDecoded = mortalityDec(input.era)
   const mortality: Mortality =
     eraDecoded.type === "inmortal"
-      ? { mortal: false, genesisHash: input.era }
+      ? { mortal: false, genesisHash }
       : {
           mortal: true,
           blockHash: input.blockHash,

--- a/packages/tx-utils/src/new-helper.ts
+++ b/packages/tx-utils/src/new-helper.ts
@@ -91,10 +91,15 @@ export const getTxHelper = (
   const fromPjsToInputRaw = (
     pjsPayload: SignerPayloadJSON,
   ): { input: TxInputsRaw; blockNumber: number } => {
-    const { tip, mortality, genesisHash, nonce, asset } = fromPjsToTxData(
-      lookup.metadata,
-      pjsPayload,
-    )
+    const {
+      tip,
+      mortality,
+      genesisHash,
+      nonce,
+      asset,
+      specVersion,
+      transactionVersion,
+    } = fromPjsToTxData(lookup.metadata, pjsPayload)
 
     const signedExtensions = lookup.metadata.extrinsic.signedExtensions[0].map(
       ({ identifier, type, additionalSigned }): SignedExtension => {
@@ -106,7 +111,7 @@ export const getTxHelper = (
           case "CheckNonce":
             return CheckNonce(nonce)
           case "CheckSpecVersion":
-            return CheckSpecVersion(lookup)
+            return CheckSpecVersion(lookup, specVersion)
           case "ChargeAssetTxPayment":
             return ChargeAssetTxPayment(tip, asset)
           case "ChargeTransactionPayment":
@@ -114,7 +119,7 @@ export const getTxHelper = (
           case "CheckMortality":
             return CheckMortality(mortality)
           case "CheckTxVersion":
-            return CheckTxVersion(lookup)
+            return CheckTxVersion(lookup, transactionVersion)
         }
 
         if (

--- a/packages/tx-utils/src/signed-extensions/chain/CheckSpecVersion.ts
+++ b/packages/tx-utils/src/signed-extensions/chain/CheckSpecVersion.ts
@@ -2,5 +2,11 @@ import { MetadataLookup } from "@polkadot-api/metadata-builders"
 import type { SignedExtension } from "../internal-types"
 import { empty, signedExtension, systemVersionProp } from "../utils"
 
-export const CheckSpecVersion = (lookupFn: MetadataLookup): SignedExtension =>
-  signedExtension(empty, systemVersionProp("spec_version", lookupFn))
+export const CheckSpecVersion = (
+  lookupFn: MetadataLookup,
+  specVersion?: number,
+): SignedExtension =>
+  signedExtension(
+    empty,
+    systemVersionProp("spec_version", lookupFn, specVersion),
+  )

--- a/packages/tx-utils/src/signed-extensions/chain/CheckTxVersion.ts
+++ b/packages/tx-utils/src/signed-extensions/chain/CheckTxVersion.ts
@@ -2,5 +2,11 @@ import { MetadataLookup } from "@polkadot-api/metadata-builders"
 import type { SignedExtension } from "../internal-types"
 import { empty, signedExtension, systemVersionProp } from "../utils"
 
-export const CheckTxVersion = (lookupFn: MetadataLookup): SignedExtension =>
-  signedExtension(empty, systemVersionProp("transaction_version", lookupFn))
+export const CheckTxVersion = (
+  lookupFn: MetadataLookup,
+  transactionVersion?: number,
+): SignedExtension =>
+  signedExtension(
+    empty,
+    systemVersionProp("transaction_version", lookupFn, transactionVersion),
+  )

--- a/packages/tx-utils/src/signed-extensions/get-signed-extension-parts.ts
+++ b/packages/tx-utils/src/signed-extensions/get-signed-extension-parts.ts
@@ -25,7 +25,16 @@ export const getSignedExtensionParts = (
   dynamicBuilder: ReturnType<typeof getDynamicBuilder>,
   data: TxData,
 ) => {
-  const { tip, mortality, genesisHash, nonce, asset, metadataHash } = data
+  const {
+    tip,
+    mortality,
+    genesisHash,
+    nonce,
+    asset,
+    metadataHash,
+    specVersion,
+    transactionVersion,
+  } = data
   const signedExtensions = lookup.metadata.extrinsic.signedExtensions[0].map(
     ({ identifier, type, additionalSigned }): SignedExtension => {
       switch (identifier) {
@@ -36,7 +45,7 @@ export const getSignedExtensionParts = (
         case "CheckNonce":
           return CheckNonce(nonce)
         case "CheckSpecVersion":
-          return CheckSpecVersion(lookup)
+          return CheckSpecVersion(lookup, specVersion)
         case "ChargeAssetTxPayment":
           return ChargeAssetTxPayment(tip, asset)
         case "ChargeTransactionPayment":
@@ -44,7 +53,7 @@ export const getSignedExtensionParts = (
         case "CheckMortality":
           return CheckMortality(mortality)
         case "CheckTxVersion":
-          return CheckTxVersion(lookup)
+          return CheckTxVersion(lookup, transactionVersion)
       }
 
       if (

--- a/packages/tx-utils/src/signed-extensions/utils.ts
+++ b/packages/tx-utils/src/signed-extensions/utils.ts
@@ -15,6 +15,7 @@ export const signedExtension = (
 export const systemVersionProp = (
   propName: string,
   lookupFn: MetadataLookup,
+  value?: number,
 ) => {
   const dynamicBuilder = getDynamicBuilder(lookupFn)
 
@@ -31,7 +32,7 @@ export const systemVersionProp = (
     systemVersion.value[propName].id,
   ).enc
 
-  return valueEnc(systemVersionDec(constant.value)[propName])
+  return valueEnc(value ?? systemVersionDec(constant.value)[propName])
 }
 
 export const EMPTY_SIGNED_EXTENSION = signedExtension(empty, empty)

--- a/packages/tx-utils/src/types.ts
+++ b/packages/tx-utils/src/types.ts
@@ -84,6 +84,8 @@ export type TxData = {
   mortality: Mortality
   genesisHash: HexString
   nonce: number
+  specVersion: number
+  transactionVersion: number
 }
 
 export type TxInputsRaw = {

--- a/packages/tx-utils/tests/pjs-tx-helper.spec.ts
+++ b/packages/tx-utils/tests/pjs-tx-helper.spec.ts
@@ -1,0 +1,141 @@
+import { getKsmMetadataBuffer } from "@polkadot-api/metadata-fixtures"
+import {
+  metadata as metadataCodec,
+  u32,
+  v15,
+} from "@polkadot-api/substrate-bindings"
+import { fromHex, mergeUint8, toHex } from "@polkadot-api/utils"
+import { beforeAll, describe, expect, it } from "vitest"
+import { getPjsTxHelper, getTxHelper, SignerPayloadJSON } from "@/."
+
+// kusama
+const GENESIS =
+  "0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe"
+const BLOCK_HASH =
+  "0xb10cb10cb10cb10cb10cb10cb10cb10cb10cb10cb10cb10cb10cb10cb10cb10c"
+const BLOCK_NUMBER = 12345678
+
+// System.Version constants of the ksm metadata fixture
+const SPEC_VERSION = 1000000
+const TX_VERSION = 24
+
+// ksm fixture signedExtensions: CheckNonZeroSender, CheckSpecVersion, CheckTxVersion,
+// CheckGenesis, CheckMortality, CheckNonce, CheckWeight, ChargeTransactionPayment
+const SIGNED_EXTENSIONS = [
+  "CheckNonZeroSender",
+  "CheckSpecVersion",
+  "CheckTxVersion",
+  "CheckGenesis",
+  "CheckMortality",
+  "CheckNonce",
+  "CheckWeight",
+  "ChargeTransactionPayment",
+]
+
+const getPayload = (
+  props: Partial<SignerPayloadJSON> = {},
+): SignerPayloadJSON => ({
+  address: "HNZata7iMYWmk5RvZRTiAsSDhV8366zq2YGb3tLH5Upf74F",
+  blockHash: BLOCK_HASH,
+  blockNumber: `0x${BLOCK_NUMBER.toString(16).padStart(8, "0")}`,
+  era: "0x00",
+  genesisHash: GENESIS,
+  // System.remark("talisman parity")
+  method: "0x00003c74616c69736d616e20706172697479",
+  nonce: "0x00000005",
+  specVersion: `0x${SPEC_VERSION.toString(16).padStart(8, "0")}`,
+  tip: "0x00000000000000000000000000000000",
+  transactionVersion: `0x${TX_VERSION.toString(16).padStart(8, "0")}`,
+  signedExtensions: SIGNED_EXTENSIONS,
+  version: 4,
+  ...props,
+})
+
+let metadataRaw: Uint8Array
+beforeAll(async () => {
+  // the fixture is a bare v15 blob: wrap it in the versioned envelope
+  const bare = await getKsmMetadataBuffer()
+  metadataRaw = metadataCodec.enc({
+    magicNumber: 0x6174656d,
+    metadata: { tag: "v15", value: v15.dec(bare) },
+  })
+})
+
+describe("getPjsTxHelper", () => {
+  it("uses the genesis hash as mortality checkpoint for immortal payloads", () => {
+    const { extra, additionalSigned } = getPjsTxHelper(metadataRaw)(
+      getPayload({ era: "0x00" }),
+    )
+
+    // era ++ compact(nonce) ++ compact(tip)
+    expect(toHex(extra)).toBe(toHex(Uint8Array.from([0x00, 0x14, 0x00])))
+    expect(toHex(additionalSigned)).toBe(
+      toHex(
+        mergeUint8([
+          u32.enc(SPEC_VERSION),
+          u32.enc(TX_VERSION),
+          fromHex(GENESIS),
+          // CheckMortality checkpoint: the genesis hash
+          fromHex(GENESIS),
+        ]),
+      ),
+    )
+  })
+
+  it("uses the block hash as mortality checkpoint for mortal payloads", () => {
+    // period 64, phase 47
+    const { extra, additionalSigned } = getPjsTxHelper(metadataRaw)(
+      getPayload({ era: "0xf502" }),
+    )
+
+    expect(toHex(extra)).toBe(toHex(Uint8Array.from([0xf5, 0x02, 0x14, 0x00])))
+    expect(toHex(additionalSigned)).toBe(
+      toHex(
+        mergeUint8([
+          u32.enc(SPEC_VERSION),
+          u32.enc(TX_VERSION),
+          fromHex(GENESIS),
+          // CheckMortality checkpoint: the block hash
+          fromHex(BLOCK_HASH),
+        ]),
+      ),
+    )
+  })
+})
+
+describe("getTxHelper", () => {
+  it("round-trips an immortal payload", () => {
+    const helper = getTxHelper(toHex(metadataRaw))
+    const { input, blockNumber } = helper.fromPjsToInputRaw(
+      getPayload({ era: "0x00" }),
+    )
+
+    const mortality = input.extensions.find((x) => x.id === "CheckMortality")!
+    expect(toHex(mortality.extra)).toBe("0x00")
+    expect(toHex(mortality.additionalSigned)).toBe(GENESIS)
+
+    const decoded = helper.getTxInputDecoded(input, blockNumber)
+    expect(decoded.mortality).toBe(null)
+    expect(decoded.genesisHash).toBe(GENESIS)
+    expect(decoded.nonce).toBe(5)
+    expect(decoded.tip).toBe(0n)
+  })
+
+  it("round-trips a mortal payload", () => {
+    const helper = getTxHelper(toHex(metadataRaw))
+    const { input, blockNumber } = helper.fromPjsToInputRaw(
+      getPayload({ era: "0xf502" }),
+    )
+
+    const mortality = input.extensions.find((x) => x.id === "CheckMortality")!
+    expect(toHex(mortality.additionalSigned)).toBe(BLOCK_HASH)
+
+    const decoded = helper.getTxInputDecoded(input, blockNumber)
+    // period 64, phase 47
+    const height = Math.floor((BLOCK_NUMBER - 47) / 64) * 64 + 47
+    expect(decoded.mortality).toEqual({
+      from: { hash: BLOCK_HASH, height },
+      to: height + 64,
+    })
+  })
+})

--- a/packages/tx-utils/tests/pjs-tx-helper.spec.ts
+++ b/packages/tx-utils/tests/pjs-tx-helper.spec.ts
@@ -82,6 +82,21 @@ describe("getPjsTxHelper", () => {
     )
   })
 
+  it("signs with the payload's specVersion/transactionVersion, not the metadata constants", () => {
+    const { additionalSigned } = getPjsTxHelper(metadataRaw)(
+      getPayload({
+        // diverge from the System.Version constants of the metadata blob,
+        // as happens whenever the cached metadata lags behind a runtime upgrade
+        specVersion: "0x000f4241",
+        transactionVersion: "0x00000019",
+      }),
+    )
+
+    expect(toHex(additionalSigned.slice(0, 8))).toBe(
+      toHex(mergeUint8([u32.enc(SPEC_VERSION + 1), u32.enc(TX_VERSION + 1)])),
+    )
+  })
+
   it("uses the block hash as mortality checkpoint for mortal payloads", () => {
     // period 64, phase 47
     const { extra, additionalSigned } = getPjsTxHelper(metadataRaw)(
@@ -119,6 +134,20 @@ describe("getTxHelper", () => {
     expect(decoded.genesisHash).toBe(GENESIS)
     expect(decoded.nonce).toBe(5)
     expect(decoded.tip).toBe(0n)
+  })
+
+  it("decodes the payload's specVersion/transactionVersion", () => {
+    const helper = getTxHelper(toHex(metadataRaw))
+    const { input, blockNumber } = helper.fromPjsToInputRaw(
+      getPayload({
+        specVersion: "0x000f4241",
+        transactionVersion: "0x00000019",
+      }),
+    )
+
+    const decoded = helper.getTxInputDecoded(input, blockNumber)
+    expect(decoded.specVersion).toBe(SPEC_VERSION + 1)
+    expect(decoded.txVersion).toBe(TX_VERSION + 1)
   })
 
   it("round-trips a mortal payload", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -888,6 +888,10 @@ importers:
       '@polkadot-api/utils':
         specifier: workspace:*
         version: link:../utils
+    devDependencies:
+      '@polkadot-api/metadata-fixtures':
+        specifier: workspace:*
+        version: link:../metadata-fixtures
 
   packages/utils: {}
 


### PR DESCRIPTION
`CheckSpecVersion`/`CheckTxVersion` are signed with the `System.Version` constants of the metadata blob, ignoring the values carried by the pjs payload. When the metadata used for signing lags behind a runtime upgrade, the signature is invalid — same failure mode as #1335, on the pjs path: the payload declares the runtime the transaction targets.

Encoders stay metadata-driven; payload values are used with fallback to the constants when absent.

Builds on #1403 — will rebase once it lands.