### PR TITLE
fix(sync-provider): reset exponential backoff when receiving a message

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Exponential backoff not working if connection handshake fails after a delay.
+
 ## 2.1.8 - 2026-07-07
 
 ### Fixed

--- a/packages/json-rpc/json-rpc-provider-proxy/CHANGELOG.md
+++ b/packages/json-rpc/json-rpc-provider-proxy/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Exponential backoff not working if connection handshake fails after a delay.
+
 ## 0.4.0 - 2026-04-07
 
 ### Changed

--- a/packages/json-rpc/json-rpc-provider-proxy/src/get-sync-provider.ts
+++ b/packages/json-rpc/json-rpc-provider-proxy/src/get-sync-provider.ts
@@ -12,7 +12,6 @@ export const getSyncProvider =
   ): JsonRpcProvider =>
   (onMessage) => {
     let proxy: ConnectableJsonRpcConnection | null = getProxy(onMessage)
-    let lastHalt = Date.now()
     let consecutiveHalts = 0
     let token: any
     const getWaitTime = () =>
@@ -29,17 +28,20 @@ export const getSyncProvider =
           else if (proxy)
             proxy.connect((onMsg, onHalt) => {
               let isOn = true
-              return cb(onMsg, (e) => {
-                if (isOn) {
-                  isOn = false
-                  const diff = Date.now() - lastHalt
-                  consecutiveHalts +=
-                    diff > WAIT_BASE + getWaitTime() ? -consecutiveHalts : 1
-                  lastHalt += diff
-                  onHalt(e)
-                  start()
-                }
-              })
+              return cb(
+                (msg) => {
+                  consecutiveHalts = 0
+                  onMsg(msg)
+                },
+                (e) => {
+                  if (isOn) {
+                    isOn = false
+                    consecutiveHalts++
+                    onHalt(e)
+                    start()
+                  }
+                },
+              )
             })
         })
         if (isWaiting) stop = result


### PR DESCRIPTION
Initially I was going to fix this by setting a fixed timeout where exponential backoff would reset, e.g. 10 seconds, instead of making it based on the waiting time of the last try plus an extra something "just-in-case" that can fail in some conditions.

However, I didn't like this because what happens if someone disconnects after say 5 seconds once it's received the info they wanted with a quick sync? exponential backoff would not reset and next connection would wait for a few ms.

So this proposes to reset the backoff as soon as the sync proxy emits a message from the remote. This ensures that the connection was fully established. If we didn't get any message before a halt, then I think we can assume something in the connection failed, so backoff kicks in.