### PR TITLE
feat(client): add missing export

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Add missing `OfflineApi` export
+
 ## 3.0.0 - 2026-08-18
 
 ### Added

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -20,6 +20,7 @@ export type {
   PolkadotClient,
   TransactionValidityError,
   TypedApi,
+  OfflineApi,
   FixedSizeArray,
   TxCallData,
 } from "./types"


### PR DESCRIPTION
Identified that by a compilation rollup warning.