### PR TITLE
feat: split TxBestBlockState into "inBestBlock" and "notInBestBlock"

### DIFF
--- a/examples/bun/src/simple-transfer.ts
+++ b/examples/bun/src/simple-transfer.ts
@@ -32,7 +32,7 @@ const transfer = api.tx.Balances.transfer_allow_death({
 transfer.createSubmitAndWatch(alice).subscribe({
   next: (e) => {
     console.log(e.type)
-    if (e.type === "txBestBlocksState") {
+    if (e.type === "inBestBlock") {
       console.log("The tx is now in a best block, check it out:")
       console.log(`https://westend.subscan.io/extrinsic/${e.txHash}`)
     }

--- a/examples/react-teleport/src/Teleport.tsx
+++ b/examples/react-teleport/src/Teleport.tsx
@@ -20,16 +20,14 @@ const teleportApis = {
 
 const TxStatus: React.FC<{ status: TxEvent | null }> = ({ status }) => {
   if (!status) return null
-  if (status.type === "signed") return <div>Tx Signed {status.txHash}</div>
-  if (status.type === "broadcasted")
+  if (status.type === "created") return <div>Tx Signed {status.txHash}</div>
+  if (status.type === "broadcasted" || status.type === "notInBestBlock")
     return <div>Tx Broadcasted {status.txHash}</div>
-  if (status.type === "txBestBlocksState")
-    return status.found ? (
+  if (status.type === "inBestBlock")
+    return (
       <div>
         Tx included in best block {status.block.hash}-{status.block.index}
       </div>
-    ) : (
-      <div>Tx Broadcasted {status.txHash}</div>
     )
 
   return (

--- a/integration-tests/forklift/src/tx.spec.ts
+++ b/integration-tests/forklift/src/tx.spec.ts
@@ -34,9 +34,7 @@ describe("tx", () => {
     await getMacroTask()
 
     let latestEvent = await firstValueFrom(obs)
-    expect(latestEvent.type === "txBestBlocksState" && latestEvent.found).toBe(
-      true,
-    )
+    expect(latestEvent.type === "inBestBlock").toBe(true)
 
     const forkedBlock = await forklift.newBlock({
       parent: bestBlock.hash,
@@ -51,9 +49,7 @@ describe("tx", () => {
     await getMacroTask()
 
     latestEvent = await firstValueFrom(obs)
-    expect(latestEvent.type === "txBestBlocksState" && !latestEvent.found).toBe(
-      true,
-    )
+    expect(latestEvent.type === "notInBestBlock").toBe(true)
 
     sub.unsubscribe()
   })

--- a/integration-tests/zombie-tests/src/main.spec.ts
+++ b/integration-tests/zombie-tests/src/main.spec.ts
@@ -406,7 +406,7 @@ describe("E2E", async () => {
 
     await lastValueFrom(
       transfer.createSubmitAndWatch(alice).pipe(
-        filter((e) => e.type === "txBestBlocksState" && e.found),
+        filter((e) => e.type === "inBestBlock"),
         switchMap(() => transfer.createSubmitAndWatch(alice)),
       ),
     )

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Changed
+
+- BREAKING: Split TxEvent `{ type: 'txBestBlocksState', found: boolean }` into `inBestBlock` and `notInBestBlock`
+- BREAKING: Replace TxEvent `type: 'signed'` for `type: 'created'`
+
+### Fixed
+
+- Add default generic type to `Transaction`
+
 ## 3.0.0-rc.3 - 2026-07-14
 
 ### Changed

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -3,18 +3,16 @@ export * from "./re-exports"
 export * from "./descriptors"
 export { InvalidTxError } from "./tx"
 export type {
-  TxEvent,
-  TxBroadcastEvent,
-  TxSigned,
+  Transaction,
   TxBroadcasted,
-  TxBestBlocksState,
-  TxInBestBlocksNotFound,
-  TxInBestBlocksFound,
+  TxCreated,
+  TxEntry,
+  TxEvent,
   TxEventsPayload,
   TxFinalized,
   TxFinalizedPayload,
-  Transaction,
-  TxEntry,
+  TxInBestBlock,
+  TxNotInBestBlock,
 } from "./tx"
 export type { EventPhase } from "./event"
 export type { TxCreator } from "@polkadot-api/tx-creator"

--- a/packages/client/src/tx/submit-fns.ts
+++ b/packages/client/src/tx/submit-fns.ts
@@ -188,7 +188,7 @@ export const submit$ = (
   chainHead: ChainHead$,
   broadcastTx$: (tx: Uint8Array) => Observable<never>,
   tx: Uint8Array,
-  emitSign = false,
+  emitCreated = false,
 ): Observable<TxEvent> =>
   chainHead.hasher$.pipe(
     mergeMap((hasher) => {
@@ -303,14 +303,9 @@ export const submit$ = (
         chainHead.pinnedBlocks$,
       ).pipe(
         map((x) => {
-          if (!x.found)
-            return getTxEvent("txBestBlocksState", {
-              found: false,
-              isValid: x.validity?.success !== false,
-            })
+          if (!x.found) return getTxEvent("notInBestBlock", {})
 
-          return getTxEvent("txBestBlocksState", {
-            found: true,
+          return getTxEvent("inBestBlock", {
             block: {
               index: x.index,
               number: x.number,
@@ -322,12 +317,14 @@ export const submit$ = (
       )
 
       return concat(
-        emitSign ? of(getTxEvent("signed", {})) : EMPTY,
+        emitCreated ? of(getTxEvent("created", {})) : EMPTY,
         validate$,
         of(getTxEvent("broadcasted", {})),
         bestBlockState$.pipe(
-          continueWith(({ found, type, ...rest }) =>
-            found ? of(getTxEvent("finalized", rest as any)) : EMPTY,
+          continueWith(({ type, ...rest }) =>
+            type === "inBestBlock"
+              ? of(getTxEvent("finalized", rest as any))
+              : EMPTY,
           ),
         ),
       )

--- a/packages/client/src/tx/types.ts
+++ b/packages/client/src/tx/types.ts
@@ -1,35 +1,30 @@
 import { PlainDescriptor } from "@/descriptors"
 import { PullOptions, TxCallData } from "@/types"
 import { SystemEvent } from "@polkadot-api/observable-client"
+import { Enum, HexString } from "@polkadot-api/substrate-bindings"
 import {
   ArgsForCreator,
   CreatorSpecs,
   TxCreator,
 } from "@polkadot-api/tx-creator"
-import { Enum, HexString } from "@polkadot-api/substrate-bindings"
 import { Observable } from "rxjs"
 
-export type TxEvent = TxSigned | TxBroadcasted | TxBestBlocksState | TxFinalized
-export type TxBroadcastEvent =
-  TxSigned | TxBroadcasted | TxBestBlocksState | TxFinalized
+export type TxEvent =
+  TxCreated | TxBroadcasted | TxInBestBlock | TxNotInBestBlock | TxFinalized
 
-export type TxSigned = { type: "signed"; txHash: HexString }
+export type TxCreated = { type: "created"; txHash: HexString }
 
 export type TxBroadcasted = { type: "broadcasted"; txHash: HexString }
 
-export type TxBestBlocksState = {
-  type: "txBestBlocksState"
+export type TxInBestBlock = {
+  type: "inBestBlock"
   txHash: HexString
-} & (TxInBestBlocksNotFound | TxInBestBlocksFound)
-
-export type TxInBestBlocksNotFound = {
-  found: false
-  isValid: boolean
-}
-
-export type TxInBestBlocksFound = {
-  found: true
 } & TxEventsPayload
+
+export type TxNotInBestBlock = {
+  type: "notInBestBlock"
+  txHash: HexString
+}
 
 export type FlattenedEvent = SystemEvent & SystemEvent["event"]
 
@@ -134,7 +129,9 @@ export type ExtensionConstraints = {
   requiredExtensions: PlainDescriptor<string>
 }
 
-export type Transaction<EC extends ExtensionConstraints> = {
+export type Transaction<
+  EC extends ExtensionConstraints = ExtensionConstraints,
+> = {
   /**
    * Creates a signed transaction asynchronously. If the creator fails (or the
    * user cancels the signature) it'll throw an error.

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -19,7 +19,7 @@ import { StorageEntry } from "./storage"
 import type {
   ExtensionConstraints,
   OfflineTxEntry,
-  TxBroadcastEvent,
+  TxEvent,
   TxEntry,
   TxFinalizedPayload,
   TxFromBinary,
@@ -344,7 +344,7 @@ export interface PolkadotClient {
   submitAndWatch: (
     transaction: Uint8Array,
     at?: HexString,
-  ) => Observable<TxBroadcastEvent>
+  ) => Observable<TxEvent>
 
   /**
    * Returns an instance of a `TypedApi`.


### PR DESCRIPTION
Also changes `signed` for `created`, to better match the current action, and adds a default generic to `Transaction`. 